### PR TITLE
Add architecture size gate for oversized Python modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ define check_venv
 fi
 endef
 
-.PHONY: help all venv install-dev docker-postgres-up docker-postgres-down docker-postgres-destroy docker-postgres-logs docker-postgres-status postgres-wait graph-db-wait graph-db-migrate artana-evidence-api-db-wait artana-evidence-api-db-migrate init-artana-schema setup-postgres graph-service-openapi graph-service-client-types graph-service-sync-contracts graph-service-contract-check graph-service-boundary-check artana-evidence-api-openapi artana-evidence-api-contract-check artana-evidence-api-boundary-check graph-phase6-release-check graph-service-lint graph-service-type-check graph-service-type-check-strict-imports graph-service-test graph-service-static-checks graph-service-checks artana-evidence-api-lint artana-evidence-api-type-check artana-evidence-api-type-check-strict-imports artana-evidence-api-test coverage-check artana-evidence-api-static-checks artana-evidence-api-service-checks service-checks live-endpoint-contract-check live-external-api-check live-service-checks type-hardening-baseline run-graph-service run-artana-evidence-api-service run-artana-evidence-api-worker run-all
+.PHONY: help all venv install-dev docker-postgres-up docker-postgres-down docker-postgres-destroy docker-postgres-logs docker-postgres-status postgres-wait graph-db-wait graph-db-migrate artana-evidence-api-db-wait artana-evidence-api-db-migrate init-artana-schema setup-postgres graph-service-openapi graph-service-client-types graph-service-sync-contracts graph-service-contract-check graph-service-boundary-check artana-evidence-api-openapi artana-evidence-api-contract-check artana-evidence-api-boundary-check graph-phase6-release-check architecture-size-check graph-service-lint graph-service-type-check graph-service-type-check-strict-imports graph-service-test graph-service-static-checks-core graph-service-static-checks graph-service-checks artana-evidence-api-lint artana-evidence-api-type-check artana-evidence-api-type-check-strict-imports artana-evidence-api-test coverage-check artana-evidence-api-static-checks-core artana-evidence-api-static-checks artana-evidence-api-service-checks service-checks live-endpoint-contract-check live-external-api-check live-service-checks type-hardening-baseline run-graph-service run-artana-evidence-api-service run-artana-evidence-api-worker run-all
 
 help: ## Show available commands
 	@grep -E '^[a-zA-Z0-9_.-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-32s %s\n", $$1, $$2}'
@@ -245,6 +245,10 @@ graph-phase6-release-check: ## Validate graph-service release-boundary policy
 	$(call check_venv)
 	$(USE_PYTHON) scripts/validate_graph_phase6_release_contract.py
 
+architecture-size-check: ## Enforce per-file architecture size budget
+	$(call check_venv)
+	$(USE_PYTHON) scripts/validate_architecture_size.py
+
 graph-service-lint: ## Run ruff on graph service paths
 	$(call check_venv)
 	$(USE_PYTHON) -m ruff check $(GRAPH_SERVICE_LINT_PATHS)
@@ -262,13 +266,17 @@ graph-service-test: ## Run graph service tests against isolated Postgres
 	@$(MAKE) -s postgres-wait
 	$(call run_with_postgres_env,$(USE_PYTHON) scripts/run_isolated_postgres_tests.py $(GRAPH_SERVICE_TEST_PATHS) -q)
 
-graph-service-static-checks: ## Run graph service gates except tests
+graph-service-static-checks-core: ## Run graph service static gates except repo-wide size check
 	@$(MAKE) -s graph-service-lint
 	@$(MAKE) -s graph-service-type-check
 	@$(MAKE) -s graph-service-type-check-strict-imports
 	@$(MAKE) -s graph-service-boundary-check
 	@$(MAKE) -s graph-service-contract-check
 	@$(MAKE) -s graph-phase6-release-check
+
+graph-service-static-checks: ## Run graph service gates except tests
+	@$(MAKE) -s graph-service-static-checks-core
+	@$(MAKE) -s architecture-size-check
 
 graph-service-checks: ## Run graph service gates
 	@$(MAKE) -s graph-service-static-checks
@@ -302,19 +310,24 @@ coverage-check: ## Enforce service coverage threshold
 	@$(MAKE) -s postgres-wait
 	$(call run_with_postgres_env,$(USE_PYTHON) scripts/run_isolated_postgres_tests.py $(COVERAGE_TEST_PATHS) -W "ignore:unclosed database in <sqlite3.Connection object:ResourceWarning" --cov=services --cov-report=term-missing --cov-report=xml --cov-fail-under=$(COVERAGE_MIN) -q)
 
-artana-evidence-api-static-checks: ## Run evidence API gates except tests
+artana-evidence-api-static-checks-core: ## Run evidence API static gates except repo-wide size check
 	@$(MAKE) -s artana-evidence-api-lint
 	@$(MAKE) -s artana-evidence-api-type-check
 	@$(MAKE) -s artana-evidence-api-boundary-check
 	@$(MAKE) -s artana-evidence-api-contract-check
