### PR TITLE
Fix graph type-hardening gates and tighten mypy policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,10 +31,3 @@ repos:
         language: system
         pass_filenames: false
         stages: [pre-commit]
-
-      - id: graph-service-strict-import-type-check
-        name: graph service strict-import type check
-        entry: make -s graph-service-type-check-strict-imports
-        language: system
-        pass_filenames: false
-        stages: [pre-commit]

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,7 @@ GRAPH_SERVICE_LINT_PATHS := \
 	 scripts/export_graph_openapi.py \
 	 tests/e2e/graph_service/test_user_flows.py
 
-GRAPH_SERVICE_TYPE_PATHS := \
- services/artana_evidence_db \
- scripts/export_graph_openapi.py
-GRAPH_SERVICE_TYPE_EXCLUDE := services/artana_evidence_db/(tests|alembic)/
+GRAPH_SERVICE_TYPE_EXCLUDE := artana_evidence_db/(tests|alembic)/
 ARTANA_EVIDENCE_API_TYPE_EXCLUDE := artana_evidence_api/(tests|alembic)/
 
 GRAPH_SERVICE_TEST_PATHS := \
@@ -78,12 +75,7 @@ ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS := \
  --show-error-codes
 
 GRAPH_SERVICE_STRICT_IMPORT_MYPY_FLAGS := \
- --show-error-codes \
- --no-warn-unused-configs \
- --disable-error-code no-any-unimported \
- --disable-error-code no-any-return \
- --disable-error-code misc \
- --disable-error-code untyped-decorator
+ --show-error-codes
 
 ARTANA_EVIDENCE_API_TEST_PATHS := \
 	 tests/e2e/artana_evidence_api \
@@ -255,11 +247,12 @@ graph-service-lint: ## Run ruff on graph service paths
 
 graph-service-type-check: ## Run mypy on graph service paths
 	$(call check_venv)
-	$(USE_PYTHON) -m mypy $(GRAPH_SERVICE_TYPE_PATHS) --exclude '$(GRAPH_SERVICE_TYPE_EXCLUDE)' --show-error-codes --no-warn-unused-configs --follow-imports=skip --disable-error-code no-any-unimported --disable-error-code no-any-return --disable-error-code misc --disable-error-code untyped-decorator
+	cd services && $(USE_PYTHON_ABS) -m mypy -p artana_evidence_db --exclude '$(GRAPH_SERVICE_TYPE_EXCLUDE)' --no-warn-unused-configs $(GRAPH_SERVICE_STRICT_IMPORT_MYPY_FLAGS)
+	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/export_graph_openapi.py --no-warn-unused-configs $(GRAPH_SERVICE_STRICT_IMPORT_MYPY_FLAGS)
 
 graph-service-type-check-strict-imports: ## Exploratory graph mypy check without skipped imports
 	$(call check_venv)
-	cd services && $(USE_PYTHON_ABS) -m mypy -p artana_evidence_db --exclude 'artana_evidence_db/(tests|alembic)/' $(GRAPH_SERVICE_STRICT_IMPORT_MYPY_FLAGS)
+	@$(MAKE) -s graph-service-type-check
 
 graph-service-test: ## Run graph service tests against isolated Postgres
 	$(call check_venv)
@@ -269,7 +262,6 @@ graph-service-test: ## Run graph service tests against isolated Postgres
 graph-service-static-checks-core: ## Run graph service static gates except repo-wide size check
 	@$(MAKE) -s graph-service-lint
 	@$(MAKE) -s graph-service-type-check
-	@$(MAKE) -s graph-service-type-check-strict-imports
 	@$(MAKE) -s graph-service-boundary-check
 	@$(MAKE) -s graph-service-contract-check
 	@$(MAKE) -s graph-phase6-release-check
