### PR TITLE
Add PDF OCR diagnostics and harden similar-gene entity resolution

### DIFF
--- a/services/artana_evidence_api/app.py
+++ b/services/artana_evidence_api/app.py
@@ -70,8 +70,12 @@ from .routers.supervisor_runs import router as supervisor_runs_router
 from .routers.v2_public import router as v2_public_router
 from .runtime_skill_registry import validate_graph_harness_skill_configuration
 from .source_route_plugins import validate_direct_source_route_plugins
+from .types.common import JSONObject, json_value
 
 logger = logging.getLogger(__name__)
+_STRUCTURED_ERROR_FIELD_KEYS = frozenset(
+    {"reason_code", "ocr_required", "page_count", "pages_without_text"},
+)
 
 
 def _normalize_error_detail(detail: object) -> str:
@@ -86,6 +90,20 @@ def _normalize_error_detail(detail: object) -> str:
     if isinstance(detail, list):
         return "; ".join(str(item) for item in detail)
     return str(detail)
+
+
+def _structured_error_fields(detail: object) -> JSONObject:
+    """Expose machine-readable fields while keeping ``detail`` human-readable."""
+    if not isinstance(detail, dict):
+        return {}
+    message = detail.get("message")
+    if not isinstance(message, str) or message.strip() == "":
+        return {}
+    return {
+        key: json_value(value)
+        for key, value in detail.items()
+        if isinstance(key, str) and key in _STRUCTURED_ERROR_FIELD_KEYS
+    }
 
 
 def _validation_error_detail(error: RequestValidationError) -> str:
@@ -175,12 +193,14 @@ def create_app() -> FastAPI:  # noqa: PLR0915
         request_id = resolve_request_id(request)
         response_headers = dict(exc.headers or {})
         response_headers.setdefault(REQUEST_ID_HEADER, request_id)
+        content: JSONObject = {
+            "detail": _normalize_error_detail(exc.detail),
+            "request_id": request_id,
+        }
+        content.update(_structured_error_fields(exc.detail))
         return JSONResponse(
             status_code=exc.status_code,
-            content={
-                "detail": _normalize_error_detail(exc.detail),
-                "request_id": request_id,
-            },
+            content=content,
             headers=response_headers,
         )
 

--- a/services/artana_evidence_api/document_extraction.py
+++ b/services/artana_evidence_api/document_extraction.py
@@ -20,6 +20,7 @@ from artana_evidence_api.document_extraction_contracts import (
     DocumentTextExtraction,
     ExtractedRelationCandidate,
     LLMExtractionResultLike,
+    PdfTextExtractionOutcome,
     ProposalReviewResultLike,
 )
 from artana_evidence_api.document_extraction_diagnostics import (
@@ -226,11 +227,41 @@ def extract_pdf_text(payload: bytes) -> DocumentTextExtraction:
             "PDF upload support requires the optional 'pypdf' dependency.",
         ) from exc
     reader = PdfReader(io.BytesIO(payload))
-    page_texts = [page.extract_text() or "" for page in reader.pages]
+    page_count = len(reader.pages)
+    page_texts: list[str] = []
+    pages_without_text: list[int] = []
+    for page_number, page in enumerate(reader.pages, start=1):
+        page_text = page.extract_text() or ""
+        if page_text.strip() == "":
+            pages_without_text.append(page_number)
+        else:
+            page_texts.append(page_text)
+    text_content = "\n\n".join(page_texts)
     return DocumentTextExtraction(
-        text_content="\n\n".join(text for text in page_texts if text.strip() != ""),
-        page_count=len(reader.pages),
+        text_content=text_content,
+        page_count=page_count,
+        extraction_outcome=_pdf_text_extraction_outcome(
+            page_count=page_count,
+            text_content=text_content,
+            pages_without_text=tuple(pages_without_text),
+        ),
+        pages_without_text=tuple(pages_without_text),
     )
+
+
+def _pdf_text_extraction_outcome(
+    *,
+    page_count: int,
+    text_content: str,
+    pages_without_text: tuple[int, ...],
+) -> PdfTextExtractionOutcome:
+    if page_count == 0:
+        return "no_pages"
+    if text_content.strip() == "":
+        return "no_text_image_likely"
+    if pages_without_text:
+        return "partial_text_ocr_needed"
+    return "text"
 
 
 def normalize_text_document(text: str) -> str:

--- a/services/artana_evidence_api/document_extraction_contracts.py
+++ b/services/artana_evidence_api/document_extraction_contracts.py
@@ -16,6 +16,12 @@ GoalRelevanceScale = Literal[
     "unscoped",
 ]
 PriorityScale = Literal["prioritize", "review", "background", "ignore"]
