### PR TITLE
Update docs and user guides for the v2 public API cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ curl http://127.0.0.1:8091/health
 - [Docs Index](docs/README.md)
 - [Current System](docs/architecture/current-system.md)
 - [User Guide](docs/user-guide/README.md)
-- [Project Status](docs/project_status.md)
 - [Engineering Plan](docs/plan.md)
+- [Source Plugin Guide](docs/source_plugins.md)
 - [Remaining Work](docs/remaining_work_priorities.md)
 
 ## Main Workflow

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
 # Docs Index
 
-Status date: April 26, 2026.
+Status date: April 29, 2026.
 
 This directory describes the current extracted backend repo. The source of
 truth in this checkout is two Python services:
 
 - `services/artana_evidence_api`: evidence workflows, identity/API keys,
   documents, durable direct source-search capture and handoff, proposals,
-  review queue, research-init, chat, and AI runs.
+  review items, research-plan orchestration, chat, and AI tasks.
 - `services/artana_evidence_db`: governed graph, dictionary, claims,
   relations, provenance, graph views, workflows, and graph admin sync.
 
@@ -17,9 +17,9 @@ or `packages/artana_api`.
 ## Start Here
 
 - [Current System](./architecture/current-system.md)
-- [Project Status](./project_status.md)
 - [User Guide](./user-guide/README.md)
 - [Engineering Plan](./plan.md)
+- [Source Plugin Developer Guide](./source_plugins.md)
 - [Remaining Work](./remaining_work_priorities.md)
 
 ## Architecture
@@ -27,7 +27,7 @@ or `packages/artana_api`.
 - [Source Boundaries](./architecture/source-boundaries.md)
 - [Local Identity Boundary](./architecture/local-identity-boundary.md)
 - [Pending Boundary Issues](./architecture/pending-boundary-issues.md)
-- [Research Init Architecture](./research_init_architecture.md)
+- [Research Plan Architecture](./research_init_architecture.md)
 - [Full AI Orchestrator](./full_AI_orchestrator.md)
 - [Artana Kernel Integration Notes](./artana-kernel/docs/README.md)
 

--- a/docs/architecture/current-system.md
+++ b/docs/architecture/current-system.md
@@ -1,6 +1,6 @@
 # Current System
 
-Status date: April 26, 2026.
+Status date: April 29, 2026.
 
 This repo is the extracted backend for the Artana evidence platform. It contains
 two service packages plus service-focused scripts, tests, migrations, docs, and
@@ -24,8 +24,8 @@ There is no top-level `src/` package, no frontend app, and no
 
 | Service | Owns | Does Not Own |
 | --- | --- | --- |
-| Evidence API | local identity gateway, API keys, spaces, documents, durable direct source-search capture and handoff, proposal/review flow, research-init, chat, AI runs, workflow artifacts | graph schema ownership, dictionary ownership, canonical graph persistence |
-| Graph service | graph schema, dictionary, claims, relations, observations, provenance, graph views, domain packs, graph workflows, admin space sync | end-user API keys, document upload UX, research-init orchestration |
+| Evidence API | local identity gateway, API keys, spaces, documents, durable direct source-search capture and handoff, proposal/review flow, research-plan orchestration, chat, AI tasks, workflow outputs | graph schema ownership, dictionary ownership, canonical graph persistence |
+| Graph service | graph schema, dictionary, claims, relations, observations, provenance, graph views, domain packs, graph workflows, admin space sync | end-user API keys, document upload UX, research-plan orchestration |
 
 The Evidence API talks to the graph service through HTTP/client contracts. It
 should not package or import graph implementation internals for normal runtime