@@ -298,7 +290,7 @@ type-hardening-baseline: ## Capture strict-import mypy baselines under tmp/type-
 	$(call check_venv)
 	@mkdir -p tmp/type-hardening
 	@/bin/bash -lc 'set +e; cd services && "$(USE_PYTHON_ABS)" -m mypy -p artana_evidence_api --exclude "$(ARTANA_EVIDENCE_API_TYPE_EXCLUDE)" --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS) > ../tmp/type-hardening/evidence-api-runtime-strict-imports.txt 2>&1; status=$$?; cd ..; "$(USE_PYTHON)" scripts/summarize_mypy_errors.py tmp/type-hardening/evidence-api-runtime-strict-imports.txt --label evidence-api-runtime-strict-imports --output tmp/type-hardening/evidence-api-runtime-strict-imports-summary.md; echo "Evidence API runtime strict-import mypy exit: $$status"; cat tmp/type-hardening/evidence-api-runtime-strict-imports-summary.md'
-	@/bin/bash -lc 'set +e; cd services && "$(USE_PYTHON_ABS)" -m mypy -p artana_evidence_db --exclude "artana_evidence_db/(tests|alembic)/" $(GRAPH_SERVICE_STRICT_IMPORT_MYPY_FLAGS) > ../tmp/type-hardening/graph-service-strict-imports.txt 2>&1; status=$$?; cd ..; "$(USE_PYTHON)" scripts/summarize_mypy_errors.py tmp/type-hardening/graph-service-strict-imports.txt --label graph-service-strict-imports --output tmp/type-hardening/graph-service-strict-imports-summary.md; echo "Graph service strict-import mypy exit: $$status"; cat tmp/type-hardening/graph-service-strict-imports-summary.md'
+	@/bin/bash -lc 'set +e; cd services && "$(USE_PYTHON_ABS)" -m mypy -p artana_evidence_db --exclude "$(GRAPH_SERVICE_TYPE_EXCLUDE)" --no-warn-unused-configs $(GRAPH_SERVICE_STRICT_IMPORT_MYPY_FLAGS) > ../tmp/type-hardening/graph-service-strict-imports.txt 2>&1; status=$$?; cd ..; "$(USE_PYTHON)" scripts/summarize_mypy_errors.py tmp/type-hardening/graph-service-strict-imports.txt --label graph-service-strict-imports --output tmp/type-hardening/graph-service-strict-imports-summary.md; echo "Graph service strict-import mypy exit: $$status"; cat tmp/type-hardening/graph-service-strict-imports-summary.md'
 
 artana-evidence-api-test: ## Run evidence API tests against isolated Postgres
 	$(call check_venv)

--- a/docs/type-hardening-plan.md
+++ b/docs/type-hardening-plan.md
@@ -8,35 +8,36 @@ losing confidence.
 
 ## Current State
 
-The repo currently has two passing type gates:
+The repo now has two strict runtime type gates:
 
 - Evidence API: `make -s artana-evidence-api-type-check`
 - Graph service: `make -s graph-service-type-check`
 
-Those gates are useful, but permissive. Both still use `--follow-imports=skip`.
-The Evidence API gate also disables several broad error classes:
+Both runtime gates run package-based mypy from `services/`, follow imports, and
+do not use broad `--disable-error-code` suppressions. The graph gate also keeps
+`scripts/export_graph_openapi.py` covered with a separate script-level mypy
+check so moving the service package to `-p artana_evidence_db` does not drop
+OpenAPI exporter coverage.
 
-- `no-any-unimported`
-- `no-any-return`
-- `misc`
-- `untyped-decorator`
-- `no-untyped-def`
-- `arg-type`
-- `attr-defined`
-- `assignment`
-- `unreachable`
-- `has-type`
+Tests and Alembic migrations remain excluded from the runtime type gates by
+design. Runtime gates enforce production service contracts; migration scripts
+are historical operational scripts, and tests can be typed later through a
+separate test-specific gate without weakening runtime enforcement.
 
