### PR TITLE
Update docs for source search handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ living inside this repository.
 ## Repository Layout
 
 - `services/artana_evidence_api`: the Evidence API for research spaces, local
-  identity, document ingestion, PubMed/MARRVEL discovery, review queues,
-  proposals, graph chat/search orchestration, guarded AI runs, and user-facing
-  workflow state.
+  identity, document ingestion, source discovery, durable direct source-search
+  handoff, review queues, proposals, graph chat/search orchestration, guarded
+  AI runs, and user-facing workflow state.
 - `services/artana_evidence_db`: the graph/evidence service for entities,
   relations, observations, provenance, relation evidence, dictionary
   governance, validation, graph views, and graph service API contracts.
@@ -60,6 +60,14 @@ generate from `services/artana_evidence_api/openapi.json`; the checked-in
 TypeScript artifact is specific to the graph service. If dedicated product,
 SDK, or notebook repositories are created, link them here as client projects
 rather than adding them to this backend repository.
+
+Direct source search is durable in the Evidence API. Clients can search enabled
+sources such as PubMed, MARRVEL, ClinVar, ClinicalTrials.gov, UniProt,
+AlphaFold, DrugBank, MGI, and ZFIN, fetch the captured search result later by
+id, and hand off a selected record through
+`POST /v2/spaces/{space_id}/sources/{source_key}/searches/{search_id}/handoffs`.
+That handoff creates review-gated extraction input or a durable source document;
+it does not automatically promote graph facts.
 
 ## Start Locally
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,13 @@
 # Docs Index
 
-Status date: April 23, 2026.
+Status date: April 26, 2026.
 
 This directory describes the current extracted backend repo. The source of
 truth in this checkout is two Python services:
 
 - `services/artana_evidence_api`: evidence workflows, identity/API keys,
-  documents, proposals, review queue, research-init, chat, and AI runs.
+  documents, durable direct source-search capture and handoff, proposals,
+  review queue, research-init, chat, and AI runs.
 - `services/artana_evidence_db`: governed graph, dictionary, claims,
   relations, provenance, graph views, workflows, and graph admin sync.
 

--- a/docs/architecture/current-system.md
+++ b/docs/architecture/current-system.md
@@ -1,6 +1,6 @@
 # Current System
 
-Status date: April 23, 2026.
+Status date: April 26, 2026.
 
 This repo is the extracted backend for the Artana evidence platform. It contains
 two service packages plus service-focused scripts, tests, migrations, docs, and
@@ -24,7 +24,7 @@ There is no top-level `src/` package, no frontend app, and no
 
 | Service | Owns | Does Not Own |
 | --- | --- | --- |
-| Evidence API | local identity gateway, API keys, spaces, documents, proposal/review flow, research-init, chat, AI runs, workflow artifacts | graph schema ownership, dictionary ownership, canonical graph persistence |
+| Evidence API | local identity gateway, API keys, spaces, documents, durable direct source-search capture and handoff, proposal/review flow, research-init, chat, AI runs, workflow artifacts | graph schema ownership, dictionary ownership, canonical graph persistence |
 | Graph service | graph schema, dictionary, claims, relations, observations, provenance, graph views, domain packs, graph workflows, admin space sync | end-user API keys, document upload UX, research-init orchestration |
 
 The Evidence API talks to the graph service through HTTP/client contracts. It
