### PR TITLE
[codex] Harden evidence API auth role parsing

### DIFF
--- a/services/artana_evidence_api/auth.py
+++ b/services/artana_evidence_api/auth.py
@@ -1,7 +1,13 @@
-"""Authentication helpers for the standalone harness service."""
+"""Authentication helpers for the standalone harness service.
+
+Platform roles carried by tokens and API keys are intentionally separate from
+research-space membership roles. For example, ``owner`` is a space role checked
+by the space ACL layer, not a valid platform role for ``HarnessUser``.
+"""
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Mapping
 from enum import Enum
@@ -19,12 +25,15 @@ from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBea
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 from sqlalchemy.orm import Session
 
+logger = logging.getLogger(__name__)
+
 _AUTH_JWT_SECRET_ENV = "AUTH_JWT_SECRET"
 _AUTH_ALLOW_TEST_HEADERS_ENV = "AUTH_ALLOW_TEST_AUTH_HEADERS"
 _PRODUCTION_LIKE_ENVS = frozenset({"production", "staging"})
 _FALLBACK_DEV_JWT_SECRET = "artana-platform-dev-jwt-secret-change-in-production-2026-01"
 _TOKEN_ISSUER = "artana-platform"
 _TOKEN_ALGORITHM = "HS256"
+_UNKNOWN_ROLE_LOG_VALUE_MAX_LENGTH = 64
 _WRITE_ROLES = frozenset(
     {
         "admin",
@@ -46,7 +55,11 @@ class HarnessUserStatus(str, Enum):
 
 
 class HarnessUserRole(str, Enum):
-    """Platform role values used by harness authorization checks."""
+    """Platform role values used by harness authorization checks.
+
+    Space ownership is represented by research-space membership records, not by
+    this platform role enum.
+    """
 
     ADMIN = "admin"
     CURATOR = "curator"
@@ -101,13 +114,38 @@ def _resolve_jwt_secret() -> str:
     return _FALLBACK_DEV_JWT_SECRET
 
 
-def _parse_role(role_value: object) -> HarnessUserRole:
+def _unknown_role_log_value(role_value: object) -> str:
+    if not isinstance(role_value, str):
+        return type(role_value).__name__
+    normalized = role_value.strip().lower()
+    if len(normalized) <= _UNKNOWN_ROLE_LOG_VALUE_MAX_LENGTH:
+        return normalized
+    return f"{normalized[:_UNKNOWN_ROLE_LOG_VALUE_MAX_LENGTH]}..."
+
+
+def _log_unknown_role(role_value: object, *, context: str | None) -> None:
+    if role_value is None:
+        return
+    logger.warning(
+        "Unknown harness platform role %r from %s; falling back to viewer",
+        _unknown_role_log_value(role_value),
+        context or "unknown auth context",
+    )
+
+
+def _parse_role(
+    role_value: object,
+    *,
+    context: str | None = None,
+) -> HarnessUserRole:
     if isinstance(role_value, str):
         normalized = role_value.strip().lower()
         try:
             return HarnessUserRole(normalized)
         except ValueError:
+            _log_unknown_role(role_value, context=context)
             return HarnessUserRole.VIEWER
+    _log_unknown_role(role_value, context=context)
     return HarnessUserRole.VIEWER
 
 
@@ -186,7 +224,7 @@ def _identity_record_from_harness_user(user: HarnessUser) -> IdentityUserRecord:
 def _build_harness_user_from_identity(record: IdentityUserRecord) -> HarnessUser:
     return _build_harness_user(
         user_id=record.id,
-        role=_parse_role(record.role),
+        role=_parse_role(record.role, context=f"identity user {record.id}"),
         email=record.email,
         username=record.username,
         full_name=record.full_name,
@@ -201,12 +239,16 @@ def _build_user_from_test_headers(request: Request) -> HarnessUser | None:
     test_user_email = request.headers.get("X-TEST-USER-EMAIL")
     if not test_user_id or not test_user_email:
         return None
+    parsed_user_id = _parse_user_id(test_user_id)
     return _build_harness_user(
-        user_id=_parse_user_id(test_user_id),
+        user_id=parsed_user_id,
         email=test_user_email,
         username=test_user_email.split("@", maxsplit=1)[0],
         full_name=test_user_email,
-        role=_parse_role(request.headers.get("X-TEST-USER-ROLE")),
+        role=_parse_role(
+            request.headers.get("X-TEST-USER-ROLE"),
+            context=f"test headers subject {parsed_user_id}",
+        ),
     )
 
 
@@ -291,7 +333,10 @@ async def get_current_harness_user(
             session,
             user=_build_harness_user(
                 user_id=user_id,
-                role=_parse_role(payload.get("role")),
+                role=_parse_role(
+                    payload.get("role"),
+                    context=f"access token subject {user_id}",
+                ),
                 email=email if isinstance(email, str) else None,
                 username=username if isinstance(username, str) else None,
                 full_name=full_name if isinstance(full_name, str) else None,

--- a/services/artana_evidence_api/tests/unit/test_auth.py
+++ b/services/artana_evidence_api/tests/unit/test_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
@@ -12,6 +13,7 @@ from artana_evidence_api.auth import (
     HarnessUser,
     HarnessUserRole,
     HarnessUserStatus,
+    _parse_role,
     get_current_harness_user,
     require_harness_write_access,
 )
@@ -30,6 +32,73 @@ def _request_with_headers(headers: dict[str, str] | None = None) -> Request:
         for name, value in (headers or {}).items()
     ]
     return Request({"type": "http", "headers": raw_headers})
+
+
+def test_parse_role_preserves_platform_roles() -> None:
+    assert _parse_role("ADMIN") == HarnessUserRole.ADMIN
+    assert _parse_role("admin") == HarnessUserRole.ADMIN
+    assert _parse_role("curator") == HarnessUserRole.CURATOR
+    assert _parse_role("researcher") == HarnessUserRole.RESEARCHER
+    assert _parse_role("viewer") == HarnessUserRole.VIEWER
+    assert _parse_role("service") == HarnessUserRole.SERVICE
+
+
+def test_parse_role_treats_owner_as_invalid_platform_role(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="artana_evidence_api.auth"):
+        role = _parse_role(
+            "OWNER",
+            context="test subject 11111111-1111-1111-1111-111111111111",
+        )
+
+    assert role == HarnessUserRole.VIEWER
+    assert "Unknown harness platform role 'owner' from test subject" in caplog.text
+    assert "falling back to viewer" in caplog.text
+
+
+def test_parse_role_warns_on_non_string_role_claim(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="artana_evidence_api.auth"):
+        role = _parse_role(
+            ["admin"],
+            context="access token subject 11111111-1111-1111-1111-111111111111",
+        )
+
+    assert role == HarnessUserRole.VIEWER
+    assert "Unknown harness platform role 'list' from access token subject" in (
+        caplog.text
+    )
+
+
+def test_parse_role_defaults_missing_role_to_viewer_without_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="artana_evidence_api.auth"):
+        role = _parse_role(None)
+
+    assert role == HarnessUserRole.VIEWER
+    assert [
+        record
+        for record in caplog.records
+        if record.name == "artana_evidence_api.auth"
+    ] == []
+
+
+def test_parse_role_truncates_long_invalid_role_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    role_value = "x" * 80
+
+    with caplog.at_level(logging.WARNING, logger="artana_evidence_api.auth"):
+        role = _parse_role(role_value, context="test subject")
+
+    assert role == HarnessUserRole.VIEWER
+    assert "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx..." in (
+        caplog.text
+    )
+    assert role_value not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -84,6 +153,46 @@ async def test_get_current_harness_user_accepts_platform_access_token(
         str(user.email)
         == "11111111-1111-1111-1111-111111111111@graph-harness.example.com"
     )
+
+
+@pytest.mark.asyncio
+async def test_owner_platform_role_claim_falls_back_to_viewer_and_fails_write_access(
+    monkeypatch: pytest.MonkeyPatch,
+    db_session: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("AUTH_JWT_SECRET", _TEST_SECRET)
+    token = jwt.encode(
+        {
+            "sub": "11111111-1111-1111-1111-111111111111",
+            "role": "owner",
+            "type": "access",
+            "iss": "artana-platform",
+            "iat": datetime.now(UTC),
+            "exp": datetime.now(UTC) + timedelta(minutes=15),
+        },
+        _TEST_SECRET,
+        algorithm="HS256",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="artana_evidence_api.auth"):
+        user = await get_current_harness_user(
+            _request_with_headers(),
+            credentials=HTTPAuthorizationCredentials(
+                scheme="Bearer",
+                credentials=token,
+            ),
+            session=db_session,
+        )
+
+    assert user.role == HarnessUserRole.VIEWER
+    assert "Unknown harness platform role 'owner'" in caplog.text
+    assert "access token subject 11111111-1111-1111-1111-111111111111" in caplog.text
+    with pytest.raises(HTTPException) as exc_info:
+        require_harness_write_access(current_user=user)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Researcher, curator, or admin role required"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Clarify that Evidence API platform roles are separate from research-space membership roles such as `owner`.
- Keep invalid platform role values falling back to `viewer`, but add warning logs with safe auth context for invalid non-`None` role claims.
- Add focused auth regressions for valid roles, invalid `owner`, non-string roles, quiet missing roles, long-value truncation, and the JWT `role=owner` write-access rejection path.

## Why
Issue #25 was migrated as an owner write-access bug, but the live code shows `owner` is a space membership role, not a platform `HarnessUserRole`. This hardening makes that boundary explicit and gives operators better visibility if a token or identity record carries an invalid platform role.

## User impact
No authorization semantics change: invalid platform roles still fail closed to `viewer`, and space ownership continues to be handled by the space ACL layer. The change improves diagnostics and regression coverage.

## Validation
- `./venv/bin/python -m pytest services/artana_evidence_api/tests/unit/test_auth.py`
- `make artana-evidence-api-service-checks`
- `git diff --check`
- Claude second-opinion review: no actionable blockers remaining

The evidence API service gate passed with the usual live/external tests skipped because local services/env vars were not present.