@@ -76,8 +76,9 @@ Create or get a space
   -> explore, ask, and repeat
 ```
 
-The review queue is the trust gate. AI workflows can search, extract, and stage
-work, but promoted graph state should flow through review/governance.
+The review queue is the trust gate. AI workflows can search, extract, and
+stage review items, but promoted graph state should flow through
+review/governance.
 Direct source-search handoff follows the same rule: it creates extraction input
 or durable source documents from captured source records, not trusted graph
 facts.

--- a/docs/architecture/evidence-selection-harness.md
+++ b/docs/architecture/evidence-selection-harness.md
@@ -38,10 +38,9 @@ service contracts.
 The product-facing public route is `POST /v2/spaces/{space_id}/evidence-runs`.
 Follow-up runs use
 `POST /v2/spaces/{space_id}/evidence-runs/{evidence_run_id}/follow-ups`.
-The lower-level evidence-selection router also exposes
-`/v1/spaces/{space_id}/agents/evidence-selection/runs` and its follow-up route
-for harness-oriented callers. This tracker does not deprecate that lower-level
-route; product docs should keep steering normal users to the `/v2` front door.
+The lower-level evidence-selection router still exists for harness-oriented
+compatibility, but product docs should keep steering normal users to the
+`/v2` front door.
 
 The agentic-discovery contract has four bounded decisions:
 

--- a/docs/architecture/local-identity-boundary.md
+++ b/docs/architecture/local-identity-boundary.md
@@ -1,6 +1,6 @@
 # Local Identity Boundary
 
-Status: implemented as v1.
+Status: implemented with v2 public routes and v1 compatibility routes.
 
 The Evidence API owns a local identity boundary for the current testing phase.
 The implementation is SQL-backed and in-process, but workflow code talks to an
@@ -26,17 +26,18 @@ space membership rows directly.
 
 The public tester flow is:
 
-- `POST /v1/auth/bootstrap`: create the first self-hosted user and initial API
+- `POST /v2/auth/bootstrap`: create the first self-hosted user and initial API
   key using `X-Artana-Bootstrap-Key`.
-- `POST /v1/auth/testers`: admin-only tester creation with an initial API key.
-- `GET /v1/auth/me`: resolve the current API key or bearer-token identity.
-- `POST /v1/auth/api-keys`: create an additional API key for the current user.
-- `GET /v1/auth/api-keys`: list API-key summaries.
-- `DELETE /v1/auth/api-keys/{key_id}`: revoke one key.
-- `POST /v1/auth/api-keys/{key_id}/rotate`: revoke and replace one key.
+- `POST /v2/auth/testers`: admin-only tester creation with an initial API key.
+- `GET /v2/auth/me`: resolve the current API key or bearer-token identity.
+- `POST /v2/auth/api-keys`: create an additional API key for the current user.
+- `GET /v2/auth/api-keys`: list API-key summaries.
+- `DELETE /v2/auth/api-keys/{key_id}`: revoke one key.
+- `POST /v2/auth/api-keys/{key_id}/rotate`: revoke and replace one key.
 
 Normal requests can use `X-Artana-Key`. Bearer JWTs are also supported by the
-auth layer.
+auth layer. Existing v1 compatibility routes mirror this auth surface for older
+clients; new docs, scripts, and testers should use the v2 routes above.
 
 ## Current Tables
 
@@ -49,7 +50,7 @@ The gateway currently uses Evidence API tables:
 
 Space creation explicitly ensures an owner through the gateway. SQL-backed
 member addition requires the target user to exist first; admins should create
-testers with `POST /v1/auth/testers` instead of relying on hidden placeholder
+testers with `POST /v2/auth/testers` instead of relying on hidden placeholder
 users.
 
 ## Future Extraction Path

--- a/docs/architecture/pending-boundary-issues.md
+++ b/docs/architecture/pending-boundary-issues.md
@@ -1,6 +1,6 @@
 # Pending Boundary Issues
 
-Status date: April 24, 2026.
+Status date: April 29, 2026.
 
 The repo is now an extracted two-service backend, but a few architecture issues
 remain too large for a narrow patch.
@@ -16,7 +16,7 @@ is still backed by local Evidence API SQL tables.
 Current state:
 
 - low-friction tester access uses `X-Artana-Key`;
-- admin tester creation lives at `POST /v1/auth/testers`;
+- admin tester creation lives at `POST /v2/auth/testers`;
 - owner/member checks use the gateway;
 - direct identity ORM imports are blocked outside the allowlist by
   `scripts/validate_artana_evidence_api_service_boundary.py`.
@@ -56,15 +56,15 @@ The largest modules still mix several responsibilities:
 
 First slice completed:
 
-- research-init document source classification and selected-source workset
+- research-plan document source classification and selected-source workset
   selection now live in
   `services/artana_evidence_api/research_init_document_selection.py`.
 
 Target split:
 
-- research-init: source discovery, replay, document preparation, extraction
+- research-plan: source discovery, replay, document preparation, extraction
   staging, state finalization;
-- full AI orchestrator: planner, action executor, guarded policy, artifact
+- full AI orchestrator: planner, action executor, guarded policy, output
   writer;
 - graph workflows: command-family modules once current service gates stay
   stable.

--- a/docs/architecture/source-boundaries.md
+++ b/docs/architecture/source-boundaries.md
@@ -1,17 +1,17 @@
 # Source Boundaries
 
-This note defines the source-boundary foundation for issue #16. It is a
-contract for future refactors, not a public API change.
+This note records the source-boundary foundation implemented for issue #16. It
+is an internal ownership contract, not a public API change.
 
 ## Boundary Rule
 
-Source-specific behavior should be owned once and reused by the registry,
+Source-specific behavior is owned once and reused by the registry,
 direct search, evidence-selection planning, evidence-selection execution,
 handoff, extraction, review, and proposal flow.
 
-The first refactor must not change public route shapes, typed response schemas,
-or OpenAPI output. Existing routes and Pydantic models stay stable while source
-policy is moved behind clearer internal ownership.
+The source plugin refactor did not change public route shapes, typed response
+schemas, or OpenAPI output. Existing routes and Pydantic models stay stable
+while source policy lives behind clearer internal ownership.
 
 Per-source policy is advisory metadata and normalization behavior. Central
 workflow services remain authoritative for safety, idempotency, review gates,
@@ -28,45 +28,47 @@ audit logging, and graph-promotion rules.
 | Source handoff | Selects a captured record, normalizes it into a durable source-document/handoff payload, applies idempotency within a research space and source search, and records handoff status. | Public route/schema changes, external provider calls, or reviewer approval. |
 | Extraction, review, and proposal policy | Consumes per-source advisory policy and centrally decides whether a handoff becomes extraction input, review item, proposal staging, or research-plan review. | Automatic trusted graph promotion or source-search execution. |
 
-## Required Source Policy Fields
+## Current Source Policy Fields
 
-Future source-family policy helpers should expose these fields for every
-source. A simple source and a variant-aware source should both satisfy the same
-contract.
+Source plugins expose these fields for every source through
+`services/artana_evidence_api/source_plugins/contracts.py` and the explicit
+registry in `services/artana_evidence_api/source_plugins/registry.py`. A simple
+source, a variant-aware source, an authority source, and a document-ingestion
+source all satisfy the same public source-definition contract while using the
+right specialized plugin protocol.
 
 | Field | Meaning |
 | --- | --- |
 | `source_key` | Stable internal key used by registry, direct search, handoff, and artifacts, such as `pubmed` or `clinvar`. |
 | `source_family` | Governed family used for grouping and source-document metadata. Start with existing families such as `literature`, `variant`, `clinical`, `protein`, `structure`, `drug`, and `model_organism`; add new families deliberately with registry and handoff tests. |
 | Direct-search capability | `direct_search_supported` plus stable `request_schema_name` and `result_schema_name` when direct search is supported. Unsupported sources leave schema names unset. |
-| Provider/external-id keys | Preference-ordered provider record keys used for selection, idempotency, external-ID lookup, and source-document provenance. Reordering can change behavior and should be protected by the future source-boundary contract test. |
+| Provider/external-id keys | Preference-ordered provider record keys used for selection, idempotency, external-ID lookup, and source-document provenance. Reordering can change behavior and should be protected by source-boundary contract tests. |
 | Normalized record shape | The minimal durable record fields handoff can rely on: title/label, source URL when available, summary text, provider metadata, PHI/redaction classification, audit-safe raw record payload, and provider identifier. |
-| Variant-aware recommendation behavior | A documented source-owned rule equivalent to `recommends_variant_aware(record) -> bool`. Non-variant sources return `False`; variant-aware sources document the normalized fields the rule reads. This is a documentation-level contract until code policy helpers are introduced. |
+| Variant-aware recommendation behavior | A source-owned rule equivalent to `recommends_variant_aware(record) -> bool`. Non-variant sources return `False`; variant-aware sources document and test the normalized fields the rule reads. |
 | Handoff target policy | Current durable source-search handoff supports `source_document`. Any new target kind requires a code contract update, route/schema review, OpenAPI check, and focused tests before use. |
 | Extraction/review/proposal policy | Advisory per-source policy for how captured records should move into extraction, review queues, proposals, or research-plan review before any graph promotion. Central workflow services enforce the final decision. |
 
-## Incremental Order
+## Implemented State
 
-1. Land docs/contract first: this file names the shared source-policy fields
-   and public contract guardrails.
-2. Add a tiny dispatcher only if code movement starts to duplicate branching
-   across registry, direct search, evidence-selection execution, and handoff.
-   If needed, keep it to a `source_key` to policy lookup that exposes the
-   required fields above.
-3. Move one simple source behind the policy shape, such as
-   `clinical_trials`, without changing route contracts.
-4. Move one variant-aware source behind the same policy shape, such as
-   `clinvar` or `marrvel`, proving variant-aware recommendation behavior fits
-   the common contract.
-5. Extract an optional direct-search helper only if repeated execution code is
-   the blocking duplication. Keep typed request/response models unchanged.
-6. Run focused tests and service gates for the touched service before closing
-   implementation work.
+The current Evidence API source boundary has:
 
-## Close Criteria For #16
+1. Direct-search plugins for PubMed, MARRVEL, ClinVar, DrugBank, AlphaFold,
+   UniProt, ClinicalTrials.gov, MGI, and ZFIN.
+2. Authority plugins for MONDO and HGNC.
+3. Document-ingestion plugins for PDF and text.
+4. Plugin-backed compatibility facades for older imports such as
+   `source_registry.py`, `source_policies.py`,
+   `evidence_selection_source_playbooks.py`, and
+   `evidence_selection_extraction_policy.py`.
+5. A public route plugin layer for typed direct-source routes and generic
+   `/sources/{source_key}/searches` dispatch.
+6. Focused plugin, route-plugin, registry, parity, source-boundary, and
+   evidence-selection tests.
 
-#16 is complete when source ownership is explicit, future policy helpers have
-the required fields above, one simple source and one variant-aware source can be
+## Keep True For #16
+
+The source-boundary foundation stays complete when source ownership is explicit,
+plugin contracts keep the fields above, simple and variant-aware sources can be
 verified against the same boundary contract, and the Evidence API public
 contracts remain unchanged. Verification should live in the relevant
 `services/artana_evidence_api/tests` tree for service behavior, with

--- a/docs/artana-kernel/docs/deep_traceability.md
+++ b/docs/artana-kernel/docs/deep_traceability.md
@@ -1,22 +1,22 @@
 # Deep Traceability
 
-Status date: April 23, 2026.
+Status date: April 29, 2026.
 
-Traceability in this repo is split between Evidence API run records, Artana
+Traceability in this repo is split between Evidence API task records, Artana
 kernel state, and graph provenance.
 
 ## Evidence API Runtime Trace
 
-Use these endpoints for one run:
+Use these endpoints for one Evidence API task:
 
-- `GET /v1/spaces/{space_id}/runs/{run_id}`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/progress`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/events`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/artifacts`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/policy-decisions`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/workspace`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/progress`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/events`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/outputs`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/decisions`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/working-state`
 
-Artifacts are the main way to inspect summaries, replay bundles, planner
+Outputs are the main way to inspect summaries, replay bundles, planner
 decisions, source execution summaries, graph snapshots, and generated briefs.
 
 ## Artana Kernel Trace

--- a/docs/full_AI_orchestrator.md
+++ b/docs/full_AI_orchestrator.md
@@ -1,14 +1,14 @@
 # Full AI Orchestrator
 
-Status date: April 23, 2026.
+Status date: April 29, 2026.
 
 The full AI orchestrator is the Evidence API's broadest research workflow. It
-wraps research-init with planner checkpoints, guarded decisions, artifacts, and
+wraps research-plan with planner checkpoints, guarded decisions, outputs, and
 operator-controllable rollout modes.
 
-Endpoint:
+Public endpoint:
 
-- `POST /v1/spaces/{space_id}/agents/full-ai-orchestrator/runs`
+- `POST /v2/spaces/{space_id}/workflows/full-research/tasks`
 
 Primary files:
 
@@ -21,13 +21,13 @@ Primary files:
 
 The orchestrator can:
 
-- create a durable run;
-- execute research-init style source discovery and extraction;
+- create a durable task;
+- execute research-plan style source discovery and extraction;
 - use planner checkpoints in shadow or guarded modes;
-- record action history and decision artifacts;
+- record action history and decision outputs;
 - preserve replay bundles and source execution summaries;
-- expose progress, events, artifacts, policy decisions, and workspace state
-  through the shared run APIs.
+- expose progress, events, outputs, decisions, and working state through the
+  shared task APIs.
 
 ## Modes
 
@@ -40,7 +40,7 @@ space settings and request/runtime options:
   actions under guardrails.
 
 Guarded behavior is intentionally narrow. The orchestrator should not bypass
-the review queue or graph governance boundary.
+the review gate or graph governance boundary.
 
 ## Trust Boundary
 
@@ -52,12 +52,12 @@ by proposal/review flows and graph service policy.
 
 Use these runtime endpoints to inspect behavior:
 
-- `GET /v1/spaces/{space_id}/runs/{run_id}`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/progress`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/events`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/artifacts`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/policy-decisions`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/workspace`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/progress`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/events`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/outputs`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/decisions`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/working-state`
 
 The old long-form canary reports are not kept in `docs/`. New rollout evidence
 should live under ignored `reports/` output and be summarized in PRs.

--- a/docs/remaining_work_priorities.md
+++ b/docs/remaining_work_priorities.md
@@ -1,6 +1,6 @@
 # Remaining Work Priorities
 
-Status date: April 26, 2026.
+Status date: April 29, 2026.
 
 The backend scaffold is in place. The remaining work is about hardening the
 boundaries, making testing easier, and preparing for external users without
@@ -30,8 +30,8 @@ overbuilding too early.
 
 ## P1 - Test Local Identity With Real Users
 
-- Use `POST /v1/auth/bootstrap` for the first local/admin user.
-- Use `POST /v1/auth/testers` for additional internal testers.
+- Use `POST /v2/auth/bootstrap` for the first local/admin user.
+- Use `POST /v2/auth/testers` for additional internal testers.
 - Watch for friction around key rotation, lost keys, space membership, and
   admin operations.
 - Decide later whether to implement `RemoteIdentityGateway`; do not add it
@@ -50,7 +50,7 @@ overbuilding too early.
 - Keep Cloud Run runtime-config sync scripts aligned with the current env var
   contract.
 - Add or refresh staging smoke checks for `/health`, OpenAPI, auth bootstrap or
-  tester creation, graph space sync, and one review-queue flow.
+  tester creation, graph space sync, and one review flow through review items.
 - Keep live external API tests opt-in. They depend on network and third-party
   service availability.
 

--- a/docs/research_init_architecture.md
+++ b/docs/research_init_architecture.md
@@ -1,18 +1,21 @@
-# Research Init Architecture
+# Research Plan Architecture
 
-Status date: April 25, 2026.
+Status date: April 29, 2026.
 
-Research init is the Evidence API workflow for starting a new research space
+Research plan is the Evidence API workflow for starting a new research space
 from an objective, seed terms, and selected sources.
 
-Entry point:
+Compatibility note: the older research-init route is still available for
+existing clients, but current public docs and examples use the v2
+`research-plan` entry point.
 
-- `POST /v1/spaces/{space_id}/research-init`
+Public entry point:
+
 - `POST /v2/spaces/{space_id}/research-plan`
 
-Related direct workflow endpoint:
+Related workflow endpoint:
 
-- `POST /v1/spaces/{space_id}/agents/research-bootstrap/runs`
+- `POST /v2/spaces/{space_id}/workflows/topic-setup/tasks`
 
 Related source capability endpoints:
 
@@ -23,28 +26,30 @@ Related source capability endpoints:
 ## Current Flow
 
 ```text
-research-init request
+research-plan request
   -> build source plan
   -> run PubMed discovery when enabled
   -> run structured-source enrichment when enabled
   -> store source/document records
   -> extract or stage reviewable findings
   -> optionally call research-bootstrap