-When the Evidence API package was first checked without `--follow-imports=skip`,
-mypy exposed a broad backlog. The first full-package exploratory run found about
-`1,847` errors across `65` files, mostly in tests. The runtime-only exploratory
-target started at `351` errors across `34` files and now passes:
-`make -s artana-evidence-api-type-check-strict-imports`. The graph-service
-strict-import baseline still reports `1,545` errors across `74` runtime files.
-Those graph errors are dominated by SQLAlchemy declarative model visibility and
-protocol variance; they need a dedicated graph-service ORM/protocol slice rather
-than a config-only change. These numbers are baselines for planning, not product
-failures. The existing service type gates still pass.
+`disallow_any_expr = false` remains intentional. The services cross JSON,
+Pydantic, SQLAlchemy, and external payload boundaries; the enforced policy is to
+use typed contracts and local narrowing helpers at those boundaries rather than
+turn on a global expression-level `Any` ban that would create noise without a
+clearer runtime contract.
+
+The only remaining `ignore_missing_imports = true` override is for `requests`
+and `requests.*`, because this environment does not currently provide bundled
+`requests` stubs. New local service modules must not be added to missing-import
+overrides.
+
+Historical baseline: the first strict-import Evidence API runtime run had
+`351` errors across `34` files, and the graph-service runtime run had `1,545`
+errors across `74` files. Both strict-import baselines now report `0` errors.
 
 ## First Principles
 
@@ -66,13 +67,12 @@ The final state should be:
 
 - Evidence API type check runs without `--follow-imports=skip`.
 - Graph service type check runs without `--follow-imports=skip`.
-- Broad disabled error classes are removed or replaced by narrow per-module
-  overrides with explicit justification.
+- Broad disabled error classes are removed from service type gates.
 - JSON payloads have typed access helpers instead of ad hoc indexing into
   `JSONValue`.
 - SQLAlchemy `Result`, `Row`, and scalar query usage is typed consistently.
-- Tests use typed fixtures/builders instead of loose dictionaries where those
-  dictionaries represent domain contracts.
+- Runtime tests use typed fixtures/builders where production contracts require
+  them; broader test-suite typing is left to a separate future gate.
 - CI can enforce the stricter gates without hiding cross-module drift.
 
 ## Workstreams
@@ -112,10 +112,10 @@ Tasks:
 - Standardize mypy invocation around package names from `services/`, not mixed
   path/package invocations.
 - Clean stale or unused `pyproject.toml` mypy override sections.
-- Keep Alembic migrations either excluded or handled by a narrow override,
-  because migration scripts are not the same quality target as runtime code.
-- Decide whether tests are part of the strict package gate or have a separate
-  test-type gate.
+- Keep Alembic migrations excluded from runtime type gates, because migration
+  scripts are not the same quality target as production service code.
+- Keep tests excluded from runtime type gates; add a separate test-type gate in
+  a future issue if test typing becomes a product priority.
 
 Acceptance:
 
@@ -313,16 +313,18 @@ Each PR should include:
 - [x] Add baseline summary command/script.
 - [x] Capture Evidence API strict-import baseline.
 - [x] Capture graph service strict-import baseline.
-- [ ] Fix package invocation and stale mypy config.
+- [x] Fix package invocation and stale mypy config.
 - [x] Add JSON narrowing helpers.
 - [x] Harden first production JSON payload access slice.
 - [x] Harden first SQLAlchemy repository/result typing slice.
 - [x] Harden first orchestrator and shadow planner payload type slice.
 - [x] Harden first router/dependency injection typing slice.
-- [ ] Add typed test fixture builders.
+- [x] Decide test typing policy: runtime gates stay production-only; typed test
+  fixture builders are future follow-up work, not required for the runtime gate.
 - [x] Remove disabled Evidence API error codes from the strict-import gate.
 - [x] Remove Evidence API `--follow-imports=skip` from the exploratory runtime gate.
-- [ ] Remove graph-service `--follow-imports=skip`.
+- [x] Remove graph-service `--follow-imports=skip`.
+- [x] Remove broad graph-service disabled error codes from the default gate.
 - [x] Run and record current `make -s artana-evidence-api-service-checks`.
 - [x] Run and record current `make -s graph-service-checks`.
 