@@ -69,6 +69,7 @@ make graph-service-contract-check
 ```text
 Create or get a space
   -> add or discover evidence
+  -> hand off selected source results when needed
   -> extract reviewable proposals
   -> review or reject proposals
   -> promote trusted items into the graph
@@ -77,6 +78,9 @@ Create or get a space
 
 The review queue is the trust gate. AI workflows can search, extract, and stage
 work, but promoted graph state should flow through review/governance.
+Direct source-search handoff follows the same rule: it creates extraction input
+or durable source documents from captured source records, not trusted graph
+facts.
 
 ## Quality Gates
 

--- a/docs/project_status.md
+++ b/docs/project_status.md
@@ -1,6 +1,6 @@
 # Project Status
 
-Status date: April 23, 2026.
+Status date: April 26, 2026.
 
 ## Summary
 
@@ -19,6 +19,9 @@ Implemented now:
 - document upload, extraction, proposals, review queue, runs, artifacts,
   research-init, chat, graph-search, continuous-learning, supervisor, and full
   AI orchestrator endpoints in the Evidence API;
+- source registry, durable direct source-search capture, and idempotent
+  selected-record handoff for PubMed, MARRVEL, ClinVar, ClinicalTrials.gov,
+  UniProt, AlphaFold, DrugBank, MGI, and ZFIN;
 - dictionary, claims, relations, observations, provenance, graph views,
   reasoning paths, workflows, domain packs, and admin space-sync endpoints in
   the graph service.
@@ -55,7 +58,8 @@ The Evidence API is the user-facing backend service in this repo. It owns:
 - run lifecycle, artifacts, progress, policy, approvals, and workspace
   inspection;
 - research-init and research-bootstrap workflows;
-- source discovery endpoints for PubMed and MARRVEL;
+- source capability, direct-search, durable search retrieval, and selected
+  source-result handoff endpoints;
 - graph explorer and graph search workflow surfaces;
 - full AI orchestrator, supervisor, continuous-learning, graph-curation,
   graph-connection, hypothesis, and mechanism-discovery runs.
@@ -105,6 +109,10 @@ scaffold:
 - no frontend or SDK package in this checkout;
 - external live-source checks remain opt-in because they depend on network and
   external API availability.
+
+Direct source-search handoff is implemented in the Evidence API and remains
+review-gated. It creates extraction inputs or durable source documents from
+captured source results, but it does not write trusted graph facts directly.
 
 See [Pending Boundary Issues](./architecture/pending-boundary-issues.md) and
 [Remaining Work](./remaining_work_priorities.md).

--- a/docs/remaining_work_priorities.md
+++ b/docs/remaining_work_priorities.md
@@ -1,6 +1,6 @@
 # Remaining Work Priorities
 
-Status date: April 23, 2026.
+Status date: April 26, 2026.
 
 The backend scaffold is in place. The remaining work is about hardening the
 boundaries, making testing easier, and preparing for external users without
@@ -13,6 +13,8 @@ overbuilding too early.
 - Keep both generated OpenAPI artifacts current.
 - Keep `services/artana_evidence_db/artana-evidence-db.generated.ts` current.
 - Do not reintroduce the removed top-level `src` runtime package.
+- Keep durable direct source-search and selected-record handoff covered in
+  OpenAPI, route tests, and user-facing docs.
 - Keep the v2 public API migration moving according to
   [V2 API Migration Plan](./v2_api_migration_plan.md).
 

--- a/docs/research_init_architecture.md
+++ b/docs/research_init_architecture.md
@@ -82,8 +82,21 @@ include `source_capture` metadata with the source key, capture stage, locator,
 query, run/search id, result count, source family, and compact provenance.
 Structured direct source searches persist their captured search response in the
 Evidence API database so lookup by search id survives process restarts.
-Downstream extraction, review items, or proposal staging still happen through
-document/extraction workflows or the `research-plan` orchestration path.
+Downstream extraction, review items, or proposal staging happen through three
+review-gated paths:
+
+- document/extraction workflows for uploaded text and PDFs;
+- `research-plan` orchestration for multi-source topic setup;
+- direct source-search handoff for one selected captured search record.
+
+The handoff endpoint is
+`POST /v2/spaces/{space_id}/sources/{source_key}/searches/{search_id}/handoffs`.
+ClinVar and MARRVEL variant records enter the variant-aware extraction branch.
+PubMed, ClinicalTrials.gov, UniProt, AlphaFold, DrugBank, MGI, and ZFIN create
+durable source documents that preserve the selected record, source-capture
+metadata, normalized fields, and audit payload. Handoff output can stage
+documents, candidates, proposals, or review items, but it does not directly
+promote trusted graph facts.
 
 Live calls to external sources remain environment-dependent. Tests that require
 real external APIs are opt-in. PubMed replay bundles are internal test fixtures,

--- a/docs/user-guide/03-workflow-overview.md
+++ b/docs/user-guide/03-workflow-overview.md
@@ -23,12 +23,13 @@ Choose topic
 | 3. Define research plan | Tell the system the research goal and source mix | `POST /v2/spaces/{space_id}/research-plan` | "Understand MED13 and cardiomyopathy using PubMed, MARRVEL, and ClinVar" |
 | 4. Add your own evidence | Upload text notes or PDFs | `POST /v2/spaces/{space_id}/documents/text` and `POST /v2/spaces/{space_id}/documents/pdf` | Upload a MED13 paper, note, or copied abstract |
 | 5. Search sources directly | Run source-specific discovery for direct-search sources | `POST /v2/spaces/{space_id}/sources/{source_key}/searches` | Search PubMed papers, ClinVar variants, or model-organism sources |
-| 6. Extract proposals | Turn documents or evidence into reviewable suggestions | `POST /v2/spaces/{space_id}/documents/{document_id}/extraction` | Extract MED13 claims, entities, observations, or variants |
-| 7. Review proposals | Have a human approve, reject, or resolve staged work | `GET /v2/spaces/{space_id}/review-items` and `POST /v2/spaces/{space_id}/review-items/{item_id}/decision` | Promote strong evidence and reject weak claims |
-| 8. Build graph | Approved proposals become trusted graph knowledge | Review action with `{"action": "promote"}` | Add an approved MED13 claim to the graph |
-| 9. Explore graph | Browse trusted entities, claims, and evidence | `GET /v2/spaces/{space_id}/evidence-map/entities`, `GET /v2/spaces/{space_id}/evidence-map/claims`, and `GET /v2/spaces/{space_id}/evidence-map/claims/{claim_id}/evidence` | See MED13 claims and supporting evidence |
-| 10. Ask questions | Query the graph and documents with AI | `POST /v2/spaces/{space_id}/workflows/evidence-search/tasks` or `POST /v2/spaces/{space_id}/chat-sessions/{session_id}/messages` | Ask "What is the strongest MED13 evidence?" |
-| 11. Find gaps and repeat | Keep the research space fresh over time | `POST /v2/spaces/{space_id}/workflows/continuous-review/tasks` or `POST /v2/spaces/{space_id}/schedules` | Re-run discovery when new MED13 evidence appears |
+| 6. Hand off selected source result | Turn one captured source-search record into extraction input or a source document | `POST /v2/spaces/{space_id}/sources/{source_key}/searches/{search_id}/handoffs` | Hand off one ClinVar or PubMed result for review-gated extraction |
+| 7. Extract proposals | Turn documents or evidence into reviewable suggestions | `POST /v2/spaces/{space_id}/documents/{document_id}/extraction` | Extract MED13 claims, entities, observations, or variants |
+| 8. Review proposals | Have a human approve, reject, or resolve staged work | `GET /v2/spaces/{space_id}/review-items` and `POST /v2/spaces/{space_id}/review-items/{item_id}/decision` | Promote strong evidence and reject weak claims |
+| 9. Build graph | Approved proposals become trusted graph knowledge | Review action with `{"action": "promote"}` | Add an approved MED13 claim to the graph |
+| 10. Explore graph | Browse trusted entities, claims, and evidence | `GET /v2/spaces/{space_id}/evidence-map/entities`, `GET /v2/spaces/{space_id}/evidence-map/claims`, and `GET /v2/spaces/{space_id}/evidence-map/claims/{claim_id}/evidence` | See MED13 claims and supporting evidence |
+| 11. Ask questions | Query the graph and documents with AI | `POST /v2/spaces/{space_id}/workflows/evidence-search/tasks` or `POST /v2/spaces/{space_id}/chat-sessions/{session_id}/messages` | Ask "What is the strongest MED13 evidence?" |
+| 12. Find gaps and repeat | Keep the research space fresh over time | `POST /v2/spaces/{space_id}/workflows/continuous-review/tasks` or `POST /v2/spaces/{space_id}/schedules` | Re-run discovery when new MED13 evidence appears |
 
 ## The Most Important Rule
 

--- a/docs/user-guide/04-adding-evidence.md
+++ b/docs/user-guide/04-adding-evidence.md
@@ -119,9 +119,27 @@ object. Use it to trace a result back to its source key, source family, query,
 locator, search id, and provenance before you decide what to extract or review.
 
 Direct source search captures the search result. It does not silently promote
-trusted graph knowledge. Normal researcher workflows should follow search with
-document capture/extraction or a `research-plan` run so proposed updates move
-through review.
+trusted graph knowledge. When you want to work on one selected result from a
+captured search, hand it off:
+
+```bash
+curl -s "$ARTANA_API_BASE_URL/v2/spaces/$SPACE_ID/sources/clinvar/searches/$SEARCH_ID/handoffs" \
+  -H "X-Artana-Key: $ARTANA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "record_index": 0
+  }'
+```
+
+Handoff is idempotent. Repeating the same handoff request returns the same
+completed or failed outcome instead of creating duplicate documents, runs, or
+review items. ClinVar and MARRVEL variant records enter the variant-aware
+extraction path. PubMed, ClinicalTrials.gov, UniProt, AlphaFold, DrugBank, MGI,
+and ZFIN handoffs create durable source documents with the selected record,
+source-capture metadata, normalized fields, and readable extraction text.
+
+Normal researcher workflows should follow search or handoff with extraction,
+proposal review, and promotion. The graph only changes after review.
 
 ## 3. Run A Multi-Source Setup
 

--- a/docs/user-guide/09-endpoint-index.md
+++ b/docs/user-guide/09-endpoint-index.md
@@ -21,6 +21,7 @@ Use these first.
 | Inspect one evidence source | `GET /v2/sources/{source_key}` |
 | Search a direct-search source | `POST /v2/spaces/{space_id}/sources/{source_key}/searches` |
 | Get a source search result | `GET /v2/spaces/{space_id}/sources/{source_key}/searches/{search_id}` |
+| Hand off a selected source result | `POST /v2/spaces/{space_id}/sources/{source_key}/searches/{search_id}/handoffs` |
 | Create research plan | `POST /v2/spaces/{space_id}/research-plan` |
 | Ask an evidence-map question | `POST /v2/spaces/{space_id}/workflows/evidence-search/tasks` |
 | Chat over documents and evidence | `/v2/spaces/{space_id}/chat-sessions/*` |
@@ -96,3 +97,12 @@ trace a result to its source, family, query, locator, and provenance. Structured
 direct source-search results are stored durably in the Evidence API database and
 can be fetched later by id; they are still not trusted graph facts until the
 review workflow promotes them.
+
+Use the handoff endpoint when a user selects one captured source-search record
+for downstream extraction or normalization. ClinVar and MARRVEL variant records
+enter the variant-aware extraction path. PubMed, ClinicalTrials.gov, UniProt,
+AlphaFold, DrugBank, MGI, and ZFIN handoffs create durable source documents with
+source-capture metadata, normalized record fields, and the original selected
+record for auditability. Handoff is idempotent: replaying the same request with
+the same idempotency key returns the existing outcome instead of creating
+duplicates.

--- a/docs/v2_api_migration_plan.md
+++ b/docs/v2_api_migration_plan.md
@@ -1,6 +1,6 @@
 # V2 API Migration Plan
 
-Status date: April 24, 2026.
+Status date: April 26, 2026.
 
 This plan covers the work required to move the Evidence API from a
 runtime-shaped v1 surface to a product-shaped v2 surface. Source-registry and
@@ -23,6 +23,10 @@ Current status:
   metadata.
 - Structured direct source-search responses are persisted as durable Evidence
   API source-search runs; direct search does not promote graph facts.
+- Selected durable source-search records can be handed off with
+  `POST /v2/spaces/{space_id}/sources/{source_key}/searches/{search_id}/handoffs`.
+  Handoff creates review-gated extraction input or durable source documents and
+  is idempotent by request hash and idempotency key.
 - v1 remains the dominant surface in docs, scripts, tests, and payload names.
 
 Target outcome:
@@ -66,6 +70,7 @@ Source-specific endpoints should use the generic source shape when possible:
 | `pubmed/searches` | `sources/{source_key}/searches` |
 | `marrvel/searches` | `sources/{source_key}/searches` |
 | source flags hidden in settings | `GET /v2/sources` capability discovery |
+| ad hoc source-result extraction | `sources/{source_key}/searches/{search_id}/handoffs` |
 
 ## Workstreams
 


### PR DESCRIPTION
## Summary

This PR updates the repo README and public docs so they match the newly merged durable direct source-search handoff behavior.

The backend now supports durable source-search capture plus selected-record handoff for enabled sources. The implementation docs and OpenAPI already reflected that, but the broader onboarding docs still described source search mostly as durable lookup and review flow, without naming the new handoff endpoint or explaining how selected source records move downstream.

## What Changed

- Updated `README.md` to describe durable direct source-search handoff as part of the Evidence API workflow surface.
- Updated `docs/README.md` and `docs/architecture/current-system.md` so the primary docs entry points mention source-search capture and handoff.
- Updated `docs/project_status.md` and `docs/remaining_work_priorities.md` to reflect the current April 26 status and keep source-search handoff in the shippability checklist.
- Updated `docs/research_init_architecture.md` to explain the three review-gated downstream paths:
  - uploaded document extraction,
  - `research-plan` orchestration,
  - direct source-search handoff for a selected captured record.
- Updated the user guide workflow map, adding-evidence guide, and endpoint index with the handoff endpoint:
  - `POST /v2/spaces/{space_id}/sources/{source_key}/searches/{search_id}/handoffs`
- Updated `docs/v2_api_migration_plan.md` so v2 migration docs include selected-record handoff as part of the current source-search surface.

## User And Developer Impact

Readers now see the same story across README, architecture docs, status docs, and user guide:

1. Search an enabled source.
2. Fetch the durable captured search result later by id.
3. Hand off a selected record when the user wants downstream extraction or normalization.
4. Keep all output review-gated; handoff does not directly promote trusted graph facts.

This should reduce confusion for API users who previously saw durable source searches in OpenAPI but could not find the selected-record handoff flow in the human docs.

## Boundaries

- Docs-only change.
- No service code, migrations, generated OpenAPI, or graph-service contracts changed.
- No frontend or SDK work added.

## Validation

- `git diff --check`
- `pre-commit run --files README.md docs/README.md docs/architecture/current-system.md docs/project_status.md docs/remaining_work_priorities.md docs/research_init_architecture.md docs/user-guide/03-workflow-overview.md docs/user-guide/04-adding-evidence.md docs/user-guide/09-endpoint-index.md docs/v2_api_migration_plan.md`
- Pre-push hooks passed:
  - graph service full checks
  - Evidence API full checks

Note: this linked worktree did not have its own local virtualenv. The docs pre-commit run used the existing installed repo virtualenv via `VENV=/Users/alvaro/Documents/Code/artana-evidence-platform/venv`, and the push gate was run with a temporary local `venv` symlink so the isolated Postgres test runner could find Alembic. The symlink was removed after the successful push.