+
+artana-evidence-api-static-checks: ## Run evidence API gates except tests
+	@$(MAKE) -s artana-evidence-api-static-checks-core
+	@$(MAKE) -s architecture-size-check
 
 artana-evidence-api-service-checks: ## Run evidence API gates
 	@$(MAKE) -s artana-evidence-api-static-checks
 	@$(MAKE) -s artana-evidence-api-test
 
 service-checks: ## Run all service gates including coverage enforcement
-	@$(MAKE) -s graph-service-static-checks
-	@$(MAKE) -s artana-evidence-api-static-checks
+	@$(MAKE) -s graph-service-static-checks-core
+	@$(MAKE) -s artana-evidence-api-static-checks-core
+	@$(MAKE) -s architecture-size-check
 	@$(MAKE) -s coverage-check
 
 live-endpoint-contract-check: ## Run opt-in live endpoint contract against make run-all

--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ make artana-evidence-api-service-checks
 ```
 
 `make all` is an alias for `make service-checks`, the normal CI gate. It runs
-lint, type checks, architecture checks, contract checks, isolated Postgres
-tests, and coverage.
+lint, type checks, architecture checks (service boundaries and per-file
+size budget under `architecture_overrides.json`), contract checks, isolated
+Postgres tests, and coverage.
 Live/external tests are not required for normal CI; they skip with explicit
 messages unless their environment variables or local services are available.
 

--- a/architecture_overrides.json
+++ b/architecture_overrides.json
@@ -7,6 +7,12 @@
             "expires_on": "2026-12-31"
         },
         {
+            "path": "services/artana_evidence_api/routers/v2_public.py",
+            "max_lines": 3900,
+            "reason": "Public v2 router consolidates request models, typed dispatch, and response construction across many endpoints; per-domain splits are deferred until the v2 route surface stabilizes.",
+            "expires_on": "2026-12-31"
+        },
+        {
             "path": "services/artana_evidence_api/full_ai_orchestrator_runtime.py",
             "max_lines": 3500,
             "reason": "Full-AI orchestration remains co-located during guarded rollout hardening; split by planning, execution, and reporting is tracked as follow-up work.",
@@ -16,6 +22,18 @@
             "path": "services/artana_evidence_api/full_ai_orchestrator_shadow_planner.py",
             "max_lines": 3400,
             "reason": "Shadow planning is broad while planner evidence, guardrail, and comparison contracts are still being stabilized.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "scripts/run_phase1_guarded_eval.py",
+            "max_lines": 3300,
+            "reason": "Phase-1 guarded eval harness drives fixture preparation, run execution, and reporting in one script for reproducible offline runs.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/phase1_compare.py",
+            "max_lines": 2800,
+            "reason": "Phase-1 compare module co-locates rollout-mode diff logic, summary aggregation, and reporting while compare contracts are still being stabilized.",
             "expires_on": "2026-12-31"
         },
         {
@@ -31,9 +49,45 @@
             "expires_on": "2026-12-31"
         },
         {
+            "path": "services/artana_evidence_api/phase2_shadow_compare.py",
+            "max_lines": 2500,
+            "reason": "Phase-2 shadow compare module co-locates shadow diff, baseline reconciliation, and reporting while shadow contracts are still being stabilized.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/research_bootstrap_runtime.py",
+            "max_lines": 2400,
+            "reason": "Research-bootstrap orchestration is co-located while bootstrap planning, source seeding, and proposal handoff contracts stabilize.",
+            "expires_on": "2026-12-31"
+        },
+        {
             "path": "services/artana_evidence_db/ai_full_mode_service.py",
             "max_lines": 2300,
             "reason": "Graph full-mode service logic remains centralized while workflow persistence and relation-governance contracts stabilize.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/research_init_source_enrichment.py",
+            "max_lines": 2300,
+            "reason": "Source enrichment intentionally consolidates per-source gateway, document, and proposal logic; decomposition is tracked under the source-boundary work in #16.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "scripts/run_full_ai_real_space_canary.py",
+            "max_lines": 2300,
+            "reason": "Full-AI real-space canary harness drives canary setup, run orchestration, and reporting in one script for reproducible canary cycles.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/routers/supervisor_runs.py",
+            "max_lines": 2200,
+            "reason": "Supervisor-runs router consolidates request validation, dispatch, and run-state shaping; per-endpoint splits are deferred until the route surface stabilizes.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_db/graph_domain_config.py",
+            "max_lines": 2000,
+            "reason": "Graph domain config groups governance defaults, allowed-relation maps, and domain rules together for review coherence during contract stabilization.",
             "expires_on": "2026-12-31"
         },
         {
@@ -49,6 +103,24 @@
             "expires_on": "2026-12-31"
         },
         {
+            "path": "services/artana_evidence_api/supervisor_runtime.py",
+            "max_lines": 1900,
+            "reason": "Supervisor runtime keeps run-lifecycle, evidence handoff, and reporting co-located while supervisor contracts are still being hardened.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/artana_stores.py",
+            "max_lines": 1900,
+            "reason": "Evidence API artana stores are temporarily consolidated during extracted-repo migration and database contract hardening, mirroring sqlalchemy_stores.py.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/evidence_selection_runtime.py",
+            "max_lines": 1900,
+            "reason": "Evidence-selection runtime keeps source screening, extraction handoff, proposal creation, and artifact reporting co-located while the harness contract stabilizes.",
+            "expires_on": "2026-12-31"
+        },
+        {
             "path": "services/artana_evidence_db/kernel_dictionary_models.py",
             "max_lines": 1800,
             "reason": "Dictionary ORM models are grouped for schema coherence during migration and contract stabilization.",
@@ -58,6 +130,84 @@
             "path": "services/artana_evidence_db/dictionary_repository.py",
             "max_lines": 1800,
             "reason": "Dictionary repository methods remain broad while governance, constraint, and search workflows are extracted by concern.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/continuous_learning_runtime.py",
+            "max_lines": 1800,
+            "reason": "Continuous-learning orchestration remains centralized while learning-loop, evaluation, and feedback contracts are still being stabilized.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "scripts/run_live_evidence_session_audit.py",
+            "max_lines": 1700,
+            "reason": "Live-evidence session-audit harness drives session preparation, audit run, and reporting in one script for reproducible live audits.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/types/graph_contracts.py",
+            "max_lines": 1700,
+            "reason": "Graph contracts group typed request/response schemas that travel together for the standalone graph boundary; splitting is deferred until the boundary stabilizes.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/source_search_handoff.py",
+            "max_lines": 1700,
+            "reason": "Source-search handoff centralizes durable handoff persistence, supported-source policy, and normalization rules; decomposition is tracked under the source-boundary work in #16.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/variant_aware_document_extraction.py",
+            "max_lines": 1600,
+            "reason": "Variant-aware extraction co-locates variant detection, normalization, and proposal preparation while variant-extraction seams settle.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/proposal_actions.py",
+            "max_lines": 1600,
+            "reason": "Proposal action handlers are grouped while proposal/review/governance contracts are still being stabilized.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/graph_transport.py",
+            "max_lines": 1600,
+            "reason": "Graph transport packages mutation/query plumbing and per-call typing while extraction-time contracts settle.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_db/dictionary_proposal_service.py",
+            "max_lines": 1500,
+            "reason": "Dictionary proposal service keeps proposal lifecycle, review gating, and persistence together while dictionary governance contracts mature.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/routers/chat.py",
+            "max_lines": 1500,
+            "reason": "Chat router consolidates request validation, dispatch, and response construction for chat endpoints; per-feature splits are deferred until the chat contract stabilizes.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/full_ai_orchestrator_shadow_support.py",
+            "max_lines": 1400,
+            "reason": "Shadow planner support utilities stay co-located while shadow planner contracts are still being stabilized.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_db/routers/dictionary.py",
+            "max_lines": 1400,
+            "reason": "Dictionary router consolidates request validation, dispatch, and response construction for dictionary endpoints; per-domain splits are deferred until the dictionary route surface stabilizes.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_api/routers/documents.py",
+            "max_lines": 1400,
+            "reason": "Documents router consolidates request validation, dispatch, and response construction for document endpoints; per-feature splits are deferred until the document route surface stabilizes.",
+            "expires_on": "2026-12-31"
+        },
+        {
+            "path": "services/artana_evidence_db/routers/claims.py",
+            "max_lines": 1300,
+            "reason": "Claims router consolidates request validation, dispatch, and response construction for claim endpoints; per-feature splits are deferred until the claim route surface stabilizes.",
             "expires_on": "2026-12-31"
         }
     ]

--- a/scripts/validate_architecture_size.py
+++ b/scripts/validate_architecture_size.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Validate architecture file-size budget and override metadata.
+
+Production Python files within the in-scope service and script trees must stay
+under the default line budget. Files that exceed it must be explicitly
+documented in ``architecture_overrides.json`` with a non-empty reason and an
+ISO ``expires_on`` date. The gate fails when:
+
+* an in-scope production file exceeds the default budget without an override;
+* an overridden file exceeds its declared ``max_lines``;
+* an override path does not exist on disk;
+* an override is missing ``reason`` or ``expires_on``;
+* an override's ``expires_on`` is on or before today;
+* an override points outside the in-scope service/script tree.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OVERRIDES_FILE = REPO_ROOT / "architecture_overrides.json"
+DEFAULT_MAX_LINES = 1200
+
+SCOPE_INCLUDE_PREFIXES: tuple[str, ...] = (
+    "services/artana_evidence_api/",
+    "services/artana_evidence_db/",
+    "scripts/",
+)
+SCOPE_EXCLUDE_PREFIXES: tuple[str, ...] = (
+    "services/artana_evidence_api/tests/",
+    "services/artana_evidence_api/alembic/",
+    "services/artana_evidence_db/tests/",
+    "services/artana_evidence_db/alembic/",
+    "scripts/ci/",
+    "scripts/deploy/",
+    "scripts/postgres-init/",
+    "scripts/fixtures/",
+)
+
+
+@dataclass(frozen=True)
+class FileSizeOverride:
+    """A single allowlist entry for an oversized production module."""
+
+    path: str
+    max_lines: int
+    reason: str
+    expires_on: date
+
+
+@dataclass(frozen=True)
+class Violation:
+    """An architecture-size rule violation, ready to print."""
+
+    path: str
+    message: str
+
+
+def is_in_scope(relative_path: str) -> bool:
+    """Return ``True`` for paths the size budget is enforced against."""
+    if not relative_path.endswith(".py"):
+        return False
+    if not relative_path.startswith(SCOPE_INCLUDE_PREFIXES):
+        return False
+    return not relative_path.startswith(SCOPE_EXCLUDE_PREFIXES)
+
+
+def count_lines(file_path: Path) -> int:
+    """Return the physical line count of ``file_path``."""
+    text = file_path.read_text(encoding="utf-8")
+    if not text:
+        return 0
+    line_count = text.count("\n")
+    if not text.endswith("\n"):
+        line_count += 1
+    return line_count
+
+
+def scan_repo(repo_root: Path) -> dict[str, int]:
+    """Return a mapping of in-scope relative paths to their physical line counts."""
+    sizes: dict[str, int] = {}
+    for prefix in SCOPE_INCLUDE_PREFIXES:
+        root = repo_root / prefix
+        if not root.exists():
+            continue
+        for file_path in root.rglob("*.py"):
+            relative_path = file_path.relative_to(repo_root).as_posix()
+            if not is_in_scope(relative_path):
+                continue
+            sizes[relative_path] = count_lines(file_path)
+    return sizes
+
+
+def parse_overrides(
+    raw: object,
+) -> tuple[list[FileSizeOverride], list[Violation]]:
+    """Parse and validate the ``file_size`` overrides block."""
+    if not isinstance(raw, dict):
+        return [], [
+            Violation(
+                path="architecture_overrides.json",
+                message="overrides root must be a JSON object",
+            ),
+        ]
+    raw_entries = raw.get("file_size")
+    if not isinstance(raw_entries, list):
+        return [], [
+            Violation(
+                path="architecture_overrides.json",
+                message='missing or invalid "file_size" array',
+            ),
+        ]
+
+    overrides: list[FileSizeOverride] = []
+    errors: list[Violation] = []
+    seen_paths: set[str] = set()
+    for index, entry in enumerate(raw_entries):
+        location = f"architecture_overrides.json[file_size][{index}]"
+        if not isinstance(entry, dict):
+            errors.append(
+                Violation(path=location, message="entry must be a JSON object"),
+            )
+            continue
+
+        path = entry.get("path")
+        max_lines = entry.get("max_lines")
+        reason = entry.get("reason")
+        expires_on_raw = entry.get("expires_on")
+
+        if not isinstance(path, str) or not path:
+            errors.append(
+                Violation(path=location, message='missing or empty "path"'),
+            )
+            continue
+        if path in seen_paths:
+            errors.append(
+                Violation(
+                    path=path,
+                    message="duplicate override entry",
+                ),
+            )
+            continue
+        seen_paths.add(path)
+        if not isinstance(max_lines, int) or max_lines <= 0:
+            errors.append(
+                Violation(
+                    path=path,
+                    message='"max_lines" must be a positive integer',
+                ),
+            )
+            continue
+        if not isinstance(reason, str) or not reason.strip():
+            errors.append(
+                Violation(
+                    path=path,
+                    message='"reason" must be a non-empty string',
+                ),
+            )
+            continue
+        if not isinstance(expires_on_raw, str):
+            errors.append(
+                Violation(
+                    path=path,
+                    message='"expires_on" must be an ISO date string (YYYY-MM-DD)',
+                ),
+            )
+            continue
+        try:
+            expires_on = date.fromisoformat(expires_on_raw)
+        except ValueError:
+            errors.append(
+                Violation(
+                    path=path,
+                    message=(
+                        f'"expires_on" is not a valid ISO date: {expires_on_raw!r}'
+                    ),
+                ),
+            )
+            continue
+
+        overrides.append(
+            FileSizeOverride(
+                path=path,
+                max_lines=max_lines,
+                reason=reason.strip(),
+                expires_on=expires_on,
+            ),
+        )
+    return overrides, errors
+
+
+def validate(
+    *,
+    file_sizes: dict[str, int],
+    overrides: Iterable[FileSizeOverride],
+    today: date,
+    default_max: int = DEFAULT_MAX_LINES,
+) -> list[Violation]:
+    """Compare actual file sizes against the default budget and overrides."""
+    overrides_by_path: dict[str, FileSizeOverride] = {}
+    violations: list[Violation] = []
+
+    for override in overrides:
+        overrides_by_path[override.path] = override
+
+        if not is_in_scope(override.path):
+            violations.append(
+                Violation(
+                    path=override.path,
+                    message=(
+                        "override path is outside the enforced service/script scope"
+                    ),
+                ),
+            )
+            continue
+        if override.path not in file_sizes:
+            violations.append(
+                Violation(
+                    path=override.path,
+                    message="override path does not exist on disk",
+                ),
+            )
+            continue
+        if override.expires_on <= today:
+            violations.append(
+                Violation(
+                    path=override.path,
+                    message=(
+                        f"override expired on {override.expires_on.isoformat()};"
+                        f" refresh expires_on or split the file"
+                    ),
+                ),
+            )
+        actual = file_sizes[override.path]
+        if actual > override.max_lines:
+            violations.append(
+                Violation(
+                    path=override.path,
+                    message=(
+                        f"file is {actual} lines but override allows"
+                        f" only {override.max_lines}"
+                    ),
+                ),
+            )
+
+    for path, line_count in sorted(file_sizes.items()):
+        if path in overrides_by_path:
+            continue
+        if line_count > default_max:
+            violations.append(
+                Violation(
+                    path=path,
+                    message=(
+                        f"file is {line_count} lines, exceeding the default"
+                        f" {default_max}-line budget; split the module or add"
+                        f" an entry to architecture_overrides.json"
+                    ),
+                ),
+            )
+
+    return violations
+
+
+def _load_overrides_from_disk() -> tuple[list[FileSizeOverride], list[Violation]]:
+    if not OVERRIDES_FILE.exists():
+        return [], [
+            Violation(
+                path="architecture_overrides.json",
+                message="overrides file is missing",
+            ),
+        ]
+    try:
+        raw = json.loads(OVERRIDES_FILE.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [], [
+            Violation(
+                path="architecture_overrides.json",
+                message=f"invalid JSON: {exc.msg} (line {exc.lineno})",
+            ),
+        ]
+    return parse_overrides(raw)
+
+
+def main() -> int:
+    overrides, parse_errors = _load_overrides_from_disk()
+    file_sizes = scan_repo(REPO_ROOT)
+    rule_violations = validate(
+        file_sizes=file_sizes,
+        overrides=overrides,
+        today=datetime.now(tz=UTC).date(),
+    )
+    violations = parse_errors + rule_violations
+    if not violations:
+        print("architecture_size: ok")
+        return 0
+
+    print("architecture_size: error")
+    print(
+        f"Default per-file budget is {DEFAULT_MAX_LINES} physical lines."
+        " Add overrides under architecture_overrides.json `file_size`.",
+    )
+    for violation in violations:
+        print(f"{violation.path}: {violation.message}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_architecture_size_validator.py
+++ b/tests/unit/test_architecture_size_validator.py
@@ -1,0 +1,335 @@
+"""Unit tests for the architecture-size validator."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_architecture_size import (
+    DEFAULT_MAX_LINES,
+    FileSizeOverride,
+    Violation,
+    count_lines,
+    is_in_scope,
+    parse_overrides,
+    scan_repo,
+    validate,
+)
+
+TODAY = date(2026, 4, 26)
+FUTURE = date(2026, 12, 31)
+PAST = date(2026, 1, 1)
+
+
+def _override(
+    path: str,
+    *,
+    max_lines: int = 1500,
+    expires_on: date = FUTURE,
+    reason: str = "transitional",
+) -> FileSizeOverride:
+    return FileSizeOverride(
+        path=path,
+        max_lines=max_lines,
+        reason=reason,
+        expires_on=expires_on,
+    )
+
+
+class TestIsInScope:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "services/artana_evidence_api/foo.py",
+            "services/artana_evidence_api/routers/bar.py",
+            "services/artana_evidence_db/baz.py",
+            "scripts/run_eval.py",
+        ],
+    )
+    def test_includes_production_python(self, path: str) -> None:
+        assert is_in_scope(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "services/artana_evidence_api/tests/unit/test_x.py",
+            "services/artana_evidence_api/alembic/versions/abc.py",
+            "services/artana_evidence_db/tests/integration/test_y.py",
+            "services/artana_evidence_db/alembic/env.py",
+            "scripts/ci/plan_service_checks.py",
+            "scripts/deploy/release.py",
+            "scripts/postgres-init/seed.py",
+            "scripts/fixtures/sample.py",
+        ],
+    )
+    def test_excludes_tests_alembic_and_internal_scripts(self, path: str) -> None:
+        assert is_in_scope(path) is False
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "services/artana_evidence_api/foo.txt",
+            "services/artana_evidence_api/Dockerfile",
+            "tests/unit/test_other.py",
+            "docs/notes.md",
+        ],
+    )
+    def test_excludes_non_python_or_out_of_tree(self, path: str) -> None:
+        assert is_in_scope(path) is False
+
+
+class TestCountLines:
+    def test_empty_file_is_zero_lines(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "empty.py"
+        file_path.write_text("", encoding="utf-8")
+        assert count_lines(file_path) == 0
+
+    def test_trailing_newline_does_not_inflate(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "two.py"
+        file_path.write_text("a\nb\n", encoding="utf-8")
+        assert count_lines(file_path) == 2
+
+    def test_missing_trailing_newline_still_counts_last_line(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        file_path = tmp_path / "two.py"
+        file_path.write_text("a\nb", encoding="utf-8")
+        assert count_lines(file_path) == 2
+
+    def test_single_line_without_newline(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "one.py"
+        file_path.write_text("only", encoding="utf-8")
+        assert count_lines(file_path) == 1
+
+
+class TestParseOverrides:
+    def test_accepts_minimal_valid_entry(self) -> None:
+        raw = {
+            "file_size": [
+                {
+                    "path": "services/artana_evidence_api/foo.py",
+                    "max_lines": 1500,
+                    "reason": "transitional",
+                    "expires_on": "2026-12-31",
+                },
+            ],
+        }
+        overrides, errors = parse_overrides(raw)
+
+        assert errors == []
+        assert overrides == [
+            FileSizeOverride(
+                path="services/artana_evidence_api/foo.py",
+                max_lines=1500,
+                reason="transitional",
+                expires_on=FUTURE,
+            ),
+        ]
+
+    def test_rejects_non_object_root(self) -> None:
+        overrides, errors = parse_overrides([])
+        assert overrides == []
+        assert len(errors) == 1
+        assert "must be a JSON object" in errors[0].message
+
+    def test_rejects_missing_file_size_array(self) -> None:
+        overrides, errors = parse_overrides({})
+        assert overrides == []
+        assert len(errors) == 1
+        assert "file_size" in errors[0].message
+
+    @pytest.mark.parametrize(
+        ("entry", "expected_fragment"),
+        [
+            ({"max_lines": 1500, "reason": "x", "expires_on": "2026-12-31"}, "path"),
+            (
+                {
+                    "path": "services/artana_evidence_api/foo.py",
+                    "max_lines": 0,
+                    "reason": "x",
+                    "expires_on": "2026-12-31",
+                },
+                "max_lines",
+            ),
+            (
+                {
+                    "path": "services/artana_evidence_api/foo.py",
+                    "max_lines": 1500,
+                    "reason": "   ",
+                    "expires_on": "2026-12-31",
+                },
+                "reason",
+            ),
+            (
+                {
+                    "path": "services/artana_evidence_api/foo.py",
+                    "max_lines": 1500,
+                    "reason": "x",
+                    "expires_on": "not-a-date",
+                },
+                "expires_on",
+            ),
+            (
+                {
+                    "path": "services/artana_evidence_api/foo.py",
+                    "max_lines": 1500,
+                    "reason": "x",
+                },
+                "expires_on",
+            ),
+        ],
+    )
+    def test_rejects_malformed_entries(
+        self,
+        entry: dict[str, object],
+        expected_fragment: str,
+    ) -> None:
+        overrides, errors = parse_overrides({"file_size": [entry]})
+
+        assert overrides == []
+        assert len(errors) == 1
+        assert expected_fragment in errors[0].message
+
+    def test_flags_duplicate_paths(self) -> None:
+        entry = {
+            "path": "services/artana_evidence_api/foo.py",
+            "max_lines": 1500,
+            "reason": "x",
+            "expires_on": "2026-12-31",
+        }
+        overrides, errors = parse_overrides({"file_size": [entry, dict(entry)]})
+
+        assert len(overrides) == 1
+        assert any("duplicate" in err.message for err in errors)
+
+
+class TestValidate:
+    def test_clean_repo_within_default_passes(self) -> None:
+        violations = validate(
+            file_sizes={
+                "services/artana_evidence_api/small.py": 800,
+                "services/artana_evidence_db/medium.py": 1200,
+            },
+            overrides=[],
+            today=TODAY,
+        )
+        assert violations == []
+
+    def test_oversized_file_without_override_fails(self) -> None:
+        violations = validate(
+            file_sizes={"services/artana_evidence_api/big.py": 1500},
+            overrides=[],
+            today=TODAY,
+        )
+        assert len(violations) == 1
+        assert violations[0].path == "services/artana_evidence_api/big.py"
+        assert "1500 lines" in violations[0].message
+        assert f"{DEFAULT_MAX_LINES}-line budget" in violations[0].message
+
+    def test_oversized_file_with_sufficient_override_passes(self) -> None:
+        violations = validate(
+            file_sizes={"services/artana_evidence_api/big.py": 1500},
+            overrides=[_override("services/artana_evidence_api/big.py", max_lines=1700)],
+            today=TODAY,
+        )
+        assert violations == []
+
+    def test_file_exceeds_override_max_lines_fails(self) -> None:
+        violations = validate(
+            file_sizes={"services/artana_evidence_api/big.py": 1800},
+            overrides=[_override("services/artana_evidence_api/big.py", max_lines=1700)],
+            today=TODAY,
+        )
+        assert len(violations) == 1
+        assert "1800 lines" in violations[0].message
+        assert "1700" in violations[0].message
+
+    def test_override_for_missing_file_fails(self) -> None:
+        violations = validate(
+            file_sizes={},
+            overrides=[_override("services/artana_evidence_api/gone.py")],
+            today=TODAY,
+        )
+        assert len(violations) == 1
+        assert "does not exist" in violations[0].message
+
+    def test_override_outside_scope_fails(self) -> None:
+        violations = validate(
+            file_sizes={"docs/large_essay.py": 5000},
+            overrides=[_override("docs/large_essay.py", max_lines=6000)],
+            today=TODAY,
+        )
+        assert any("outside" in v.message for v in violations)
+
+    def test_expired_override_fails_even_if_within_max_lines(self) -> None:
+        violations = validate(
+            file_sizes={"services/artana_evidence_api/big.py": 1500},
+            overrides=[
+                _override(
+                    "services/artana_evidence_api/big.py",
+                    max_lines=1700,
+                    expires_on=PAST,
+                ),
+            ],
+            today=TODAY,
+        )
+        assert any("expired" in v.message for v in violations)
+
+    def test_override_expiring_today_fails(self) -> None:
+        """expires_on is interpreted as "must be after today", not "after-or-equal"."""
+        violations = validate(
+            file_sizes={"services/artana_evidence_api/big.py": 1500},
+            overrides=[
+                _override(
+                    "services/artana_evidence_api/big.py",
+                    max_lines=1700,
+                    expires_on=TODAY,
+                ),
+            ],
+            today=TODAY,
+        )
+        assert any("expired" in v.message for v in violations)
+
+
+class TestScanRepo:
+    def test_collects_only_in_scope_python_files(self, tmp_path: Path) -> None:
+        api_root = tmp_path / "services" / "artana_evidence_api"
+        db_root = tmp_path / "services" / "artana_evidence_db"
+        scripts_root = tmp_path / "scripts"
+        for parent in (api_root, db_root, scripts_root):
+            parent.mkdir(parents=True)
+
+        (api_root / "kept.py").write_text("a\nb\nc\n", encoding="utf-8")
+        (api_root / "tests").mkdir()
+        (api_root / "tests" / "skipped.py").write_text("x\n", encoding="utf-8")
+        (api_root / "alembic").mkdir()
+        (api_root / "alembic" / "skipped.py").write_text("x\n", encoding="utf-8")
+
+        (db_root / "tests").mkdir()
+        (db_root / "tests" / "skipped.py").write_text("x\n", encoding="utf-8")
+        (db_root / "kept.py").write_text("a\nb\n", encoding="utf-8")
+
+        (scripts_root / "ci").mkdir()
+        (scripts_root / "ci" / "skipped.py").write_text("x\n", encoding="utf-8")
+        (scripts_root / "kept.py").write_text("a\n", encoding="utf-8")
+
+        sizes = scan_repo(tmp_path)
+
+        assert sizes == {
+            "services/artana_evidence_api/kept.py": 3,
+            "services/artana_evidence_db/kept.py": 2,
+            "scripts/kept.py": 1,
+        }
+
+    def test_handles_missing_root_dirs_gracefully(self, tmp_path: Path) -> None:
+        assert scan_repo(tmp_path) == {}
+
+
+class TestViolationDataclass:
+    def test_is_immutable(self) -> None:
+        violation = Violation(path="x", message="y")
+        with pytest.raises(AttributeError):
+            violation.path = "z"  # type: ignore[misc]

--- a/tests/unit/test_control_files.py
+++ b/tests/unit/test_control_files.py
@@ -298,7 +298,11 @@ def test_architecture_overrides_reference_existing_service_paths() -> None:
         raw_path = raw_entry.get("path")
         assert isinstance(raw_path, str)
         assert raw_path.startswith(
-            ("services/artana_evidence_api/", "services/artana_evidence_db/"),
+            (
+                "services/artana_evidence_api/",
+                "services/artana_evidence_db/",
+                "scripts/",
+            ),
         )
         assert not raw_path.startswith("src/")
         assert (REPO_ROOT / raw_path).exists()
@@ -313,3 +317,47 @@ def _make_target_body(makefile: str, target_name: str) -> str:
 
     assert match is not None, f"missing Makefile target: {target_name}"
     return match.group("body")
+
+
+def test_architecture_size_check_target_exists() -> None:
+    """Regression: the size gate must be a first-class Makefile target."""
+    makefile = _read_text("Makefile")
+    body = _make_target_body(makefile, "architecture-size-check")
+
+    assert "scripts/validate_architecture_size.py" in body
+    assert "architecture-size-check" in _make_targets()
+
+
+def test_graph_service_static_checks_runs_architecture_size_check() -> None:
+    """Regression: the graph static gate must include the size budget check."""
+    body = _make_target_body(_read_text("Makefile"), "graph-service-static-checks")
+    assert "$(MAKE) -s architecture-size-check" in body
+
+
+def test_artana_evidence_api_static_checks_runs_architecture_size_check() -> None:
+    """Regression: the evidence API static gate must include the size budget check."""
+    body = _make_target_body(
+        _read_text("Makefile"),
+        "artana-evidence-api-static-checks",
+    )
+    assert "$(MAKE) -s architecture-size-check" in body
+
+
+def test_service_checks_runs_architecture_size_check_once() -> None:
+    """Regression: the aggregate gate must not duplicate the repo-wide size check."""
+    body = _make_target_body(_read_text("Makefile"), "service-checks")
+
+    assert body.count("$(MAKE) -s architecture-size-check") == 1
+    assert "$(MAKE) -s graph-service-static-checks-core" in body
+    assert "$(MAKE) -s artana-evidence-api-static-checks-core" in body
+    assert "$(MAKE) -s graph-service-static-checks\n" not in body
+    assert "$(MAKE) -s artana-evidence-api-static-checks\n" not in body
+
+
+def test_validate_architecture_size_script_exists_and_is_executable_module() -> None:
+    """Regression: the validator script must exist and be importable."""
+    script_path = REPO_ROOT / "scripts" / "validate_architecture_size.py"
+    assert script_path.exists()
+    text = script_path.read_text(encoding="utf-8")
+    assert text.startswith("#!/usr/bin/env python3")
+    assert "raise SystemExit(main())" in text

--- a/tests/unit/test_coverage_enforcement_contract.py
+++ b/tests/unit/test_coverage_enforcement_contract.py
@@ -47,9 +47,16 @@ def test_aggregate_service_checks_run_coverage_gate() -> None:
     makefile = (REPO_ROOT / "Makefile").read_text()
     service_checks_target = _make_target_body(makefile, "service-checks")
 
-    assert "$(MAKE) -s graph-service-static-checks" in service_checks_target
-    assert "$(MAKE) -s artana-evidence-api-static-checks" in service_checks_target
+    assert "$(MAKE) -s graph-service-static-checks-core" in service_checks_target
+    assert (
+        "$(MAKE) -s artana-evidence-api-static-checks-core" in service_checks_target
+    )
+    assert "$(MAKE) -s architecture-size-check" in service_checks_target
     assert "$(MAKE) -s coverage-check" in service_checks_target
+    assert "$(MAKE) -s graph-service-static-checks\n" not in service_checks_target
+    assert (
+        "$(MAKE) -s artana-evidence-api-static-checks\n" not in service_checks_target
+    )
     assert "$(MAKE) -s graph-service-checks" not in service_checks_target
     assert "$(MAKE) -s artana-evidence-api-service-checks" not in service_checks_target
 

--- a/tests/unit/test_makefile_type_gate_contract.py
+++ b/tests/unit/test_makefile_type_gate_contract.py
@@ -49,7 +49,7 @@ def test_evidence_api_strict_import_target_remains_explicit_alias() -> None:
 def test_evidence_api_service_checks_enforce_normal_type_gate_once() -> None:
     static_check_body = _target_body(
         _makefile_text(),
-        "artana-evidence-api-static-checks",
+        "artana-evidence-api-static-checks-core",
     )
 
     assert static_check_body.count("artana-evidence-api-type-check") == 1
@@ -59,9 +59,17 @@ def test_evidence_api_service_checks_enforce_normal_type_gate_once() -> None:
 def test_static_service_check_targets_do_not_run_tests() -> None:
     makefile_text = _makefile_text()
     graph_static_body = _target_body(makefile_text, "graph-service-static-checks")
+    graph_static_core_body = _target_body(
+        makefile_text,
+        "graph-service-static-checks-core",
+    )
     evidence_static_body = _target_body(
         makefile_text,
         "artana-evidence-api-static-checks",
+    )
+    evidence_static_core_body = _target_body(
+        makefile_text,
+        "artana-evidence-api-static-checks-core",
     )
     graph_service_body = _target_body(makefile_text, "graph-service-checks")
     evidence_service_body = _target_body(
@@ -70,7 +78,14 @@ def test_static_service_check_targets_do_not_run_tests() -> None:
     )
 
     assert "graph-service-test" not in graph_static_body
+    assert "graph-service-test" not in graph_static_core_body
     assert "artana-evidence-api-test" not in evidence_static_body
+    assert "artana-evidence-api-test" not in evidence_static_core_body
+    assert "@$(MAKE) -s graph-service-static-checks-core" in graph_static_body
+    assert (
+        "@$(MAKE) -s artana-evidence-api-static-checks-core"
+        in evidence_static_body
+    )
     assert "@$(MAKE) -s graph-service-static-checks" in graph_service_body
     assert "@$(MAKE) -s graph-service-test" in graph_service_body
     assert "@$(MAKE) -s artana-evidence-api-static-checks" in evidence_service_body


### PR DESCRIPTION
## Summary
- New `make architecture-size-check` validator: enforces a 1200-line default budget per production Python module under `services/artana_evidence_api/`, `services/artana_evidence_db/`, and `scripts/` (excluding tests, alembic, and CI/deploy/fixtures helpers).
- Files exceeding the budget must be documented in `architecture_overrides.json` with a non-empty `reason` and an ISO `expires_on`. The gate fails on missing overrides, expired overrides, override paths outside scope, and files that exceed their declared `max_lines`.
- Wired into both `graph-service-checks` and `artana-evidence-api-service-checks` so it runs transitively in `make all`, CI, and pre-push hooks.
- Baselined the 24 currently oversized files into the existing override allowlist (10 → 34 entries) — no refactors required to land. The gate prevents future bloat.

Closes #13.

## Test plan
- [x] `make architecture-size-check` passes on current repo
- [x] Synthetic >1200-line file without override is rejected with an actionable error (path, actual lines, budget, remediation)
- [x] 40 new validator unit tests in `tests/unit/test_architecture_size_validator.py` cover scope rules, line counting, override schema parsing, expired/missing/out-of-scope overrides, and the default-budget rule
- [x] 4 new control-file tests in `tests/unit/test_control_files.py` assert: target exists, included in both service-checks targets, validator script shape
- [x] Existing `test_architecture_overrides_reference_existing_service_paths` widened to allow `scripts/` paths (3 oversized harnesses live there)
- [x] `ruff check` clean on touched files
- [x] `mypy` clean on validator
- [x] Pre-push hooks (`graph-service-checks` + `artana-evidence-api-service-checks`) pass with the gate active

🤖 Generated with [Claude Code](https://claude.com/claude-code)