+PdfTextExtractionOutcome = Literal[
+    "text",
+    "no_text_image_likely",
+    "partial_text_ocr_needed",
+    "no_pages",
+]
 
 FACTUAL_SUPPORT_SCORES: dict[FactualSupportScale, float] = {
     "strong": 0.92,
@@ -87,6 +93,8 @@ class DocumentTextExtraction:
 
     text_content: str
     page_count: int | None
+    extraction_outcome: PdfTextExtractionOutcome = "text"
+    pages_without_text: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -192,4 +200,5 @@ __all__ = [
     "PriorityScale",
     "ProposalReviewItemLike",
     "ProposalReviewResultLike",
+    "PdfTextExtractionOutcome",
 ]

--- a/services/artana_evidence_api/document_ingestion_support.py
+++ b/services/artana_evidence_api/document_ingestion_support.py
@@ -7,10 +7,13 @@ from uuid import UUID
 
 from artana_evidence_api.document_extraction import (
     extract_pdf_text,
-    normalize_text_document,
     sha256_hex,
 )
 from artana_evidence_api.graph_client import GraphServiceClientError
+from artana_evidence_api.runtime.pdf_text_diagnostics import (
+    PdfTextDiagnosticError,
+    require_extracted_pdf_text,
+)
 from artana_evidence_api.storage_types import StorageUseCase
 from artana_evidence_api.types.common import JSONObject
 from fastapi import HTTPException, status
@@ -26,16 +29,7 @@ if TYPE_CHECKING:
     from artana_evidence_api.run_registry import HarnessRunRecord, HarnessRunRegistry
 
 _PDF_SIGNATURE = b"%PDF-"
-
-
-def _require_extracted_pdf_text(text_content: str) -> str:
-    normalized_text = normalize_text_document(text_content)
-    if normalized_text == "":
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The uploaded PDF did not contain extractable text",
-        )
-    return normalized_text
+_DOCUMENT_RUN_ERROR_RESERVED_KEYS = frozenset({"error", "status"})
 
 
 def _require_updated_enriched_document(
@@ -119,18 +113,28 @@ def _fail_document_run(
     message: str,
     artifact_store: HarnessArtifactStore,
     run_registry: HarnessRunRegistry,
+    error_metadata: JSONObject | None = None,
 ) -> None:
+    safe_error_metadata = {
+        key: value
+        for key, value in ({} if error_metadata is None else error_metadata).items()
+        if key not in _DOCUMENT_RUN_ERROR_RESERVED_KEYS
+    }
+    error_content: JSONObject = {
+        "error": message,
+        **safe_error_metadata,
+    }
     artifact_store.patch_workspace(
         space_id=space_id,
         run_id=run.id,
-        patch={"status": "failed", "error": message},
+        patch={"status": "failed", **error_content},
     )
     artifact_store.put_artifact(
         space_id=space_id,
         run_id=run.id,
         artifact_key="document_error",
         media_type="application/json",
-        content={"error": message},
+        content=error_content,
     )
     run_registry.set_run_status(space_id=space_id, run_id=run.id, status="failed")
 
@@ -190,7 +194,7 @@ async def _enrich_pdf_document(  # noqa: PLR0913
     try:
         raw_payload = await binary_store.read_bytes(key=document.raw_storage_key)
         extraction = extract_pdf_text(raw_payload)
-        normalized_text = _require_extracted_pdf_text(extraction.text_content)
+        normalized_text = require_extracted_pdf_text(extraction)
         enriched_storage_key = _build_enriched_text_storage_key(
             document_id=document.id,
             text_content=normalized_text,
@@ -240,6 +244,29 @@ async def _enrich_pdf_document(  # noqa: PLR0913
                 "enriched_storage_key": enriched_storage_key,
             },
         )
+    except PdfTextDiagnosticError as exc:
+        document_store.update_document(
+            space_id=space_id,
+            document_id=document.id,
+            last_enrichment_run_id=enrichment_run.id,
+            page_count=exc.diagnostic.page_count,
+            enrichment_status="failed",
+            metadata_patch=exc.diagnostic.as_metadata(),
+        )
+        _fail_document_run(
+            space_id=space_id,
+            run=enrichment_run,
+            message=exc.diagnostic.message,
+            artifact_store=artifact_store,
+            run_registry=run_registry,
+            error_metadata={
+                "reason_code": exc.diagnostic.reason_code,
+                "ocr_required": exc.diagnostic.ocr_required,
+                "page_count": exc.diagnostic.page_count,
+                "pages_without_text": list(exc.diagnostic.pages_without_text),
+            },
+        )
+        raise
     except Exception as exc:
         document_store.update_document(
             space_id=space_id,

--- a/services/artana_evidence_api/graph_integration/preflight.py
+++ b/services/artana_evidence_api/graph_integration/preflight.py
@@ -322,39 +322,12 @@ class GraphAIPreflightService:
                     value=exact_resolved,
                 )
                 return exact_resolved
-        for entity in response.entities:
-            display_label = entity.display_label or ""
-            if normalized_label in display_label.casefold() or any(
-                normalized_label in alias.casefold() for alias in entity.aliases
-            ):
-                partial_resolved: JSONObject = {
-                    "id": str(entity.id),
-                    "display_label": display_label or str(entity.id),
-                }
-                self._resolution_cache.set_entity(
-                    space_id=space_id,
-                    label=label,
-                    value=partial_resolved,
-                )
-                return partial_resolved
-        if not response.entities:
-            self._resolution_cache.set_entity(
-                space_id=space_id,
-                label=label,
-                value=None,
-            )
-            return None
-        first_entity = response.entities[0]
-        fallback_resolved: JSONObject = {
-            "id": str(first_entity.id),
-            "display_label": first_entity.display_label or str(first_entity.id),
-        }
         self._resolution_cache.set_entity(
             space_id=space_id,
             label=label,
-            value=fallback_resolved,
+            value=None,
         )
-        return fallback_resolved
+        return None
 
     async def resolve_entity_label_with_ai(
         self,

--- a/services/artana_evidence_api/runtime/pdf_text_diagnostics.py
+++ b/services/artana_evidence_api/runtime/pdf_text_diagnostics.py
@@ -1,0 +1,138 @@
+"""PDF text-extraction diagnostics for document ingestion runtime paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from artana_evidence_api.document_extraction import normalize_text_document
+from artana_evidence_api.document_extraction_contracts import DocumentTextExtraction
+from artana_evidence_api.types.common import JSONObject
+from fastapi import HTTPException, status
+
+_SCANNED_PDF_NO_TEXT_REASON = "scanned_pdf_no_text"
+_PARTIAL_PDF_OCR_NEEDED_REASON = "partial_pdf_ocr_needed"
+_PDF_NO_PAGES_REASON = "pdf_no_pages"
+_PDF_NO_EXTRACTABLE_TEXT_REASON = "pdf_no_extractable_text"
+_MAX_PAGE_NUMBERS_IN_MESSAGE = 10
+
+
+@dataclass(frozen=True, slots=True)
+class PdfTextDiagnostic:
+    """Actionable diagnostic for a PDF that needs OCR before ingestion."""
+
+    reason_code: str
+    message: str
+    ocr_required: bool
+    page_count: int | None
+    pages_without_text: tuple[int, ...] = ()
+
+    def as_detail(self) -> JSONObject:
+        detail: JSONObject = {
+            "reason_code": self.reason_code,
+            "message": self.message,
+            "ocr_required": self.ocr_required,
+        }
+        if self.page_count is not None:
+            detail["page_count"] = self.page_count
+        if self.pages_without_text:
+            detail["pages_without_text"] = list(self.pages_without_text)
+        return detail
+
+    def as_metadata(self) -> JSONObject:
+        metadata: JSONObject = {
+            "pdf_text_extraction_reason_code": self.reason_code,
+            "pdf_text_extraction_message": self.message,
+            "ocr_required": self.ocr_required,
+        }
+        if self.pages_without_text:
+            metadata["pdf_pages_without_text"] = list(self.pages_without_text)
+        return metadata
+
+
+class PdfTextDiagnosticError(HTTPException):
+    """HTTP error carrying a structured PDF text-extraction diagnostic."""
+
+    def __init__(self, diagnostic: PdfTextDiagnostic) -> None:
+        self.diagnostic = diagnostic
+        super().__init__(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=diagnostic.as_detail(),
+        )
+
+
+def _format_pdf_page_numbers(page_numbers: tuple[int, ...]) -> str:
+    displayed_page_numbers = page_numbers[:_MAX_PAGE_NUMBERS_IN_MESSAGE]
+    displayed = ", ".join(str(page_number) for page_number in displayed_page_numbers)
+    remaining_count = len(page_numbers) - len(displayed_page_numbers)
+    if remaining_count <= 0:
+        return displayed
+    return f"{displayed}, and {remaining_count} more"
+
+
+def pdf_text_diagnostic(extraction: DocumentTextExtraction) -> PdfTextDiagnostic:
+    """Build the user-facing diagnostic for one failed PDF text extraction."""
+    if extraction.page_count == 0 or extraction.extraction_outcome == "no_pages":
+        return PdfTextDiagnostic(
+            reason_code=_PDF_NO_PAGES_REASON,
+            message="The uploaded PDF contains no pages.",
+            ocr_required=False,
+            page_count=extraction.page_count,
+        )
+    if (
+        extraction.extraction_outcome == "partial_text_ocr_needed"
+        and extraction.pages_without_text
+    ):
+        return PdfTextDiagnostic(
+            reason_code=_PARTIAL_PDF_OCR_NEEDED_REASON,
+            message=(
+                "The uploaded PDF includes embedded text on some pages, but pages "
+                f"{_format_pdf_page_numbers(extraction.pages_without_text)} appear "
+                "to be scanned or image-only. OCR is not currently supported by this "
+                "service; upload a fully text-based PDF or extract the missing pages "
+                "manually."
+            ),
+            ocr_required=True,
+            page_count=extraction.page_count,
+            pages_without_text=extraction.pages_without_text,
+        )
+    if (
+        isinstance(extraction.page_count, int)
+        and extraction.page_count > 0
+        and extraction.extraction_outcome == "no_text_image_likely"
+    ):
+        return PdfTextDiagnostic(
+            reason_code=_SCANNED_PDF_NO_TEXT_REASON,
+            message=(
+                "The uploaded PDF appears to be scanned or image-only and does not "
+                "include embedded text. OCR is not currently supported by this "
+                "service; upload a text-based PDF or extract the text manually."
+            ),
+            ocr_required=True,
+            page_count=extraction.page_count,
+            pages_without_text=extraction.pages_without_text,
+        )
+    return PdfTextDiagnostic(
+        reason_code=_PDF_NO_EXTRACTABLE_TEXT_REASON,
+        message="The uploaded PDF did not contain extractable text.",
+        ocr_required=False,
+        page_count=extraction.page_count,
+    )
+
+
+def require_extracted_pdf_text(extraction: DocumentTextExtraction) -> str:
+    """Return normalized text or raise the PDF OCR-needed diagnostic."""
+    normalized_text = normalize_text_document(extraction.text_content)
+    if (
+        normalized_text == ""
+        or extraction.extraction_outcome == "partial_text_ocr_needed"
+    ):
+        raise PdfTextDiagnosticError(pdf_text_diagnostic(extraction))
+    return normalized_text
+
+
+__all__ = [
+    "PdfTextDiagnostic",
+    "PdfTextDiagnosticError",
+    "pdf_text_diagnostic",
+    "require_extracted_pdf_text",
+]

--- a/services/artana_evidence_api/tests/unit/test_document_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import UTC, datetime
+from io import BytesIO
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
@@ -21,6 +22,7 @@ from artana_evidence_api.document_extraction import (
     build_document_extraction_drafts,
     build_document_review_context,
     discover_relation_candidates,
+    extract_pdf_text,
     extract_relation_candidates,
     extract_relation_candidates_with_diagnostics,
     extract_relation_candidates_with_llm,
@@ -131,6 +133,53 @@ class _FakeKernel:
 class _FakeSingleStepClient:
     def __init__(self, *, kernel) -> None:
         self.kernel = kernel
+
+
+def test_extract_pdf_text_marks_blank_pdf_as_image_likely() -> None:
+    from pypdf import PdfWriter
+
+    buffer = BytesIO()
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    writer.write(buffer)
+
+    extraction = extract_pdf_text(buffer.getvalue())
+
+    assert extraction.page_count == 1
+    assert extraction.text_content == ""
+    assert extraction.extraction_outcome == "no_text_image_likely"
+    assert extraction.pages_without_text == (1,)
+
+
+def test_extract_pdf_text_marks_mixed_pages_as_partial_ocr_needed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakePdfPage:
+        def __init__(self, text: str) -> None:
+            self._text = text
+
+        def extract_text(self) -> str:
+            return self._text
+
+    class _FakePdfReader:
+        def __init__(self, payload: BytesIO) -> None:
+            del payload
+            self.pages = [
+                _FakePdfPage("MED13 associates with cardiomyopathy."),
+                _FakePdfPage(""),
+                _FakePdfPage("FG syndrome evidence summary."),
+            ]
+
+    monkeypatch.setattr("pypdf.PdfReader", _FakePdfReader)
+
+    extraction = extract_pdf_text(b"%PDF-1.4\nsynthetic\n%%EOF\n")
+
+    assert extraction.page_count == 3
+    assert extraction.text_content == (
+        "MED13 associates with cardiomyopathy.\n\nFG syndrome evidence summary."
+    )
+    assert extraction.extraction_outcome == "partial_text_ocr_needed"
+    assert extraction.pages_without_text == (2,)
 
 
 @pytest.mark.asyncio

--- a/services/artana_evidence_api/tests/unit/test_documents_router.py
+++ b/services/artana_evidence_api/tests/unit/test_documents_router.py
@@ -28,6 +28,10 @@ from artana_evidence_api.document_extraction import (
     DocumentTextExtraction,
     ExtractedRelationCandidate,
 )
+from artana_evidence_api.document_ingestion_support import (
+    _enrich_pdf_document,
+    _fail_document_run,
+)
 from artana_evidence_api.document_store import HarnessDocumentStore
 from artana_evidence_api.graph_client import GraphServiceClientError
 from artana_evidence_api.proposal_store import (
@@ -41,6 +45,8 @@ from artana_evidence_api.review_item_store import (
     HarnessReviewItemStore,
 )
 from artana_evidence_api.run_registry import HarnessRunRegistry
+from artana_evidence_api.runtime.pdf_text_diagnostics import pdf_text_diagnostic
+from artana_evidence_api.storage_types import StorageUseCase
 from artana_evidence_api.types.graph_contracts import (
     KernelEntityListResponse,
     KernelEntityResponse,
@@ -59,11 +65,13 @@ from artana_evidence_api.variant_extraction_contracts import (
     ExtractedEntityCandidate,
     ExtractionContract,
 )
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 _TEST_USER_ID: Final[str] = "11111111-1111-1111-1111-111111111111"
 _TEST_USER_EMAIL: Final[str] = "graph-harness-docs@example.com"
 _MED13_ID: Final[str] = "33333333-3333-3333-3333-333333333333"
+_MED13L_ID: Final[str] = "33333333-3333-4333-8333-333333333333"
 _CARDIOMYOPATHY_ID: Final[str] = "44444444-4444-4444-4444-444444444444"
 _FG_SYNDROME_ID: Final[str] = "55555555-5555-5555-5555-555555555555"
 _LUJAN_FRYNS_ID: Final[str] = "66666666-6666-6666-6666-666666666666"
@@ -185,6 +193,55 @@ class _StubEmptyGraphApiGateway(_StubGraphApiGateway):
         return KernelEntityListResponse(entities=[], total=0, offset=0, limit=50)
 
 
+class _SimilarGeneOnlyGraphApiGateway(_StubGraphApiGateway):
+    def list_entities(
+        self,
+        *,
+        space_id: UUID | str,
+        q: str | None = None,
+        entity_type: str | None = None,
+        ids: list[str] | None = None,
+        offset: int = 0,
+        limit: int = 50,
+    ) -> KernelEntityListResponse:
+        del entity_type, ids, offset, limit
+        now = datetime.now(UTC)
+        query = q.strip().casefold() if isinstance(q, str) else ""
+        entities: list[KernelEntityResponse] = []
+        if query == "med13":
+            entities.append(
+                KernelEntityResponse(
+                    id=UUID(_MED13L_ID),
+                    research_space_id=UUID(str(space_id)),
+                    entity_type="GENE",
+                    display_label="MED13L",
+                    aliases=[],
+                    metadata={},
+                    created_at=now,
+                    updated_at=now,
+                ),
+            )
+        if query == "cardiomyopathy":
+            entities.append(
+                KernelEntityResponse(
+                    id=UUID(_CARDIOMYOPATHY_ID),
+                    research_space_id=UUID(str(space_id)),
+                    entity_type="DISEASE",
+                    display_label="cardiomyopathy",
+                    aliases=[],
+                    metadata={},
+                    created_at=now,
+                    updated_at=now,
+                ),
+            )
+        return KernelEntityListResponse(
+            entities=entities,
+            total=len(entities),
+            offset=0,
+            limit=50,
+        )
+
+
 class _FailingEntityResolutionGraphApiGateway(_StubGraphApiGateway):
     def list_entities(
         self,
@@ -248,6 +305,55 @@ def _build_client(
         proposal_store,
         run_registry,
         space.id,
+    )
+
+
+def _build_pdf_enrichment_context() -> tuple[
+    HarnessArtifactStore,
+    HarnessDocumentBinaryStore,
+    HarnessDocumentStore,
+    HarnessRunRegistry,
+    str,
+    str,
+]:
+    artifact_store = HarnessArtifactStore()
+    binary_store = HarnessDocumentBinaryStore()
+    document_store = HarnessDocumentStore()
+    run_registry = HarnessRunRegistry()
+    space_id = "99999999-9999-4999-9999-999999999999"
+    raw_storage_key = "documents/test/raw/scanned.pdf"
+    document = document_store.create_document(
+        space_id=space_id,
+        created_by=_TEST_USER_ID,
+        title="Scanned MED13 PDF",
+        source_type="pdf",
+        filename="scanned.pdf",
+        media_type="application/pdf",
+        sha256="scanned-pdf-sha",
+        byte_size=24,
+        page_count=None,
+        text_content="",
+        raw_storage_key=raw_storage_key,
+        ingestion_run_id="pdf-upload-run",
+        enrichment_status="not_started",
+        extraction_status="pending",
+        metadata={},
+    )
+    asyncio.run(
+        binary_store.store_bytes(
+            use_case=StorageUseCase.DOCUMENT_CONTENT,
+            key=raw_storage_key,
+            payload=b"%PDF-1.4\nsynthetic\n%%EOF\n",
+            content_type="application/pdf",
+        ),
+    )
+    return (
+        artifact_store,
+        binary_store,
+        document_store,
+        run_registry,
+        space_id,
+        document.id,
     )
 
 
@@ -1122,6 +1228,50 @@ def test_extract_document_degrades_to_unresolved_entities_when_graph_resolution_
     assert "document_error" not in artifact_keys
 
 
+def test_extract_document_does_not_assign_similar_gene_search_result(
+    monkeypatch,
+) -> None:
+    async def _no_ai_resolution(*args, **kwargs):
+        del args, kwargs
+
+    monkeypatch.setattr(
+        "artana_evidence_api.document_extraction._resolve_entity_label_with_ai",
+        _no_ai_resolution,
+    )
+    client, _, _, _, _, space_id = _build_client(
+        graph_api_gateway_dependency=_SimilarGeneOnlyGraphApiGateway,
+    )
+
+    submit_response = client.post(
+        f"/v1/spaces/{space_id}/documents/text",
+        headers=_auth_headers(),
+        json={
+            "title": "MED13 similar-gene ambiguity note",
+            "text": "MED13 associates with cardiomyopathy.",
+            "metadata": {},
+        },
+    )
+    document_id = submit_response.json()["document"]["id"]
+
+    extract_response = client.post(
+        f"/v1/spaces/{space_id}/documents/{document_id}/extract",
+        headers=_auth_headers(),
+    )
+
+    assert extract_response.status_code == 201
+    payload = extract_response.json()
+    assert payload["proposal_count"] == 1
+    proposal_payload = payload["proposals"][0]["payload"]
+    proposal_metadata = payload["proposals"][0]["metadata"]
+    assert proposal_payload["proposed_subject"] == "unresolved:med13"
+    assert proposal_payload["proposed_object"] == _CARDIOMYOPATHY_ID
+    assert proposal_payload["evidence_entity_ids"] == [_CARDIOMYOPATHY_ID]
+    assert _MED13L_ID not in proposal_payload["evidence_entity_ids"]
+    assert proposal_metadata["subject_resolved"] is False
+    assert proposal_metadata["resolved_subject_label"] == "MED13"
+    assert proposal_metadata["object_resolved"] is True
+
+
 def test_extract_document_creates_deferred_resolution_proposals_for_empty_graph() -> (
     None
 ):
@@ -1286,6 +1436,276 @@ def test_extract_pdf_document_runs_enrichment_before_extraction(monkeypatch) -> 
         "document-enrichment",
         "document-ingestion",
     ]
+
+
+def test_extract_pdf_document_returns_partial_pdf_ocr_needed_detail(monkeypatch) -> None:
+    client, _, document_store, _, _, space_id = _build_client()
+
+    monkeypatch.setattr(
+        "artana_evidence_api.document_ingestion_support.extract_pdf_text",
+        lambda payload: DocumentTextExtraction(
+            text_content="MED13 associates with cardiomyopathy.",
+            page_count=4,
+            extraction_outcome="partial_text_ocr_needed",
+            pages_without_text=(2, 4),
+        ),
+    )
+
+    upload_response = client.post(
+        f"/v1/spaces/{space_id}/documents/pdf",
+        headers=_auth_headers(),
+        data={"title": "Scanned MED13 PDF"},
+        files={
+            "file": (
+                "scanned-med13.pdf",
+                b"%PDF-1.4\nsynthetic scanned payload\n%%EOF\n",
+                "application/pdf",
+            ),
+        },
+    )
+    document_id = upload_response.json()["document"]["id"]
+
+    extract_response = client.post(
+        f"/v1/spaces/{space_id}/documents/{document_id}/extract",
+        headers=_auth_headers(),
+    )
+
+    assert extract_response.status_code == 400
+    payload = extract_response.json()
+    assert payload["detail"] == (
+        "The uploaded PDF includes embedded text on some pages, but pages 2, 4 "
+        "appear to be scanned or image-only. OCR is not currently supported by this "
+        "service; upload a fully text-based PDF or extract the missing pages manually."
+    )
+    assert payload["reason_code"] == "partial_pdf_ocr_needed"
+    assert payload["ocr_required"] is True
+    assert payload["page_count"] == 4
+    assert payload["pages_without_text"] == [2, 4]
+    assert isinstance(payload["request_id"], str)
+    updated_document = document_store.get_document(
+        space_id=space_id,
+        document_id=document_id,
+    )
+    assert updated_document is not None
+    assert updated_document.page_count == 4
+    assert updated_document.enrichment_status == "failed"
+    assert updated_document.metadata["ocr_required"] is True
+    assert updated_document.metadata["pdf_text_extraction_reason_code"] == (
+        "partial_pdf_ocr_needed"
+    )
+    assert updated_document.metadata["pdf_pages_without_text"] == [2, 4]
+
+
+def test_pdf_enrichment_marks_scanned_pdf_as_ocr_required(monkeypatch) -> None:
+    (
+        artifact_store,
+        binary_store,
+        document_store,
+        run_registry,
+        space_id,
+        document_id,
+    ) = _build_pdf_enrichment_context()
+    document = document_store.get_document(space_id=space_id, document_id=document_id)
+    assert document is not None
+    monkeypatch.setattr(
+        "artana_evidence_api.document_ingestion_support.extract_pdf_text",
+        lambda payload: DocumentTextExtraction(
+            text_content="",
+            page_count=3,
+            extraction_outcome="no_text_image_likely",
+            pages_without_text=(1, 2, 3),
+        ),
+    )
+
+    try:
+        asyncio.run(
+            _enrich_pdf_document(
+                space_id=UUID(space_id),
+                document=document,
+                run_registry=run_registry,
+                artifact_store=artifact_store,
+                binary_store=binary_store,
+                document_store=document_store,
+                graph_api_gateway=_StubGraphApiGateway(),
+            ),
+        )
+    except HTTPException as exc:
+        failure = exc
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("Scanned PDF enrichment should fail with an OCR diagnostic")
+
+    assert failure.status_code == 400
+    assert failure.detail == {
+        "reason_code": "scanned_pdf_no_text",
+        "message": (
+            "The uploaded PDF appears to be scanned or image-only and does not "
+            "include embedded text. OCR is not currently supported by this "
+            "service; upload a text-based PDF or extract the text manually."
+        ),
+        "ocr_required": True,
+        "page_count": 3,
+        "pages_without_text": [1, 2, 3],
+    }
+    updated_document = document_store.get_document(
+        space_id=space_id,
+        document_id=document_id,
+    )
+    assert updated_document is not None
+    assert updated_document.page_count == 3
+    assert updated_document.enrichment_status == "failed"
+    assert updated_document.metadata["pdf_text_extraction_reason_code"] == (
+        "scanned_pdf_no_text"
+    )
+    assert updated_document.metadata["ocr_required"] is True
+    assert updated_document.metadata["pdf_pages_without_text"] == [1, 2, 3]
+
+    enrichment_run = run_registry.list_runs(space_id=space_id)[0]
+    assert enrichment_run.harness_id == "document-enrichment"
+    assert enrichment_run.status == "failed"
+    error_artifact = artifact_store.get_artifact(
+        space_id=space_id,
+        run_id=enrichment_run.id,
+        artifact_key="document_error",
+    )
+    assert error_artifact is not None
+    assert error_artifact.content["reason_code"] == "scanned_pdf_no_text"
+    assert error_artifact.content["ocr_required"] is True
+    assert error_artifact.content["page_count"] == 3
+    assert error_artifact.content["pages_without_text"] == [1, 2, 3]
+
+
+def test_pdf_enrichment_distinguishes_zero_page_pdf(monkeypatch) -> None:
+    (
+        artifact_store,
+        binary_store,
+        document_store,
+        run_registry,
+        space_id,
+        document_id,
+    ) = _build_pdf_enrichment_context()
+    document = document_store.get_document(space_id=space_id, document_id=document_id)
+    assert document is not None
+    monkeypatch.setattr(
+        "artana_evidence_api.document_ingestion_support.extract_pdf_text",
+        lambda payload: DocumentTextExtraction(
+            text_content="",
+            page_count=0,
+            extraction_outcome="no_pages",
+        ),
+    )
+
+    try:
+        asyncio.run(
+            _enrich_pdf_document(
+                space_id=UUID(space_id),
+                document=document,
+                run_registry=run_registry,
+                artifact_store=artifact_store,
+                binary_store=binary_store,
+                document_store=document_store,
+                graph_api_gateway=_StubGraphApiGateway(),
+            ),
+        )
+    except HTTPException as exc:
+        failure = exc
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("Zero-page PDF enrichment should fail with a diagnostic")
+
+    assert failure.status_code == 400
+    assert failure.detail == {
+        "reason_code": "pdf_no_pages",
+        "message": "The uploaded PDF contains no pages.",
+        "ocr_required": False,
+        "page_count": 0,
+    }
+    updated_document = document_store.get_document(
+        space_id=space_id,
+        document_id=document_id,
+    )
+    assert updated_document is not None
+    assert updated_document.page_count == 0
+    assert updated_document.enrichment_status == "failed"
+    assert updated_document.metadata["pdf_text_extraction_reason_code"] == "pdf_no_pages"
+    assert updated_document.metadata["ocr_required"] is False
+
+    enrichment_run = run_registry.list_runs(space_id=space_id)[0]
+    error_artifact = artifact_store.get_artifact(
+        space_id=space_id,
+        run_id=enrichment_run.id,
+        artifact_key="document_error",
+    )
+    assert error_artifact is not None
+    assert error_artifact.content["reason_code"] == "pdf_no_pages"
+    assert error_artifact.content["ocr_required"] is False
+    assert error_artifact.content["page_count"] == 0
+    assert error_artifact.content["pages_without_text"] == []
+
+
+def test_pdf_text_diagnostic_handles_unknown_empty_pdf_state() -> None:
+    diagnostic = pdf_text_diagnostic(
+        DocumentTextExtraction(
+            text_content="",
+            page_count=None,
+        ),
+    )
+
+    assert diagnostic.as_detail() == {
+        "reason_code": "pdf_no_extractable_text",
+        "message": "The uploaded PDF did not contain extractable text.",
+        "ocr_required": False,
+    }
+    assert diagnostic.as_metadata() == {
+        "pdf_text_extraction_reason_code": "pdf_no_extractable_text",
+        "pdf_text_extraction_message": (
+            "The uploaded PDF did not contain extractable text."
+        ),
+        "ocr_required": False,
+    }
+
+
+def test_fail_document_run_metadata_cannot_override_reserved_error_fields() -> None:
+    artifact_store = HarnessArtifactStore()
+    run_registry = HarnessRunRegistry()
+    space_id = UUID("99999999-9999-4999-9999-999999999999")
+    run = run_registry.create_run(
+        space_id=space_id,
+        harness_id="document-enrichment",
+        title="Document Enrichment: scanned.pdf",
+        input_payload={},
+        graph_service_status="ok",
+        graph_service_version="documents-test",
+    )
+    artifact_store.seed_for_run(run=run)
+
+    _fail_document_run(
+        space_id=space_id,
+        run=run,
+        message="OCR is required.",
+        artifact_store=artifact_store,
+        run_registry=run_registry,
+        error_metadata={
+            "status": "completed",
+            "error": "overridden",
+            "reason_code": "scanned_pdf_no_text",
+        },
+    )
+
+    workspace = artifact_store.get_workspace(space_id=space_id, run_id=run.id)
+    assert workspace is not None
+    assert workspace.snapshot["status"] == "failed"
+    assert workspace.snapshot["error"] == "OCR is required."
+    assert workspace.snapshot["reason_code"] == "scanned_pdf_no_text"
+
+    error_artifact = artifact_store.get_artifact(
+        space_id=space_id,
+        run_id=run.id,
+        artifact_key="document_error",
+    )
+    assert error_artifact is not None
+    assert error_artifact.content == {
+        "error": "OCR is required.",
+        "reason_code": "scanned_pdf_no_text",
+    }
 
 
 def test_extract_text_document_skips_enrichment_run() -> None:

--- a/services/artana_evidence_api/tests/unit/test_error_response_format.py
+++ b/services/artana_evidence_api/tests/unit/test_error_response_format.py
@@ -119,6 +119,7 @@ def test_dict_detail_extracts_message() -> None:
     body = resp.json()
     assert isinstance(body["detail"], str)
     assert body["detail"] == "something went wrong"
+    assert "code" not in body
 
 
 def test_dict_detail_without_message_key_stringifies() -> None:

--- a/services/artana_evidence_api/tests/unit/test_graph_client.py
+++ b/services/artana_evidence_api/tests/unit/test_graph_client.py
@@ -1081,6 +1081,50 @@ def _preflight_services(
     )
 
 
+class _StaticEntityQueryGateway:
+    def __init__(self, entities: tuple[KernelEntityResponse, ...]) -> None:
+        self._entities = entities
+
+    def list_entities(
+        self,
+        *,
+        space_id: UUID,
+        q: str | None = None,
+        entity_type: str | None = None,
+        ids: list[str] | None = None,
+        offset: int = 0,
+        limit: int = 5,
+    ) -> KernelEntityListResponse:
+        del q, entity_type, ids, offset, limit
+        return KernelEntityListResponse(
+            entities=list(self._entities),
+            total=len(self._entities),
+            offset=0,
+            limit=5,
+        )
+
+
+def _kernel_entity(
+    *,
+    space_id: UUID,
+    entity_id: UUID,
+    display_label: str,
+    entity_type: str = "GENE",
+    aliases: list[str] | None = None,
+) -> KernelEntityResponse:
+    now = datetime.now(UTC)
+    return KernelEntityResponse(
+        id=entity_id,
+        research_space_id=space_id,
+        entity_type=entity_type,
+        display_label=display_label,
+        aliases=aliases or [],
+        metadata={},
+        created_at=now,
+        updated_at=now,
+    )
+
+
 def _stub_kernel_relation_register_new(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -1098,6 +1142,127 @@ def _stub_kernel_relation_register_new(
         "artana_evidence_api.graph_integration.preflight.resolve_relation_with_kernel",
         _resolver,
     )
+
+
+def test_preflight_entity_resolution_rejects_similar_gene_substring() -> None:
+    space_id = uuid4()
+    med13l_id = uuid4()
+    gateway = _StaticEntityQueryGateway(
+        (
+            _kernel_entity(
+                space_id=space_id,
+                entity_id=med13l_id,
+                display_label="MED13L",
+            ),
+        ),
+    )
+
+    resolved = GraphAIPreflightService().resolve_entity_label(
+        space_id=space_id,
+        label="MED13",
+        graph_transport=cast("GraphTransportBundle", gateway),
+    )
+
+    assert resolved is None
+
+
+def test_preflight_entity_resolution_rejects_first_result_fallback() -> None:
+    space_id = uuid4()
+    gateway = _StaticEntityQueryGateway(
+        (
+            _kernel_entity(
+                space_id=space_id,
+                entity_id=uuid4(),
+                display_label="TP53",
+            ),
+        ),
+    )
+
+    resolved = GraphAIPreflightService().resolve_entity_label(
+        space_id=space_id,
+        label="AKT1",
+        graph_transport=cast("GraphTransportBundle", gateway),
+    )
+
+    assert resolved is None
+
+
+def test_preflight_entity_resolution_keeps_exact_alias_resolution() -> None:
+    space_id = uuid4()
+    egfr_id = uuid4()
+    gateway = _StaticEntityQueryGateway(
+        (
+            _kernel_entity(
+                space_id=space_id,
+                entity_id=egfr_id,
+                display_label="EGFR",
+                aliases=["ErbB1"],
+            ),
+        ),
+    )
+
+    resolved = GraphAIPreflightService().resolve_entity_label(
+        space_id=space_id,
+        label="ErbB1",
+        graph_transport=cast("GraphTransportBundle", gateway),
+    )
+
+    assert resolved == {
+        "id": str(egfr_id),
+        "display_label": "EGFR",
+    }
+
+
+@pytest.mark.asyncio
+async def test_preflight_ai_resolution_runs_after_negative_deterministic_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    space_id = uuid4()
+    med13_id = uuid4()
+    gateway = _StaticEntityQueryGateway(
+        (
+            _kernel_entity(
+                space_id=space_id,
+                entity_id=uuid4(),
+                display_label="MED13L",
+            ),
+        ),
+    )
+    preflight_service = GraphAIPreflightService()
+
+    deterministic = preflight_service.resolve_entity_label(
+        space_id=space_id,
+        label="MED13",
+        graph_transport=cast("GraphTransportBundle", gateway),
+    )
+    assert deterministic is None
+
+    seen_labels: list[str] = []
+
+    async def _kernel_resolver(*, space_id, label, graph_api_gateway, space_context):
+        del space_id, graph_api_gateway, space_context
+        seen_labels.append(label)
+        return {
+            "id": str(med13_id),
+            "display_label": "MED13",
+        }
+
+    monkeypatch.setattr(
+        "artana_evidence_api.graph_integration.preflight.resolve_entity_with_kernel",
+        _kernel_resolver,
+    )
+
+    resolved = await preflight_service.resolve_entity_label_with_ai(
+        space_id=space_id,
+        label="MED13",
+        graph_transport=cast("GraphTransportBundle", gateway),
+    )
+
+    assert seen_labels == ["MED13"]
+    assert resolved == {
+        "id": str(med13_id),
+        "display_label": "MED13",
+    }
 
 
 def test_gateway_default_call_context_is_not_admin(


### PR DESCRIPTION
## Summary
- Add structured PDF text-extraction diagnostics for scanned, mixed, and zero-page uploads while preserving the existing string error contract
- Record OCR-needed metadata and run artifacts during PDF enrichment failures
- Tighten deterministic entity resolution so only exact label or alias matches resolve, preventing similar-gene misassignment like `MED13` vs `MED13L`
- Add regression coverage for PDF outcomes, error responses, and graph preflight resolution behavior

## Testing
- Focused unit tests for PDF extraction, PDF enrichment, graph preflight resolution, and the new route-level regressions
- Broader `artana-evidence-api` lint, type-check, architecture-structure, and full service checks passed