@@ -417,6 +419,49 @@ Verification:
 - `make -s graph-service-lint`
 - `make -s type-hardening-baseline`
 
+### Issue #12 Closeout Gate Tightening
+
+Applied in `alvaro/issue-12-type-hardening`:
+
+- Converted the graph default type gate to package-based mypy with import
+  following enabled and no broad disabled error-code flags.
+- Kept `scripts/export_graph_openapi.py` covered by the graph type gate through
+  a separate script mypy command.
+- Made `graph-service-type-check-strict-imports` an alias of the default graph
+  type gate, matching the Evidence API gate shape.
+- Removed stale internal and unused mypy overrides. The only remaining
+  `ignore_missing_imports = true` override is for `requests` / `requests.*`.
+- Added graph Makefile/pre-commit regression tests so skipped imports and
+  broad disabled error-code flags cannot return unnoticed.
+- Recorded policy decisions for runtime-only gates, Alembic/test exclusions,
+  and `disallow_any_expr = false`.
+
+Escape-hatch inventory at closeout:
+
+- Graph runtime: 1 localized `# type: ignore`, 3 `Any` tokens, 47 `cast(...)`
+  calls.
+- Evidence API runtime: 4 localized `# type: ignore`, 3 `Any` tokens, 408
+  `cast(...)` calls.
+
+Verification results from `2026-04-29 UTC`:
+
+- `make -s graph-service-type-check`: passed; graph package and
+  `scripts/export_graph_openapi.py` both reported `0` mypy issues.
+- `make -s graph-service-type-check-strict-imports`: passed; alias ran the same
+  graph package and OpenAPI exporter mypy checks.
+- `make -s artana-evidence-api-type-check`: passed with `0` mypy issues across
+  `272` source files.
+- `make -s type-hardening-baseline`: passed; Evidence API and graph strict
+  baselines both reported `0` errors.
+- `venv/bin/pytest tests/unit/test_makefile_type_gate_contract.py -q`: passed
+  with `9` regression tests.
+- `make -s graph-service-checks`: passed.
+- `make -s artana-evidence-api-service-checks`: passed.
+- `make -s service-checks`: passed, including coverage at `87.44%` against the
+  `86%` gate.
+- `make all`: passed, including coverage at `87.44%` against the `86%` gate.
+- `git diff --check`: passed.
+
 ## Non-Goals
 
 - Do not build external identity in this type-hardening branch.
@@ -430,8 +475,7 @@ Verification:
 The full type-hardening project is done when:
 
 1. Both services pass mypy without `--follow-imports=skip`.
-2. Broad disabled error-code lists are gone or reduced to narrow documented
-   exceptions.
+2. Broad disabled error-code lists are gone from service type gates.
 3. The full service gates pass:
    - `make -s artana-evidence-api-service-checks`
    - `make -s graph-service-checks`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,35 +43,16 @@ strict_equality = true
 show_error_codes = true
 disallow_any_generics = true
 disallow_any_unimported = true
+# Keep expression-level Any allowed because service boundaries intentionally
+# normalize JSON, Pydantic, SQLAlchemy, and external payloads with narrower
+# helpers and typed contracts instead of a global expression ban.
 disallow_any_expr = false
 [[tool.mypy.overrides]]
-module = [ "alembic.*", "requests.*", "requests",]
+module = [ "requests.*", "requests",]
+# requests is the only remaining runtime dependency without bundled stubs in
+# this environment; keep the override narrow and do not add service-local
+# modules here.
 ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = [ "jsonschema", "jsonschema.*",]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = [ "artana", "artana.*",]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = [ "artana_evidence_db", "artana_evidence_db.*",]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = [
-  "services.artana_evidence_db.legacy_dependency_factories",
-]
-disallow_untyped_defs = false
-
-[[tool.mypy.overrides]]
-module = [
-  "services.artana_evidence_db.routers.graph_views",
-  "services.artana_evidence_db.routers.reasoning_paths",
-]
-disable_error_code = [ "arg-type",]
 
 [tool.flake8]
 max-line-length = 88