-  -> save run state, artifacts, and research state
+  -> save task state, outputs, and research state
 ```
 
-The runtime is queue-aware through the Evidence API run infrastructure. Callers
-can inspect run progress, events, artifacts, policy decisions, and workspace
-state through `/v1/spaces/{space_id}/runs/*`.
+The runtime is queue-aware through the Evidence API task infrastructure. Callers
+can inspect task progress, events, outputs, decisions, and working state through
+`/v2/spaces/{space_id}/tasks/*`.
 
 ## Source Coverage In This Service
 
-Research-init source keys are registered in
-`services/artana_evidence_api/source_registry.py`. The registry tells clients
-which sources support direct search, which sources run through `research-plan`,
-and which sources require live external calls or credentials.
+Research-plan source keys are registered in
+`services/artana_evidence_api/source_registry.py`, while direct-search route
+behavior is registered through `services/artana_evidence_api/source_plugins/`.
+Together they tell clients which sources support direct search, which sources
+run through `research-plan`, and which sources require live external calls or
+credentials.
 
-Research-init code currently has service-local source support for:
+Research-plan runtime currently has service-local source support for:
 
 - PubMed;
 - MARRVEL;
@@ -77,7 +82,7 @@ MONDO remains a research-plan/background ontology grounding step rather than a
 direct search endpoint. Text and PDF remain document-capture sources. HGNC
 remains an enrichment/grounding source.
 
-Generic v2 source-search responses and research-init-created source documents
+Generic v2 source-search responses and research-plan-created source documents
 include `source_capture` metadata with the source key, capture stage, locator,
 query, run/search id, result count, source family, and compact provenance.
 Structured direct source searches persist their captured search response in the
@@ -117,7 +122,7 @@ research_init_runtime
 
 The distinction is practical:
 
-- research-init is document/source heavy;
+- research-plan is document/source heavy;
 - bootstrap is graph/reasoning heavy.
 
 ## Governance
@@ -125,13 +130,13 @@ The distinction is practical:
 Research init should stage proposals or review items rather than silently
 turning AI output into trusted graph truth. Review happens through:
 
-- `GET /v1/spaces/{space_id}/review-queue`
-- `POST /v1/spaces/{space_id}/review-queue/{item_id}/actions`
+- `GET /v2/spaces/{space_id}/review-items`
+- `POST /v2/spaces/{space_id}/review-items/{item_id}/decision`
 
 Advanced direct-write endpoints still exist, such as
-`POST /v1/spaces/{space_id}/marrvel/ingest`, but normal researcher workflows
-should prefer discovery, extraction, and review. Direct source search and
-research-plan orchestration both stage work before graph promotion.
+`POST /v2/spaces/{space_id}/sources/marrvel/ingestion`, but normal researcher
+workflows should prefer discovery, extraction, and review. Direct source
+search and research-plan orchestration both stage work before graph promotion.
 
 ## Current Files
 
@@ -139,6 +144,7 @@ research-plan orchestration both stage work before graph promotion.
 | --- | --- |
 | `services/artana_evidence_api/routers/research_init.py` | API route |
 | `services/artana_evidence_api/source_registry.py` | source capability registry |
+| `services/artana_evidence_api/source_plugins/` | source plugin contracts and route registration |
 | `services/artana_evidence_api/source_result_capture.py` | normalized source-result capture metadata |
 | `services/artana_evidence_api/routers/v2_public.py` | v2 source and research-plan routes |
 | `services/artana_evidence_api/research_init_runtime.py` | main runtime |

--- a/docs/source_plugins.md
+++ b/docs/source_plugins.md
@@ -198,6 +198,6 @@ Do not:
   `source_plugins/pdf.py`;
 - register plugins through import side effects;
 - put database sessions, routers, SQLAlchemy models, graph-service internals,
-  or review-queue persistence inside plugins;
+  or review-item persistence inside plugins;
 - make document-ingestion plugins dispatch extraction/review side effects;
 - add new source-key live-search handler maps outside the plugin registry.

--- a/docs/user-guide/03-workflow-overview.md
+++ b/docs/user-guide/03-workflow-overview.md
@@ -37,7 +37,7 @@ when you need more control or debugging visibility.
 | Inspect sources | `GET /v2/sources` | Confirm which sources support direct search or enrichment |
 | Search one source directly | `POST /v2/spaces/{space_id}/sources/{source_key}/searches` | Manually pre-capture or debug source-specific results |
 | Hand off one selected source result | `POST /v2/spaces/{space_id}/sources/{source_key}/searches/{search_id}/handoffs` | Manually turn one captured result into extraction input |
-| Create an older research plan | `POST /v2/spaces/{space_id}/research-plan` | Use legacy source-enrichment planning workflows |
+| Create a research plan | `POST /v2/spaces/{space_id}/research-plan` | Use source-enrichment planning workflows |
 | Add your own evidence | `POST /v2/spaces/{space_id}/documents/text` and `POST /v2/spaces/{space_id}/documents/pdf` | Upload a MED13 paper, note, or copied abstract |
 | Extract from one document | `POST /v2/spaces/{space_id}/documents/{document_id}/extraction` | Turn a specific document into reviewable suggestions |
 

--- a/docs/user-guide/04-adding-evidence.md
+++ b/docs/user-guide/04-adding-evidence.md
@@ -55,11 +55,12 @@ curl -s "$ARTANA_API_BASE_URL/v2/sources" \
 Direct source search currently supports sources whose capability record has
 `"direct_search_enabled": true`: PubMed, MARRVEL, ClinVar, AlphaFold,
 UniProt, ClinicalTrials.gov, MGI, and ZFIN. DrugBank also supports direct
-search when `DRUGBANK_API_KEY` is configured. MONDO is an ontology-grounding
-source, not a bounded direct-search endpoint. Text and PDF are document-capture
-sources. Direct source-search responses are durable captured source results:
-the search result can be fetched later by id, but it is not promoted into the
-trusted graph until downstream extraction, proposal, and review steps approve it.
+search when `DRUGBANK_API_KEY` is configured. MONDO and HGNC are
+ontology/authority-grounding sources, not bounded direct-search endpoints. Text
+and PDF are document-capture sources. Direct source-search responses are durable
+captured source results: the search result can be fetched later by id, but it is
+not promoted into the trusted graph until downstream extraction, proposal, and
+review steps approve it.
 
 Search PubMed:
 

--- a/docs/user-guide/07-multi-source-and-automation.md
+++ b/docs/user-guide/07-multi-source-and-automation.md
@@ -23,11 +23,13 @@ Endpoints:
 - `POST /v2/spaces/{space_id}/evidence-runs/{evidence_run_id}/follow-ups`
 
 Current behavior: evidence runs default to `planner_mode: "model"`. When the
-model planner is configured, you can submit only a goal/instructions and the
-harness will choose a small set of supported source searches, run them, screen
-the durable results, create guarded handoffs, and stage review-gated proposals
-or review items. You can still provide `source_searches` or `candidate_searches`
-directly for manual control. Shadow mode records recommendations without
+model planner is configured, you can submit a goal/instructions plus
+`live_network_allowed: true`, and the harness will choose a small set of
+supported source searches, run them, screen the durable results, create guarded
+handoffs, and stage review-gated proposals or review items. You can still
+provide `source_searches` or `candidate_searches` directly for manual control.
+Any request that creates live source searches must set
+`live_network_allowed: true`. Shadow mode records recommendations without
 creating handoffs.
 If model planning is not configured, goal-only requests return a clear
 unavailable error; explicit source-search requests can still run
@@ -38,7 +40,8 @@ Goal-only example:
 ```json
 {
   "goal": "Find evidence linking MED13 variants to congenital heart disease",
-  "mode": "guarded"
+  "mode": "guarded",
+  "live_network_allowed": true
 }
 ```
 
@@ -49,6 +52,7 @@ Manual deterministic example:
   "goal": "Find evidence linking MED13 variants to congenital heart disease",
   "mode": "guarded",
   "planner_mode": "deterministic",
+  "live_network_allowed": true,
   "source_searches": [
     {
       "source_key": "clinvar",
@@ -65,6 +69,7 @@ Explicit source-search example:
 {
   "goal": "Find evidence linking MED13 variants to congenital heart disease",
   "mode": "guarded",
+  "live_network_allowed": true,
   "source_searches": [
     {
       "source_key": "clinvar",
@@ -81,6 +86,7 @@ PubMed uses a nested query payload:
 {
   "goal": "Find papers linking MED13 variants to congenital heart disease",
   "mode": "guarded",
+  "live_network_allowed": true,
   "source_searches": [
     {
       "source_key": "pubmed",
@@ -101,6 +107,7 @@ MARRVEL uses gene or variant query fields:
 {
   "goal": "Find variant-context evidence for MED13",
   "mode": "guarded",
+  "live_network_allowed": true,
   "source_searches": [
     {
       "source_key": "marrvel",

--- a/docs/user-guide/09-endpoint-index.md
+++ b/docs/user-guide/09-endpoint-index.md
@@ -40,8 +40,10 @@ Use these when you understand the core review flow.
 | Run evidence curation | `POST /v2/spaces/{space_id}/workflows/evidence-curation/tasks` |
 | Create or manage schedules | `/v2/spaces/{space_id}/schedules/*` |
 | Use full research workflows | `/v2/spaces/{space_id}/workflows/full-research/*` |
-| Create an older research plan | `POST /v2/spaces/{space_id}/research-plan` |
-| Search a direct-search source manually | `POST /v2/spaces/{space_id}/sources/{source_key}/searches` |
+| Create a research plan | `POST /v2/spaces/{space_id}/research-plan` |
+| Search PubMed directly with its typed request/response shape | `POST /v2/spaces/{space_id}/sources/pubmed/searches` |
+| Search MARRVEL directly with its typed request/response shape | `POST /v2/spaces/{space_id}/sources/marrvel/searches` |
+| Search any direct-search source manually | `POST /v2/spaces/{space_id}/sources/{source_key}/searches` |
 | Get a source search result | `GET /v2/spaces/{space_id}/sources/{source_key}/searches/{search_id}` |
 | Hand off one selected source record | `POST /v2/spaces/{space_id}/sources/{source_key}/searches/{search_id}/handoffs` |
 
@@ -98,8 +100,9 @@ reaches the review gate.
 `GET /v2/sources` is the source of truth for which sources can be searched
 directly. PubMed, MARRVEL, ClinVar, AlphaFold, UniProt, ClinicalTrials.gov,
 MGI, and ZFIN support direct search. DrugBank supports direct search when
-`DRUGBANK_API_KEY` is configured. MONDO is a background ontology-grounding
-source, while text and PDF are document-capture sources.
+`DRUGBANK_API_KEY` is configured. MONDO and HGNC are background
+ontology/authority-grounding sources, while text and PDF are document-capture
+sources.
 Generic source-search responses include `source_capture` metadata so clients can
 trace a result to its source, family, query, locator, and provenance. Structured
 direct source-search results are stored durably in the Evidence API database and

--- a/services/artana_evidence_api/docs/README.md
+++ b/services/artana_evidence_api/docs/README.md
@@ -20,7 +20,7 @@ If you are new to the service, read these files in order:
 3. [Full Research Workflow](./full-research-workflow.md)
 4. [Core Concepts](./concepts.md)
 5. [Example Use Cases](./use-cases.md)
-6. [Run Transparency](./transparency.md)
+6. [Task Transparency](./transparency.md)
 7. [API Reference](./api-reference.md)
 
 Useful companion files:
@@ -48,7 +48,7 @@ Read:
   for chat, PubMed, MARRVEL, bootstrap, schedules, or supervisor
 - [Core Concepts](./concepts.md) if you want the vocabulary explained in plain
   English
-- [Run Transparency](./transparency.md) if you want to inspect what a run could
+- [Task Transparency](./transparency.md) if you want to inspect what a task could
   do versus what it actually did
 - [API Reference](./api-reference.md) if you already know the workflow and just
   want route details
@@ -62,26 +62,26 @@ What this service does:
   sources such as PubMed and MARRVEL, and larger workflow-managed source
   families such as ClinVar, DrugBank, AlphaFold, ClinicalTrials, MGI, and
   ZFIN when enabled through broader orchestration flows.
-- Stores run lifecycle state, artifacts, workspace snapshots, events, and
+- Stores task lifecycle state, outputs, working-state snapshots, events, and
   progress through the Artana-backed runtime.
 - Keeps domain state such as proposals, review-only queue items, approvals,
   schedules, research state, graph snapshots, and chat sessions.
-- Exposes account, API-key, space-membership, graph-explorer, onboarding, and
+- Exposes account, API-key, space-membership, evidence-map, onboarding, and
   settings endpoints in addition to the main research workflow routes.
 - Exposes an HTTP API that other services and UI clients can call directly.
 
 Route execution model:
 
-- Harness run-start routes are queue-first and worker-owned.
-- The API creates a durable run record, seeds workspace state, and then either:
+- Task-start routes are queue-first and worker-owned.
+- The API creates a durable task record, seeds working state, and then either:
   - waits briefly for the worker so clients can keep the existing synchronous
     response shape, or
-  - returns `202 Accepted` with run URLs when the caller sends
+  - returns `202 Accepted` with task URLs when the caller sends
     `Prefer: respond-async` or the sync wait budget expires.
 - This applies to chat, research bootstrap, research onboarding, graph search,
   graph connections, hypotheses, continuous learning, mechanism discovery,
-  claim curation, supervisor, and research init.
-- Worker concurrency is currently one run at a time per worker process.
+  claim curation, supervisor, and research-plan work.
+- Worker concurrency is currently one task at a time per worker process.
   Horizontal scale comes from running more worker replicas against the same
   lease-backed queue.
 
@@ -91,10 +91,10 @@ What this docs set focuses on:
   are ready
 - how to start the service
 - how auth, API keys, and default spaces work
-- how the document -> extract -> review queue -> chat workflow works
-- what a run, document, proposal, review item, approval, and schedule mean
-- when to use chat, documents, the review queue, proposals, graph explorer,
-  PubMed, MARRVEL, onboarding, and research-init
-- how to inspect run transparency through capabilities and policy decisions
+- how the document -> extraction -> review items -> chat workflow works
+- what a task, document, proposal, review item, approval, and schedule mean
+- when to use chat, documents, review items, proposed updates, evidence-map,
+  PubMed, MARRVEL, onboarding, and research-plan work
+- how to inspect task transparency through capabilities and decisions
 - every available endpoint
 - realistic beginner and advanced examples

--- a/services/artana_evidence_api/docs/api-reference.md
+++ b/services/artana_evidence_api/docs/api-reference.md
@@ -34,7 +34,7 @@ The current endpoint surface is easiest to understand in layers:
 1. auth and space setup
 2. generic run lifecycle and transparency
 3. document, review, and chat workflows
-4. direct discovery and graph explorer reads
+4. direct discovery and evidence-map reads
 5. typed research workflows
 
 One important runtime rule:
@@ -347,11 +347,11 @@ Important promotion nuance:
 | --- | --- | --- |
 | `GET` | `/v2/spaces/{space_id}/review-items` | Lists the unified review queue across proposals, review-only items, and approvals. |
 | `GET` | `/v2/spaces/{space_id}/review-items/{item_id}` | Returns one review queue item. |
-| `POST` | `/v2/spaces/{space_id}/review-items/{item_id}/actions` | Applies one review action through the unified queue surface. |
-| `GET` | `/v2/spaces/{space_id}/proposals` | Lists proposal records directly. |
-| `GET` | `/v2/spaces/{space_id}/proposals/{proposal_id}` | Returns one proposal. |
-| `POST` | `/v2/spaces/{space_id}/proposals/{proposal_id}/promote` | Promotes one proposal directly. |
-| `POST` | `/v2/spaces/{space_id}/proposals/{proposal_id}/reject` | Rejects one proposal directly. |
+| `POST` | `/v2/spaces/{space_id}/review-items/{item_id}/decision` | Applies one review action through the unified queue surface. |
+| `GET` | `/v2/spaces/{space_id}/proposed-updates` | Lists proposal records directly. |
+| `GET` | `/v2/spaces/{space_id}/proposed-updates/{proposal_id}` | Returns one proposal. |
+| `POST` | `/v2/spaces/{space_id}/proposed-updates/{proposal_id}/promote` | Promotes one proposal directly. |
+| `POST` | `/v2/spaces/{space_id}/proposed-updates/{proposal_id}/reject` | Rejects one proposal directly. |
 
 Use `/review-items` as the default human review API.
 
@@ -392,10 +392,10 @@ Proposal list filters:
 - `task_id`
 - `document_id`
 
-Think of `/proposals` as the lower-level primitive behind the unified review
-queue.
+Think of `/proposed-updates` as the lower-level primitive behind the unified
+review queue.
 
-## 9. Graph Explorer
+## 9. Evidence Map
 
 | Method | Path | What it does |
 | --- | --- | --- |
@@ -432,7 +432,7 @@ Unified graph document request body:
 }
 ```
 
-Use graph explorer when you want read-only graph inspection without starting a
+Use the evidence map when you want read-only graph inspection without starting a
 new AI run.
 
 ## 10. Direct Source Discovery
@@ -684,11 +684,11 @@ immediately instead of waiting for the inline completion window.
 | --- | --- | --- |
 | `GET` | `/v2/spaces/{space_id}/schedules` | Lists saved schedules. |
 | `POST` | `/v2/spaces/{space_id}/schedules` | Creates one schedule. |
-| `GET` | `/v2/spaces/{space_id}/schedules/{schedule_id}` | Returns one schedule plus recent runs. |
+| `GET` | `/v2/spaces/{space_id}/schedules/{schedule_id}` | Returns one schedule plus recent tasks. |
 | `PATCH` | `/v2/spaces/{space_id}/schedules/{schedule_id}` | Updates one schedule. |
 | `POST` | `/v2/spaces/{space_id}/schedules/{schedule_id}/pause` | Pauses one schedule. |
 | `POST` | `/v2/spaces/{space_id}/schedules/{schedule_id}/resume` | Resumes one schedule. |
-| `POST` | `/v2/spaces/{space_id}/schedules/{schedule_id}/start-now` | Triggers an immediate run from the stored schedule. |
+| `POST` | `/v2/spaces/{space_id}/schedules/{schedule_id}/start-now` | Triggers an immediate task from the stored schedule. |
 
 Create schedule body:
 
@@ -723,7 +723,7 @@ Create schedule body:
 | Method | Path | What it does |
 | --- | --- | --- |
 | `POST` | `/v2/spaces/{space_id}/workflows/full-research/tasks` | Starts one composed supervisor workflow. |
-| `GET` | `/v2/spaces/{space_id}/workflows/full-research/tasks` | Lists typed supervisor runs. |
+| `GET` | `/v2/spaces/{space_id}/workflows/full-research/tasks` | Lists typed supervisor tasks. |
 | `GET` | `/v2/spaces/{space_id}/workflows/full-research/tasks/{task_id}` | Returns typed supervisor detail. |
 | `GET` | `/v2/spaces/{space_id}/workflows/full-research/dashboard` | Returns typed dashboard summary. |
 | `POST` | `/v2/spaces/{space_id}/workflows/full-research/tasks/{task_id}/suggested-updates/{candidate_index}/decision` | Promotes or rejects one supervisor briefing-chat candidate. |
@@ -782,10 +782,10 @@ Most users should start with:
 
 Advanced or lower-level surfaces:
 
-- `/v2/spaces/{space_id}/proposals/*`
+- `/v2/spaces/{space_id}/proposed-updates/*`
 - inline chat candidate review
 - `/v2/spaces/{space_id}/sources/marrvel/ingestion`
-- graph explorer entity, claim, evidence, and unified-document routes
+- evidence-map entity, claim, evidence, and unified-document routes
 - `/v2/spaces/{space_id}/members/*`
 - `/v2/spaces/{space_id}/settings`
 - direct generic `/tasks` creation
@@ -803,7 +803,7 @@ Read endpoints include:
 - document list/detail
 - review queue list/detail
 - proposal list/detail
-- graph explorer reads
+- evidence-map reads
 - saved PubMed and MARRVEL result reads
 - research state
 - supervisor list/detail/dashboard

--- a/services/artana_evidence_api/docs/concepts.md
+++ b/services/artana_evidence_api/docs/concepts.md
@@ -30,7 +30,7 @@ Examples:
 - `claim-curation`
 - `supervisor`
 
-Use `GET /v1/harnesses` to discover the available harnesses and their declared
+Use `GET /v2/workflow-templates` to discover the available harnesses and their declared
 outputs.
 
 ## Run
@@ -56,9 +56,9 @@ Common run statuses:
 
 There are two ways to start work:
 
-- generic route: `POST /v1/spaces/{space_id}/runs`
+- generic route: `POST /v2/spaces/{space_id}/tasks`
 - typed workflow routes such as
-  `/v1/spaces/{space_id}/agents/research-bootstrap/runs`
+  `/v2/spaces/{space_id}/workflows/topic-setup/tasks`
 
 For most users, the typed workflow routes are easier to use.
 
@@ -77,7 +77,7 @@ The progress payload includes:
 
 Use:
 
-- `GET /v1/spaces/{space_id}/runs/{run_id}/progress`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/progress`
 
 ## Event
 
@@ -93,7 +93,7 @@ Examples:
 
 Use:
 
-- `GET /v1/spaces/{space_id}/runs/{run_id}/events`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/events`
 
 ## Transparency
 
@@ -101,20 +101,20 @@ Every run now has two transparency views:
 
 - `capabilities`: the frozen list of tools the run was allowed to use when it
   started
-- `policy-decisions`: the ordered log of what the run actually tried to do,
+- `decisions`: the ordered log of what the run actually tried to do,
   plus any later human review decisions tied back to that run
 
 Use:
 
-- `GET /v1/spaces/{space_id}/runs/{run_id}/capabilities`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/policy-decisions`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/capabilities`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/decisions`
 
 Use `capabilities` when you want to answer:
 
 - what tools could this run use?
 - which tools were filtered out?
 
-Use `policy-decisions` when you want to answer:
+Use `decisions` when you want to answer:
 
 - what did the run actually execute?
 - did it pause for approval?
@@ -124,7 +124,7 @@ The simplest way to think about transparency is:
 
 - `capabilities` is the allowed-tool snapshot
 - `events` is the raw lifecycle log
-- `policy-decisions` is the structured decision timeline
+- `decisions` is the structured decision timeline
 
 If you are new to these features, read [Run Transparency](./transparency.md)
 next.
@@ -144,8 +144,8 @@ Examples:
 
 Use:
 
-- `GET /v1/spaces/{space_id}/runs/{run_id}/artifacts`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/artifacts/{artifact_key}`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/outputs`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/outputs/{artifact_key}`
 
 ## Workspace Snapshot
 
@@ -161,7 +161,7 @@ Workspace is better for the latest evolving state, such as:
 
 Use:
 
-- `GET /v1/spaces/{space_id}/runs/{run_id}/workspace`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/working-state`
 
 ## Proposal
 
@@ -196,7 +196,7 @@ One queue item can wrap:
 - one review-only follow-up item
 - one paused-run approval
 
-That is why `/review-queue` is the easiest default review surface.
+That is why `/review-items` is the easiest default review surface.
 
 Typical actions:
 
@@ -352,7 +352,7 @@ Approval-gated runs:
 2. run pauses
 3. review approvals
 4. resume run
-5. inspect summary and artifacts
+5. inspect summary and outputs
 
 Supervisor runs:
 

--- a/services/artana_evidence_api/docs/full-research-workflow.md
+++ b/services/artana_evidence_api/docs/full-research-workflow.md
@@ -44,16 +44,16 @@ Choose one:
 If you are scripting the API from Python, call the same HTTP routes with
 `httpx` or `requests`. The matching route families are:
 
-- `POST /v1/spaces/{space_id}/documents/text`
-- `POST /v1/spaces/{space_id}/documents/pdf`
-- `POST /v1/spaces/{space_id}/chat-sessions/{session_id}/messages`
-- `POST /v1/spaces/{space_id}/pubmed/searches`
+- `POST /v2/spaces/{space_id}/documents/text`
+- `POST /v2/spaces/{space_id}/documents/pdf`
+- `POST /v2/spaces/{space_id}/chat-sessions/{session_id}/messages`
+- `POST /v2/spaces/{space_id}/sources/pubmed/searches`
 
 If your space is brand new and you want the service to guide setup before you
 start reviewing evidence, the newer setup endpoints are:
 
-- `POST /v1/spaces/{space_id}/agents/research-onboarding/runs`
-- `POST /v1/spaces/{space_id}/research-init`
+- `POST /v2/spaces/{space_id}/workflows/research-onboarding/tasks`
+- `POST /v2/spaces/{space_id}/research-plan`
 
 ## What The Main Terms Mean
 
@@ -79,7 +79,7 @@ PDF workflow:
 - that enriched text is then used for proposal staging
 
 This means PDF upload alone does not immediately create proposals. The
-`/extract` call is the point where enrichment and proposal staging happen.
+`/extraction` call is the point where enrichment and proposal staging happen.
 
 ## Use Case 1: Review One Paper
 
@@ -92,7 +92,7 @@ Goal:
 Upload the PDF:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/pdf" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/documents/pdf" \
   -H "Authorization: Bearer $TOKEN" \
   -F "file=@./med13.pdf" \
   -F "title=MED13 paper"
@@ -101,7 +101,7 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/pdf" \
 Run extraction:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/<document_id>/extract" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/documents/<document_id>/extraction" \
   -H "Authorization: Bearer $TOKEN" \
   -X POST
 ```
@@ -109,14 +109,14 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/<document_id>/extract" \
 List the document-scoped review queue:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/review-queue?document_id=<document_id>" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items?document_id=<document_id>" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
 Act on one queue item:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/review-queue/<item_id>/actions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items/<item_id>/decision" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -157,7 +157,7 @@ First upload or submit the document.
 Then create a chat session:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/chat-sessions" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -168,7 +168,7 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions" \
 Send the message with the tracked `document_id`:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions/<session_id>/messages" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/chat-sessions/<session_id>/messages" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -182,7 +182,7 @@ If the answer is verified and you want reviewed graph changes, stage generic
 proposals from the chat result:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions/<session_id>/proposals/graph-write" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/chat-sessions/<session_id>/suggested-updates" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -193,7 +193,7 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions/<session_id>/proposals/g
 Then review those staged items through the review queue:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/review-queue" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -208,7 +208,7 @@ Goal:
 Start the search:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/pubmed/searches" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/sources/pubmed/searches" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -223,7 +223,7 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/pubmed/searches" \
 Fetch the saved job:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/pubmed/searches/<job_id>" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/sources/pubmed/searches/<job_id>" \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/services/artana_evidence_api/docs/getting-started.md
+++ b/services/artana_evidence_api/docs/getting-started.md
@@ -149,7 +149,7 @@ All examples below assume `SPACE_ID` is a research space you can access.
 If you want to confirm who the service thinks you are, call:
 
 ```bash
-curl -s "$HARNESS_URL/v1/auth/me" \
+curl -s "$HARNESS_URL/v2/auth/me" \
   -H "X-Artana-Key: $ARTANA_API_KEY"
 ```
 
@@ -163,7 +163,7 @@ Example:
 ```bash
 export HARNESS_URL="http://localhost:8091"
 
-curl -s "$HARNESS_URL/v1/harnesses" \
+curl -s "$HARNESS_URL/v2/workflow-templates" \
   -H "X-TEST-USER-ID: 11111111-1111-1111-1111-111111111111" \
   -H "X-TEST-USER-EMAIL: researcher@example.com" \
   -H "X-TEST-USER-ROLE: researcher"
@@ -175,7 +175,7 @@ Use this only for local development and tests.
 
 If you want a normal Artana API key for SDK or HTTP usage, use:
 
-[`scripts/issue_artana_evidence_api_key.py`](/Users/alvaro/Documents/Code/monorepo/scripts/issue_artana_evidence_api_key.py)
+[`scripts/issue_artana_evidence_api_key.py`](../../../scripts/issue_artana_evidence_api_key.py)
 
 Fresh deployment, first key:
 
@@ -210,7 +210,7 @@ eval "$(venv/bin/python scripts/issue_artana_evidence_api_key.py ...)"
 Once you have a working credential, the easiest space setup call is:
 
 ```bash
-curl -s -X PUT "$HARNESS_URL/v1/spaces/default" \
+curl -s -X PUT "$HARNESS_URL/v2/spaces/default" \
   -H "X-Artana-Key: $ARTANA_API_KEY"
 ```
 
@@ -243,7 +243,7 @@ What changes between text and PDF:
 Example with one text note:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/text" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/documents/text" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -256,7 +256,7 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/text" \
 Then:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/<document_id>/extract" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/documents/<document_id>/extraction" \
   -H "Authorization: Bearer $TOKEN" \
   -X POST
 ```
@@ -264,14 +264,14 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/<document_id>/extract" \
 Then:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/review-queue?document_id=<document_id>" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items?document_id=<document_id>" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
 Then:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/chat-sessions" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -282,7 +282,7 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions" \
 And finally:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions/<session_id>/messages" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/chat-sessions/<session_id>/messages" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -316,26 +316,26 @@ curl -s "$HARNESS_URL/health" -H "Authorization: Bearer $TOKEN"
 2. Confirm your identity:
 
 ```bash
-curl -s "$HARNESS_URL/v1/auth/me" -H "X-Artana-Key: $ARTANA_API_KEY"
+curl -s "$HARNESS_URL/v2/auth/me" -H "X-Artana-Key: $ARTANA_API_KEY"
 ```
 
 3. Get or create your default space:
 
 ```bash
-curl -s -X PUT "$HARNESS_URL/v1/spaces/default" \
+curl -s -X PUT "$HARNESS_URL/v2/spaces/default" \
   -H "X-Artana-Key: $ARTANA_API_KEY"
 ```
 
 4. List available harnesses:
 
 ```bash
-curl -s "$HARNESS_URL/v1/harnesses" -H "Authorization: Bearer $TOKEN"
+curl -s "$HARNESS_URL/v2/workflow-templates" -H "Authorization: Bearer $TOKEN"
 ```
 
 5. Start a research bootstrap run:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/agents/research-bootstrap/runs" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/workflows/topic-setup/tasks" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -346,17 +346,17 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/agents/research-bootstrap/runs" \
   }'
 ```
 
-6. Inspect the run artifacts:
+6. Inspect the task outputs:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/runs/<run_id>/artifacts" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/outputs" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
 And then, once you have staged work, list the review queue:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/review-queue" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -370,27 +370,27 @@ Every run now gives you two extra views:
 
 - `capabilities`
   what the run was allowed to use when it started
-- `policy-decisions`
+- `decisions`
   what the run actually executed, plus later human review decisions that can be
   tied back to the run
 
 If you only want one quick learning exercise after your first run, do this:
 
 1. start any run
-2. copy the returned `run.id`
+2. copy the returned `task_id`
 3. fetch `capabilities`
-4. fetch `policy-decisions`
+4. fetch `decisions`
 
 Example:
 
 ```bash
 export SPACE_ID="11111111-1111-1111-1111-111111111111"
-export RUN_ID="<run_id>"
+export TASK_ID="<task_id>"
 
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/runs/$RUN_ID/capabilities" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/$TASK_ID/capabilities" \
   -H "Authorization: Bearer $TOKEN"
 
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/runs/$RUN_ID/policy-decisions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/$TASK_ID/decisions" \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/services/artana_evidence_api/docs/transparency.md
+++ b/services/artana_evidence_api/docs/transparency.md
@@ -13,8 +13,8 @@ Use this page when you want to answer:
 
 Every run now exposes two dedicated transparency endpoints:
 
-- `GET /v1/spaces/{space_id}/runs/{run_id}/capabilities`
-- `GET /v1/spaces/{space_id}/runs/{run_id}/policy-decisions`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/capabilities`
+- `GET /v2/spaces/{space_id}/tasks/{task_id}/decisions`
 
 Every run also persists two matching artifacts:
 
@@ -33,22 +33,22 @@ Think about transparency in three layers:
    started.
 2. `events`
    This is the raw lifecycle stream for the run.
-3. `policy-decisions`
+3. `decisions`
    This is the cleaned-up ordered record of what the run actually tried to do,
    including later manual review actions when they can be tied back to the run.
 
 If you only remember one rule:
 
 - use `capabilities` to answer "what could this run do?"
-- use `policy-decisions` to answer "what did this run do?"
+- use `decisions` to answer "what did this run do?"
 
 ## When To Use Each Endpoint
 
 | Endpoint | Use it when you want to know | Typical reader |
 | --- | --- | --- |
-| `/runs/{run_id}/capabilities` | what tools were visible, blocked, or filtered | developers, operators, UI clients |
-| `/runs/{run_id}/policy-decisions` | what the run executed and how those decisions ended | developers, reviewers, auditors |
-| `/runs/{run_id}/events` | the raw lifecycle trace | debugging and low-level inspection |
+| `/tasks/{task_id}/capabilities` | what tools were visible, blocked, or filtered | developers, operators, UI clients |
+| `/tasks/{task_id}/decisions` | what the run executed and how those decisions ended | developers, reviewers, auditors |
+| `/tasks/{task_id}/events` | the raw lifecycle trace | debugging and low-level inspection |
 
 ## `capabilities`: What The Run Could Use
 
@@ -81,9 +81,9 @@ Example:
 export HARNESS_URL="http://localhost:8091"
 export TOKEN="your-jwt-token"
 export SPACE_ID="11111111-1111-1111-1111-111111111111"
-export RUN_ID="44444444-4444-4444-4444-444444444444"
+export TASK_ID="44444444-4444-4444-4444-444444444444"
 
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/runs/$RUN_ID/capabilities" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/$TASK_ID/capabilities" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -94,7 +94,7 @@ What to look for first:
 - `policy_profile`
 - `artifact_key`
 
-## `policy-decisions`: What The Run Actually Did
+## `decisions`: What The Run Actually Did
 
 This endpoint returns the ordered decision log for the run.
 
@@ -130,13 +130,13 @@ Important fields on each decision:
 Example:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/runs/$RUN_ID/policy-decisions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/$TASK_ID/decisions" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
 ## What `decision_source` Means
 
-`policy-decisions` can contain more than one kind of decision.
+`decisions` can contain more than one kind of decision.
 
 Current values:
 
@@ -154,11 +154,11 @@ This means one run can show both:
 
 ## Common Questions
 
-### Why do I sometimes see tools in `capabilities` but not in `policy-decisions`?
+### Why do I sometimes see tools in `capabilities` but not in `decisions`?
 
 Because the run was allowed to use those tools, but it did not need them.
 
-### Why can `policy-decisions` be empty?
+### Why can `decisions` be empty?
 
 This usually means one of these things:
 
@@ -176,14 +176,14 @@ promoted or rejected, that decision can still be attached to the original run.
 
 `events` is the raw lifecycle log.
 
-`policy-decisions` is the structured answer to:
+`decisions` is the structured answer to:
 
 - what was attempted
 - what decision was taken
 - what was the outcome
 
 Use `events` for low-level debugging.
-Use `policy-decisions` for product and audit views.
+Use `decisions` for product and audit views.
 
 ## Typical Workflow
 
@@ -191,20 +191,20 @@ This is the recommended order when you are inspecting a run:
 
 1. Start or fetch a run.
 2. Read `capabilities` once to see the allowed tool surface.
-3. Read `policy-decisions` to see what the run actually executed.
+3. Read `decisions` to see what the run actually executed.
 4. Read `events` only if you need the lower-level trace.
-5. Read `artifacts` if you want the actual content outputs.
+5. Read `outputs` if you want the actual content outputs.
 
 In practice, most users should use this sequence:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/runs/$RUN_ID/capabilities" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/$TASK_ID/capabilities" \
   -H "Authorization: Bearer $TOKEN"
 
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/runs/$RUN_ID/policy-decisions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/$TASK_ID/decisions" \
   -H "Authorization: Bearer $TOKEN"
 
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/runs/$RUN_ID/artifacts" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/$TASK_ID/outputs" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -215,11 +215,11 @@ A good first example is a verified chat run.
 Typical inspection flow:
 
 1. send a chat message
-2. record the returned `run.id`
+2. record the returned `task_id`
 3. open `capabilities`
-4. open `policy-decisions`
+4. open `decisions`
 5. if the chat produced graph-write candidates, review one
-6. open `policy-decisions` again and confirm the manual review entry is there
+6. open `decisions` again and confirm the manual review entry is there
 
 That gives you a full trace from:
 
@@ -229,7 +229,7 @@ That gives you a full trace from:
 
 ## Example: Approval-Gated Curation Run
 
-For curation runs, `policy-decisions` is especially useful because it helps
+For curation runs, `decisions` is especially useful because it helps
 explain pauses and resumes.
 
 Typical pattern:
@@ -240,7 +240,7 @@ Typical pattern:
 - the run resumes
 - final actions are recorded
 
-This is much easier to follow through `policy-decisions` than by reading raw
+This is much easier to follow through `decisions` than by reading raw
 events alone.
 
 ## Artifact Keys To Remember
@@ -254,10 +254,10 @@ You can fetch them directly through the artifact routes if you already know the
 key:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/runs/$RUN_ID/artifacts/run_capabilities" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/$TASK_ID/outputs/run_capabilities" \
   -H "Authorization: Bearer $TOKEN"
 
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/runs/$RUN_ID/artifacts/policy_decisions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/$TASK_ID/outputs/policy_decisions" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -267,12 +267,12 @@ clearest public API.
 ## Best Practices
 
 - Always inspect `capabilities` before assuming a missing tool call is a bug.
-- Use `policy-decisions` as the default audit view for runs.
+- Use `decisions` as the default audit view for runs.
 - Use `events` only when you need lower-level lifecycle detail.
-- For UI pages, show `capabilities` as a snapshot and `policy-decisions` as a
+- For UI pages, show `capabilities` as a snapshot and `decisions` as a
   timeline.
 - For support/debugging, compare the four views in this order:
-  `progress`, `capabilities`, `policy-decisions`, `events`.
+  `progress`, `capabilities`, `decisions`, `events`.
 
 ## Related Docs
 

--- a/services/artana_evidence_api/docs/use-cases.md
+++ b/services/artana_evidence_api/docs/use-cases.md
@@ -74,7 +74,7 @@ curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items?document_id=<document_id>
 Promote one staged queue item:
 
 ```bash
-curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items/<item_id>/actions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items/<item_id>/decision" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -87,7 +87,7 @@ curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items/<item_id>/actions" \
 Reject one instead:
 
 ```bash
-curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items/<item_id>/actions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items/<item_id>/decision" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -157,7 +157,7 @@ curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/chat-sessions/<session_id>/suggested-u
   }'
 ```
 
-Then review those staged items through `/review-items/<item_id>/actions`.
+Then review those staged items through `/review-items/<item_id>/decision`.
 
 Inline candidate review still exists, but generic proposal staging plus the
 review queue is the easier default to explain and operate.
@@ -258,12 +258,12 @@ curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/workflows/topic-setup/tasks" \
 
 What to look for in the response:
 
-- `run.id`
+- `task_id`
 - `graph_snapshot.id`
 - `research_brief`
 - `proposal_count`
 
-List the artifacts for the run:
+List the outputs for the task:
 
 ```bash
 curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/outputs" \
@@ -350,7 +350,7 @@ What to inspect:
 List the staged mechanism proposals:
 
 ```bash
-curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/proposals?proposal_type=mechanism_candidate" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/proposed-updates?proposal_type=mechanism_candidate" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -385,7 +385,7 @@ curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/approvals" \
 Approve one action:
 
 ```bash
-curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/approvals/<approval_key>" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/approvals/<approval_key>/decision" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -406,7 +406,7 @@ curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/resume" \
   }'
 ```
 
-Inspect final curation artifacts:
+Inspect final curation outputs:
 
 ```bash
 curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/outputs/curation_summary" \
@@ -482,13 +482,13 @@ curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/resume" \
 
 5. fetch supervisor detail again and confirm it is completed
 
-## Use Case 9: Build A Dashboard For Supervisor Runs
+## Use Case 9: Build A Dashboard For Supervisor Tasks
 
 Goal:
 
 - show recent supervisor activity
 - highlight paused approval queues
-- deep-link into the most important runs
+- deep-link into the most important tasks
 
 Fetch the dashboard summary:
 
@@ -499,7 +499,7 @@ curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/workflows/full-research/dashboard" \
 
 Useful query examples:
 
-Only paused runs:
+Only paused tasks:
 
 ```bash
 curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/workflows/full-research/dashboard?status=paused" \
@@ -581,7 +581,7 @@ curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/events" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-If you need the actual output content, open the artifacts:
+If you need the actual output content, open the outputs:
 
 ```bash
 curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/outputs" \
@@ -591,6 +591,6 @@ curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/tasks/<task_id>/outputs" \
 This is the recommended inspection order for operators and UI clients:
 
 1. `capabilities`
-2. `policy-decisions`
+2. `decisions`
 3. `events`
-4. `artifacts`
+4. `outputs`

--- a/services/artana_evidence_api/docs/user-guide.md
+++ b/services/artana_evidence_api/docs/user-guide.md
@@ -38,7 +38,7 @@ It is a governed workflow system. That means it tries to keep track of:
 - what evidence supported it
 - what the AI suggested
 - what a human approved or rejected
-- what happened during a run
+- what happened during a task
 
 ## Data Sources: Not Just PubMed
 
@@ -76,7 +76,7 @@ These are sources the larger orchestration flows can use when enabled:
 - `mondo`
 
 In practice, these usually show up through larger workflows like
-`research-init`, bootstrap-style discovery, or guarded orchestration rather
+`research-plan`, bootstrap-style discovery, or guarded orchestration rather
 than through the very first beginner examples.
 
 ### Why PubMed Shows Up More In The Docs
@@ -99,9 +99,9 @@ full service accurately enough.
 Think of the service like this:
 
 1. you give it research material
-2. it creates a work session called a `run`
-3. the AI reads, searches, or reasons inside that run
-4. the service saves artifacts, progress, and decisions
+2. it creates a work session called a `task`
+3. the AI reads, searches, or reasons inside that task
+4. the service saves outputs, progress, and decisions
 5. you review anything important before it becomes official
 
 For beginners, the easiest version is even simpler:
@@ -131,7 +131,7 @@ that graph.
 If you want the simplest boundary:
 
 - `artana_evidence_db` owns official graph state and graph governance
-- `artana_evidence_api` owns AI-assisted workflows, runs, chat, extraction,
+- `artana_evidence_api` owns AI-assisted workflows, tasks, chat, extraction,
   orchestration, review, and transparency
 
 ## Who This Guide Is For
@@ -224,7 +224,7 @@ default it sets:
 If you prefer the raw API instead of the helper script, the first-key route is:
 
 ```bash
-curl -s "$HARNESS_URL/v1/auth/bootstrap" \
+curl -s "$HARNESS_URL/v2/auth/bootstrap" \
   -X POST \
   -H "X-Artana-Bootstrap-Key: $ARTANA_EVIDENCE_API_BOOTSTRAP_KEY" \
   -H "Content-Type: application/json" \
@@ -261,7 +261,7 @@ venv/bin/python scripts/issue_artana_evidence_api_key.py \
 You can also do that directly through HTTP:
 
 ```bash
-curl -s "$HARNESS_URL/v1/auth/api-keys" \
+curl -s "$HARNESS_URL/v2/auth/api-keys" \
   -X POST \
   -H "X-Artana-Key: $ARTANA_API_KEY" \
   -H "Content-Type: application/json" \
@@ -276,7 +276,7 @@ curl -s "$HARNESS_URL/v1/auth/api-keys" \
 The easiest sanity check is:
 
 ```bash
-curl -s "$HARNESS_URL/v1/auth/me" \
+curl -s "$HARNESS_URL/v2/auth/me" \
   -H "X-Artana-Key: $ARTANA_API_KEY"
 ```
 
@@ -287,7 +287,7 @@ If that works, your key is valid and the service can resolve your identity.
 If you do not already know your `SPACE_ID`, the easiest beginner setup call is:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/default" \
+curl -s "$HARNESS_URL/v2/spaces/default" \
   -X PUT \
   -H "X-Artana-Key: $ARTANA_API_KEY"
 ```
@@ -325,9 +325,9 @@ Examples:
 - a PDF
 - a paper you want tracked
 
-### Run
+### Task
 
-A `run` is one AI job or workflow execution.
+A `task` is one AI job or workflow execution.
 
 Examples:
 
@@ -344,25 +344,25 @@ It is the system saying:
 
 "I think this might be worth adding, but I want review before it becomes official."
 
-### Review Queue Item
+### Review Item
 
-A `review queue item` is the unified thing you actually review in the product.
+A `review item` is the unified thing you actually review in the product.
 
 It can represent:
 
 - a proposal
 - a review-only follow-up item
-- a paused approval from a run
+- a paused approval from a task
 
-That is why the review queue is now the easiest default review surface.
+That is why review items are now the easiest default review surface.
 
 ### Approval
 
 An `approval` is a human yes/no decision on something the system paused for.
 
-### Artifact
+### Output
 
-An `artifact` is saved output from a run.
+An `output` is saved content from a task.
 
 Examples:
 
@@ -373,7 +373,7 @@ Examples:
 
 ### Progress And Events
 
-These are the "what is happening right now?" views for a run.
+These are the "what is happening right now?" views for a task.
 
 - `progress` is the latest status snapshot
 - `events` are the step-by-step history
@@ -392,7 +392,7 @@ Start with one note or one PDF.
 Text note:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/text" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/documents/text" \
   -H "X-Artana-Key: $ARTANA_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -405,7 +405,7 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/text" \
 PDF:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/pdf" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/documents/pdf" \
   -H "X-Artana-Key: $ARTANA_API_KEY" \
   -F "file=@./paper.pdf" \
   -F "title=MED13 paper"
@@ -425,7 +425,7 @@ What success looks like:
 Now ask the system to read the document and stage reviewable findings.
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/documents/<document_id>/extract" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/documents/<document_id>/extraction" \
   -H "X-Artana-Key: $ARTANA_API_KEY" \
   -X POST
 ```
@@ -458,7 +458,7 @@ What success looks like:
 - you may also get a `review_item_count`
 - genomics documents can also mark the document as `variant_aware_extraction`
   in metadata
-- if you retry after a partial earlier run, the service now reuses matching
+- if you retry after a partial earlier extraction attempt, the service now reuses matching
   already-staged proposals and review items instead of returning a misleading
   empty extraction result
 
@@ -467,7 +467,7 @@ What success looks like:
 List the unified queue:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/review-queue?document_id=<document_id>" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items?document_id=<document_id>" \
   -H "X-Artana-Key: $ARTANA_API_KEY"
 ```
 
@@ -475,7 +475,7 @@ This queue can include:
 
 - proposals you can `promote` or `reject`
 - review-only items you can `convert_to_proposal`, `mark_resolved`, or `dismiss`
-- approvals from paused runs that you can `approve` or `reject`
+- approvals from paused tasks that you can `approve` or `reject`
 
 One important nuance:
 
@@ -489,14 +489,14 @@ If you want the lower-level proposal records directly, you can still list them:
 List proposals:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/proposals?document_id=<document_id>" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/proposed-updates?document_id=<document_id>" \
   -H "X-Artana-Key: $ARTANA_API_KEY"
 ```
 
 Promote one:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/review-queue/<item_id>/actions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items/<item_id>/decision" \
   -H "X-Artana-Key: $ARTANA_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -509,7 +509,7 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/review-queue/<item_id>/actions" \
 Reject one:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/review-queue/<item_id>/actions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/review-items/<item_id>/decision" \
   -H "X-Artana-Key: $ARTANA_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -537,7 +537,7 @@ Compatibility note:
 Create a chat session:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/chat-sessions" \
   -H "X-Artana-Key: $ARTANA_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -548,7 +548,7 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions" \
 Ask a question:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/chat-sessions/<session_id>/messages" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/chat-sessions/<session_id>/messages" \
   -H "X-Artana-Key: $ARTANA_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -575,14 +575,14 @@ If you are unsure which feature to use, use this table.
 
 | Your goal | Start with | Why |
 | --- | --- | --- |
-| Review one note or paper | Documents + extraction + review queue | Safest and easiest workflow |
+| Review one note or paper | Documents + extraction + review items | Safest and easiest workflow |
 | Ask questions about a known document set | Chat sessions | Keeps answers tied to documents and graph context |
 | Find literature first | PubMed search | Good before extraction or bootstrap |
 | Build an initial project map | Research bootstrap | Bigger starting workflow for a new space |
 | Keep a topic refreshed over time | Continuous learning | Re-runs research on a schedule |
 | Compare many generated ideas | Mechanism discovery | Produces ranked hypothesis-style outputs |
 | Force approval checkpoints into claim writing | Claim curation | Most governed path for graph-impacting claims |
-| Run a bigger orchestrated sequence | Supervisor | Composes several workflows into one parent run |
+| Run a bigger orchestrated sequence | Supervisor | Composes several workflows into one parent task |
 
 ## How A Researcher Can Actually Use The Different Sources
 
@@ -647,7 +647,7 @@ Typical path:
 1. run a PubMed search
 2. inspect the returned job
 3. optionally ingest or follow up with document-centered review
-4. use the results to seed chat, bootstrap, or research-init
+4. use the results to seed chat, bootstrap, or research-plan work
 
 #### MARRVEL
 
@@ -671,7 +671,7 @@ evidence.
 
 The direct ingest route still exists for advanced or system-owned usage:
 
-- `POST /v1/spaces/{space_id}/marrvel/ingest`
+- `POST /v2/spaces/{space_id}/sources/marrvel/ingestion`
 
 ### 3. Ask For A Bigger Multi-Source Research Sweep
 
@@ -679,10 +679,10 @@ Use this when your question is larger than one document or one search.
 
 Best entry point:
 
-- `research-init`
+- `research-plan`
 
 This is where the service can combine multiple enabled source families in one
-run.
+task.
 
 The public request shape supports a `sources` map, for example:
 
@@ -716,7 +716,7 @@ Good rule of thumb:
 - add `mgi` or `zfin` when model-organism evidence matters
 - add `alphafold` when structure or protein-shape context matters
 
-### 4. Use Bootstrap For A First Map, Then Graduate To Research-Init
+### 4. Use Bootstrap For A First Map, Then Graduate To Research-Plan
 
 Bootstrap is still useful, but it is a narrower mental model.
 
@@ -730,7 +730,7 @@ If what you want is:
 
 - "use several sources intentionally and let me choose them"
 
-`research-init` is the better fit.
+`research-plan` is the better fit.
 
 ### 5. Use Chat After You Have Evidence In Place
 
@@ -738,7 +738,7 @@ Chat works best after at least one of these is true:
 
 - you uploaded documents
 - you ran literature discovery
-- you completed a broader multi-source run
+- you completed a broader multi-source task
 
 That way the chat is grounded in something real instead of being asked to think
 from scratch.
@@ -761,11 +761,11 @@ If you are a researcher and do not want to overthink this, use:
 
 - `marrvel`
 - optionally `clinvar`
-- then chat or research-init
+- then chat or research-plan
 
 ### Broad Mechanism Or Evidence-Mapping Question
 
-- `research-init`
+- `research-plan`
 - enable `pubmed`, `marrvel`, and `clinvar`
 - add `drugbank`, `clinical_trials`, `mgi`, `zfin`, or `alphafold` only when
   the question needs them
@@ -787,11 +787,11 @@ Good learning order:
 
 This order works because each step builds on the last one.
 
-## The Next Level: Understanding Runs
+## The Next Level: Understanding Tasks
 
-Once you move beyond one document, you need to understand `runs`.
+Once you move beyond one document, you need to understand `tasks`.
 
-A run is the service's way of making AI work inspectable.
+A task is the service's way of making AI work inspectable.
 
 That matters because bigger workflows are not just one response body. They
 have:
@@ -799,14 +799,14 @@ have:
 - status
 - progress
 - events
-- artifacts
+- outputs
 - pause/resume behavior
 
 ### Why Runs Matter
 
-Without runs, a long AI workflow would feel like a black box.
+Without tasks, a long AI workflow would feel like a black box.
 
-With runs, you can answer:
+With tasks, you can answer:
 
 - is it still working?
 - what step is it on?
@@ -817,24 +817,24 @@ With runs, you can answer:
 
 | What you want to know | Endpoint |
 | --- | --- |
-| Is the run alive? | `GET /v1/spaces/{space_id}/runs/{run_id}` |
-| What is it doing now? | `GET /v1/spaces/{space_id}/runs/{run_id}/progress` |
-| What happened step by step? | `GET /v1/spaces/{space_id}/runs/{run_id}/events` |
-| What files or outputs did it save? | `GET /v1/spaces/{space_id}/runs/{run_id}/artifacts` |
-| What tools was it allowed to use? | `GET /v1/spaces/{space_id}/runs/{run_id}/capabilities` |
-| What did it actually decide to do? | `GET /v1/spaces/{space_id}/runs/{run_id}/policy-decisions` |
-| It paused, now what? | `POST /v1/spaces/{space_id}/runs/{run_id}/resume` |
+| Is the task alive? | `GET /v2/spaces/{space_id}/tasks/{task_id}` |
+| What is it doing now? | `GET /v2/spaces/{space_id}/tasks/{task_id}/progress` |
+| What happened step by step? | `GET /v2/spaces/{space_id}/tasks/{task_id}/events` |
+| What files or outputs did it save? | `GET /v2/spaces/{space_id}/tasks/{task_id}/outputs` |
+| What tools was it allowed to use? | `GET /v2/spaces/{space_id}/tasks/{task_id}/capabilities` |
+| What did it actually decide to do? | `GET /v2/spaces/{space_id}/tasks/{task_id}/decisions` |
+| It paused, now what? | `POST /v2/spaces/{space_id}/tasks/{task_id}/resume` |
 
 ### A Good Beginner Habit
 
-When something feels confusing, inspect the run in this order:
+When something feels confusing, inspect the task in this order:
 
-1. run
+1. task
 2. progress
 3. events
-4. artifacts
+4. outputs
 5. capabilities
-6. policy-decisions
+6. decisions
 
 That usually tells the story.
 
@@ -875,7 +875,7 @@ This is good for:
 Start a search:
 
 ```bash
-curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/pubmed/searches" \
+curl -s "$HARNESS_URL/v2/spaces/$SPACE_ID/sources/pubmed/searches" \
   -H "X-Artana-Key: $ARTANA_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -887,7 +887,7 @@ curl -s "$HARNESS_URL/v1/spaces/$SPACE_ID/pubmed/searches" \
   }'
 ```
 
-This is often the right move before a bootstrap run or before asking a broad
+This is often the right move before a bootstrap task or before asking a broad
 chat question.
 
 ## MARRVEL Search: Best For Gene-Centered Discovery
@@ -902,7 +902,7 @@ Typical use:
 
 1. search by gene symbol or variant
 2. inspect the returned panels
-3. use the result to guide later extraction, review, or multi-source runs
+3. use the result to guide later extraction, review, or multi-source tasks
 
 This is especially useful when a researcher starts with a gene and wants a fast
 structured view before doing broader workflow orchestration.
@@ -999,12 +999,12 @@ happened.
 Two endpoints matter a lot:
 
 - `GET /capabilities`
-- `GET /policy-decisions`
+- `GET /decisions`
 
 In plain English:
 
-- `capabilities` says what the run could use
-- `policy-decisions` says what the run actually did
+- `capabilities` says what the task could use
+- `decisions` says what the task actually did
 
 This matters when someone asks:
 
@@ -1063,7 +1063,7 @@ Usually it is better to inspect:
 
 - progress
 - events
-- artifacts
+- outputs
 
 first.
 
@@ -1081,17 +1081,17 @@ Those are related, but they are not the same thing.
 | If you want to... | Use... |
 | --- | --- |
 | check the service is alive | `/health` |
-| see what workflows exist | `/v1/harnesses` |
+| see what workflows exist | `/v2/workflow-templates` |
 | upload evidence | `/documents/text` or `/documents/pdf` |
-| extract findings from a document | `/documents/{document_id}/extract` |
-| review staged findings | `/review-queue` |
+| extract findings from a document | `/documents/{document_id}/extraction` |
+| review staged findings | `/review-items` |
 | ask grounded questions | `/chat-sessions` and `/messages` |
-| stage graph writes from verified chat | `/chat-sessions/{session_id}/proposals/graph-write` |
-| inspect long-running work | `/runs`, `/progress`, `/events`, `/artifacts` |
-| inspect AI policy and tool visibility | `/capabilities` and `/policy-decisions` |
-| search literature | `/pubmed/searches` |
-| start a larger research job | workflow-specific run endpoints |
-| resume a paused governed workflow | `/runs/{run_id}/resume` |
+| stage graph writes from verified chat | `/chat-sessions/{session_id}/suggested-updates` |
+| inspect long-running work | `/tasks`, `/progress`, `/events`, `/outputs` |
+| inspect AI policy and tool visibility | `/capabilities` and `/decisions` |
+| search literature | `/sources/pubmed/searches` |
+| start a larger research job | workflow-specific task endpoints |
+| resume a paused governed workflow | `/tasks/{task_id}/resume` |
 
 ## Recommended Learning Path For Teams
 
@@ -1102,12 +1102,12 @@ If you are onboarding a team, this order works well:
 - health
 - one text document
 - extraction
-- review queue
+- review items
 
 ### Day 2
 
 - chat with document context
-- run inspection
+- task inspection
 - transparency inspection
 
 ### Day 3
@@ -1133,7 +1133,7 @@ A good practical rule is:
 - let AI read, summarize, search, and suggest
 - let governed review decide what becomes official
 
-That is why proposals, approvals, runs, and transparency exist.
+That is why proposals, approvals, tasks, and transparency exist.
 
 ## When You Are Ready For More Detail
 

--- a/services/artana_evidence_db/docs/README.md
+++ b/services/artana_evidence_db/docs/README.md
@@ -4,10 +4,10 @@ This folder explains the standalone `artana_evidence_db` service in plain langua
 
 If you are new to the service, read these files in order:
 
-1. [Getting Started](/Users/alvaro1/Documents/med13/foundation/resource_library/services/artana_evidence_db/docs/getting-started.md)
-2. [Core Concepts](/Users/alvaro1/Documents/med13/foundation/resource_library/services/artana_evidence_db/docs/concepts.md)
-3. [Data Model](/Users/alvaro1/Documents/med13/foundation/resource_library/services/artana_evidence_db/docs/data-model.md)
-4. [API Reference](/Users/alvaro1/Documents/med13/foundation/resource_library/services/artana_evidence_db/docs/api-reference.md)
+1. [Getting Started](./getting-started.md)
+2. [Core Concepts](./concepts.md)
+3. [Data Model](./data-model.md)
+4. [API Reference](./api-reference.md)
 
 Planning:
 
@@ -15,10 +15,10 @@ Planning:
 
 Useful companion files:
 
-- Service overview: [README.md](/Users/alvaro1/Documents/med13/foundation/resource_library/services/artana_evidence_db/README.md)
-- Container definition: [Dockerfile](/Users/alvaro1/Documents/med13/foundation/resource_library/services/artana_evidence_db/Dockerfile)
+- Service overview: [README.md](../README.md)
+- Container definition: [Dockerfile](../Dockerfile)
 - Interactive API docs when the service is running: `/docs`
-- Raw OpenAPI spec: [openapi.json](/Users/alvaro1/Documents/med13/foundation/resource_library/services/artana_evidence_db/openapi.json)
+- Raw OpenAPI spec: [openapi.json](../openapi.json)
 
 What this service is:
 

--- a/services/artana_evidence_db/docs/api-reference.md
+++ b/services/artana_evidence_db/docs/api-reference.md
@@ -315,7 +315,7 @@ If you are learning the service, start here:
 For exact request and response schemas, use one of these:
 
 - interactive docs at `/docs`
-- [openapi.json](/Users/alvaro1/Documents/med13/foundation/resource_library/services/artana_evidence_db/openapi.json)
+- [openapi.json](../openapi.json)
 
 For a minimal external-project flow, see
 `services/artana_evidence_db/examples/http_only_client_flow.py`. It uses only

--- a/services/artana_evidence_db/docs/getting-started.md
+++ b/services/artana_evidence_db/docs/getting-started.md
@@ -22,7 +22,7 @@ In one sentence:
 ## What The Container Contains
 
 The runtime container is defined in
-[Dockerfile](/Users/alvaro1/Documents/med13/foundation/resource_library/services/artana_evidence_db/Dockerfile).
+[Dockerfile](../Dockerfile).
 
 At runtime it contains:
 

--- a/tests/unit/test_control_files.py
+++ b/tests/unit/test_control_files.py
@@ -34,6 +34,11 @@ STALE_ROOT_PATH_REFERENCES = (
     "src/infrastructure",
     "src/type_definitions",
 )
+DOC_ROOTS = (
+    "docs",
+    "services/artana_evidence_api/docs",
+    "services/artana_evidence_db/docs",
+)
 
 
 def _read_text(relative_path: str) -> str:
@@ -172,6 +177,24 @@ def test_readme_presents_independent_backend_project() -> None:
         / "artana_evidence_db"
         / "artana-evidence-db.generated.ts"
     ).exists()
+
+
+def test_docs_do_not_link_removed_project_status() -> None:
+    """Regression: docs indexes must not point at deleted status files."""
+
+    assert not (REPO_ROOT / "docs" / "project_status.md").exists()
+    for relative_path in ("README.md", "docs/README.md"):
+        assert "project_status.md" not in _read_text(relative_path)
+
+
+def test_docs_do_not_use_machine_absolute_paths() -> None:
+    """Regression: reusable docs must not link to one developer's checkout."""
+
+    for doc_root in DOC_ROOTS:
+        for path in (REPO_ROOT / doc_root).rglob("*.md"):
+            text = path.read_text(encoding="utf-8")
+            assert "/Users/alvaro" not in text, path.relative_to(REPO_ROOT)
+            assert "/Users/alvaro1" not in text, path.relative_to(REPO_ROOT)
 
 
 def test_readme_visualizes_two_service_system_shape() -> None:

--- a/tests/unit/test_v2_cutover_docs_and_scripts.py
+++ b/tests/unit/test_v2_cutover_docs_and_scripts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -66,6 +67,30 @@ def test_high_traffic_docs_are_v2_first() -> None:
             "/v2/spaces/$SPACE_ID/documents/text",
             "/v2/spaces/$SPACE_ID/workflows/topic-setup/tasks",
             "/v2/spaces/$SPACE_ID/tasks/<task_id>/outputs",
+        ),
+        "services/artana_evidence_api/docs/user-guide.md": (
+            "/v2/spaces/$SPACE_ID/proposed-updates?document_id=<document_id>",
+            "/v2/spaces/{space_id}/tasks/{task_id}/outputs",
+        ),
+        "docs/full_AI_orchestrator.md": (
+            "/v2/spaces/{space_id}/workflows/full-research/tasks",
+            "/v2/spaces/{space_id}/tasks/{task_id}/decisions",
+        ),
+        "docs/research_init_architecture.md": (
+            "/v2/spaces/{space_id}/research-plan",
+            "/v2/spaces/{space_id}/review-items",
+            "services/artana_evidence_api/source_plugins/",
+        ),
+        "docs/architecture/local-identity-boundary.md": (
+            "/v2/auth/bootstrap",
+            "/v2/auth/api-keys",
+        ),
+        "docs/remaining_work_priorities.md": (
+            "/v2/auth/bootstrap",
+            "review flow through review items",
+        ),
+        "docs/artana-kernel/docs/deep_traceability.md": (
+            "/v2/spaces/{space_id}/tasks/{task_id}/working-state",
         ),
         "docs/user-guide/02-core-concepts.md": ("/v2/spaces/{space_id}/tasks",),
         "docs/user-guide/03-workflow-overview.md": (
@@ -132,8 +157,10 @@ def test_user_guide_matches_key_v2_public_endpoints() -> None:
     }
     forbidden_fragments = (
         "/v2/spaces/{space_id}/proposals",
+        "/v2/spaces/$SPACE_ID/proposals",
         "/v2/spaces/$SPACE_ID/review-items/<item_id>/actions",
         "/v2/spaces/{space_id}/review-items/{item_id}/actions",
+        '/v2/spaces/$SPACE_ID/tasks/<task_id>/approvals/<approval_key>"',
         "/v2/spaces/$SPACE_ID/evidence-map/document",
         "/v2/spaces/{space_id}/tasks/{task_id}/approvals/{approval_key}`",
         "sources/sources",
@@ -147,3 +174,40 @@ def test_user_guide_matches_key_v2_public_endpoints() -> None:
             assert fragment in contents, (relative_path, fragment)
         for fragment in forbidden_fragments:
             assert fragment not in contents, (relative_path, fragment)
+
+
+def test_evidence_run_examples_include_live_network_opt_in() -> None:
+    doc = _read("docs/user-guide/07-multi-source-and-automation.md")
+
+    assert doc.count('"live_network_allowed": true') >= 5
+    assert "Any request that creates live source searches must set" in doc
+
+
+def test_endpoint_index_names_public_grounding_sources() -> None:
+    doc = _read("docs/user-guide/09-endpoint-index.md")
+
+    assert "MONDO and HGNC are background" in doc
+    assert "/v2/spaces/{space_id}/sources/pubmed/searches" in doc
+    assert "/v2/spaces/{space_id}/sources/marrvel/searches" in doc
+
+
+def test_rewritten_public_routes_exist_in_openapi() -> None:
+    document = json.loads(_read("services/artana_evidence_api/openapi.json"))
+    paths = document["paths"]
+    required_routes = {
+        "/v2/auth/bootstrap": ("post",),
+        "/v2/auth/api-keys": ("get", "post"),
+        "/v2/spaces/{space_id}/proposed-updates": ("get",),
+        "/v2/spaces/{space_id}/review-items/{item_id}/decision": ("post",),
+        "/v2/spaces/{space_id}/sources/marrvel/ingestion": ("post",),
+        "/v2/spaces/{space_id}/tasks/{task_id}/decisions": ("get",),
+        "/v2/spaces/{space_id}/tasks/{task_id}/outputs": ("get",),
+        "/v2/spaces/{space_id}/tasks/{task_id}/working-state": ("get",),
+        "/v2/spaces/{space_id}/workflows/full-research/tasks": ("get", "post"),
+        "/v2/spaces/{space_id}/workflows/topic-setup/tasks": ("post",),
+    }
+
+    for path, methods in required_routes.items():
+        assert path in paths, path
+        for method in methods:
+            assert method in paths[path], (path, method)


### PR DESCRIPTION
## Summary
- Refresh repo-level and service docs to match the latest merged backend routes and source-plugin layout
- Update user-guide examples for v2 endpoints, direct source searches, evidence runs, and task transparency
- Add regression tests to catch stale links, machine-local paths, and mismatched v2 route references

## Testing
- `pytest tests/unit/test_control_files.py tests/unit/test_v2_cutover_docs_and_scripts.py -q`
- `pytest services/artana_evidence_api/tests/unit/test_evidence_selection_router.py::test_v2_evidence_run_rejects_goal_only_model_without_live_network_opt_in services/artana_evidence_api/tests/unit/test_evidence_selection_router.py::test_v2_evidence_run_requires_live_network_opt_in_for_live_searches -q`
- `ruff check tests/unit/test_control_files.py tests/unit/test_v2_cutover_docs_and_scripts.py`
- `git diff --check`