--- a/scripts/export_graph_openapi.py
+++ b/scripts/export_graph_openapi.py
@@ -7,9 +7,13 @@ import argparse
 import json
 import os
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
-from typing import Self
+from typing import TYPE_CHECKING, Protocol, Self, cast
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
 
 
 def _skip_dictionary_seed(*_args: object, **_kwargs: object) -> None:
@@ -32,6 +36,15 @@ class _NoopSession:
 
     def commit(self) -> None:
         """No-op commit for schema export."""
+
+
+class _GraphAppOpenAPIExportModule(Protocol):
+    """Module surface patched while rendering the graph OpenAPI document."""
+
+    SessionLocal: type[_NoopSession]
+    seed_builtin_dictionary_entries: Callable[..., None]
+    seed_biomedical_starter_concepts_for_existing_spaces: Callable[..., None]
+    create_app: Callable[[], FastAPI]
 
 
 def _parse_args() -> argparse.Namespace:
@@ -66,12 +79,14 @@ def render_openapi_document() -> str:
 
     import artana_evidence_db.app as graph_app_module
 
-    graph_app_module.SessionLocal = _NoopSession
-    graph_app_module.seed_builtin_dictionary_entries = _skip_dictionary_seed
-    graph_app_module.seed_biomedical_starter_concepts_for_existing_spaces = (
+    # Narrow the module to the monkey-patched export surface used only here.
+    graph_app_export_module = cast("_GraphAppOpenAPIExportModule", graph_app_module)
+    graph_app_export_module.SessionLocal = _NoopSession
+    graph_app_export_module.seed_builtin_dictionary_entries = _skip_dictionary_seed
+    graph_app_export_module.seed_biomedical_starter_concepts_for_existing_spaces = (
         _skip_dictionary_seed
     )
-    create_app = graph_app_module.create_app
+    create_app = graph_app_export_module.create_app
 
     document = create_app().openapi()
     return json.dumps(document, indent=2, sort_keys=True) + "\n"

--- a/tests/unit/test_makefile_type_gate_contract.py
+++ b/tests/unit/test_makefile_type_gate_contract.py
@@ -1,11 +1,13 @@
 """Regression tests for Makefile type-check gates."""
 
 import re
+import tomllib
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _MAKEFILE = _REPO_ROOT / "Makefile"
-_FORBIDDEN_EVIDENCE_API_FLAGS = ("--follow-imports=skip", "--disable-error-code")
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_FORBIDDEN_TYPE_GATE_FLAGS = ("--follow-imports=skip", "--disable-error-code")
 
 
 def _makefile_text() -> str:
@@ -30,7 +32,7 @@ def test_evidence_api_type_gate_uses_strict_package_invocation() -> None:
     assert "--exclude '$(ARTANA_EVIDENCE_API_TYPE_EXCLUDE)'" in type_check_body
     assert "$(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)" in type_check_body
     assert "ARTANA_EVIDENCE_API_MYPY_FLAGS" not in makefile_text
-    for forbidden_flag in _FORBIDDEN_EVIDENCE_API_FLAGS:
+    for forbidden_flag in _FORBIDDEN_TYPE_GATE_FLAGS:
         assert forbidden_flag not in type_check_body
 
 
@@ -42,7 +44,36 @@ def test_evidence_api_strict_import_target_remains_explicit_alias() -> None:
     )
 
     assert "@$(MAKE) -s artana-evidence-api-type-check" in strict_import_body
-    for forbidden_flag in _FORBIDDEN_EVIDENCE_API_FLAGS:
+    for forbidden_flag in _FORBIDDEN_TYPE_GATE_FLAGS:
+        assert forbidden_flag not in strict_import_body
+
+
+def test_graph_service_type_gate_uses_strict_package_invocation() -> None:
+    makefile_text = _makefile_text()
+    type_check_body = _target_body(makefile_text, "graph-service-type-check")
+
+    assert "-m mypy -p artana_evidence_db" in type_check_body
+    assert "--exclude '$(GRAPH_SERVICE_TYPE_EXCLUDE)'" in type_check_body
+    assert "$(GRAPH_SERVICE_STRICT_IMPORT_MYPY_FLAGS)" in type_check_body
+    assert (
+        "cd services && $(USE_PYTHON_ABS) -m mypy "
+        "../scripts/export_graph_openapi.py --no-warn-unused-configs "
+        "$(GRAPH_SERVICE_STRICT_IMPORT_MYPY_FLAGS)"
+    ) in type_check_body
+    assert "GRAPH_SERVICE_TYPE_PATHS" not in makefile_text
+    for forbidden_flag in _FORBIDDEN_TYPE_GATE_FLAGS:
+        assert forbidden_flag not in type_check_body
+
+
+def test_graph_service_strict_import_target_remains_explicit_alias() -> None:
+    makefile_text = _makefile_text()
+    strict_import_body = _target_body(
+        makefile_text,
+        "graph-service-type-check-strict-imports",
+    )
+
+    assert "@$(MAKE) -s graph-service-type-check" in strict_import_body
+    for forbidden_flag in _FORBIDDEN_TYPE_GATE_FLAGS:
         assert forbidden_flag not in strict_import_body
 
 
@@ -54,6 +85,31 @@ def test_evidence_api_service_checks_enforce_normal_type_gate_once() -> None:
 
     assert static_check_body.count("artana-evidence-api-type-check") == 1
     assert "artana-evidence-api-type-check-strict-imports" not in static_check_body
+
+
+def test_graph_service_checks_enforce_normal_type_gate_once() -> None:
+    static_check_body = _target_body(
+        _makefile_text(),
+        "graph-service-static-checks-core",
+    )
+
+    assert static_check_body.count("graph-service-type-check") == 1
+    assert "graph-service-type-check-strict-imports" not in static_check_body
+
+
+def test_mypy_missing_import_override_only_covers_requests() -> None:
+    config = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    overrides = config["tool"]["mypy"]["overrides"]
+
+    assert len(overrides) == 1
+
+    missing_import_modules = [
+        override["module"]
+        for override in overrides
+        if override.get("ignore_missing_imports") is True
+    ]
+
+    assert missing_import_modules == [["requests.*", "requests"]]
 
 
 def test_static_service_check_targets_do_not_run_tests() -> None:
@@ -98,7 +154,9 @@ def test_pre_commit_hooks_avoid_duplicate_full_service_gates() -> None:
     )
 
     assert "entry: make -s artana-evidence-api-type-check\n" in pre_commit_config
+    assert "entry: make -s graph-service-type-check\n" in pre_commit_config
     assert "artana-evidence-api-type-check-strict-imports" not in pre_commit_config
+    assert "graph-service-type-check-strict-imports" not in pre_commit_config
     assert "pre-push" not in pre_commit_config
     assert "entry: make -s graph-service-checks" not in pre_commit_config
     assert "entry: make -s artana-evidence-api-service-checks" not in pre_commit_config


### PR DESCRIPTION
## Summary
- Tighten the graph service type gate to use package-based mypy with imports enabled and no broad disabled error codes
- Keep the graph OpenAPI export script covered by its own mypy check while removing duplicate strict-import execution from static checks and pre-commit
- Prune stale mypy overrides down to the documented `requests` stub gap and record the final typing policy in `docs/type-hardening-plan.md`
- Add regression tests that pin the Makefile gate shape, pre-commit hook contract, and mypy override policy

## Testing
- Local type gates passed for both services and the graph strict-import alias
- Full service checks passed, including `graph-service-checks`, `artana-evidence-api-service-checks`, `service-checks`, and `make all`
- Unit regression tests for the Makefile/type-gate contract passed