### PR TITLE
Fix reasoning path refresh after graph mutations

### DIFF
--- a/services/artana_evidence_db/README.md
+++ b/services/artana_evidence_db/README.md
@@ -47,6 +47,10 @@ Current scope:
 - claim-relation write and review endpoints
 - graph-view and mechanism-chain endpoints
 - service-owned maintenance endpoints for participant backfill, projection readiness, projection repair, and reasoning-path rebuilds
+- reasoning paths are derived data: claim, claim-relation, and projection
+  mutations mark affected paths `STALE` and refresh the compact mechanism-path
+  candidate index; admin rebuilds replace stale derived paths with new `ACTIVE`
+  paths
 - service-owned operation history endpoints under `/v1/admin/operations/runs` for readiness, repair, backfill, and rebuild workflows
 - service-owned graph-space registry endpoints under `/v1/admin/spaces/...`
 - service-owned graph-space sync endpoint under `/v1/admin/spaces/{space_id}/sync`

--- a/services/artana_evidence_db/claim_relation_service.py
+++ b/services/artana_evidence_db/claim_relation_service.py
@@ -12,6 +12,22 @@ from artana_evidence_db.claim_relation_models import (
 from artana_evidence_db.common_types import JSONObject
 
 
+class ReasoningPathInvalidationServiceLike(Protocol):
+    """Minimal reasoning-path invalidation surface for claim-relation mutations."""
+
+    def invalidate_for_claim_ids(
+        self,
+        claim_ids: list[str],
+        research_space_id: str,
+    ) -> int: ...
+
+    def invalidate_for_claim_relation_ids(
+        self,
+        relation_ids: list[str],
+        research_space_id: str,
+    ) -> int: ...
+
+
 class ClaimRelationRepositoryLike(Protocol):
     """Minimal repository contract required for claim-relation workflows."""
 
@@ -82,8 +98,14 @@ class ClaimRelationRepositoryLike(Protocol):
 class KernelClaimRelationService:
     """Application service for claim-to-claim relation graph workflows."""
 
-    def __init__(self, claim_relation_repo: ClaimRelationRepositoryLike) -> None:
+    def __init__(
+        self,
+        claim_relation_repo: ClaimRelationRepositoryLike,
+        *,
+        reasoning_path_invalidation_service: ReasoningPathInvalidationServiceLike,
+    ) -> None:
         self._claim_relations = claim_relation_repo
+        self._reasoning_path_invalidation = reasoning_path_invalidation_service
 
     def create_claim_relation(  # noqa: PLR0913
         self,
@@ -101,7 +123,7 @@ class KernelClaimRelationService:
         metadata: JSONObject | None = None,
     ) -> KernelClaimRelation:
         """Create one claim relation row."""
-        return self._claim_relations.create(
+        relation = self._claim_relations.create(
             research_space_id=research_space_id,
             source_claim_id=source_claim_id,
             target_claim_id=target_claim_id,
@@ -114,6 +136,8 @@ class KernelClaimRelationService:
             evidence_summary=evidence_summary,
             metadata=metadata,
         )
+        self._invalidate_relation(relation)
+        return relation
 
     def get_claim_relation(self, relation_id: str) -> KernelClaimRelation | None:
         """Fetch one claim relation by ID."""
@@ -184,9 +208,22 @@ class KernelClaimRelationService:
         review_status: ClaimRelationReviewStatus,
     ) -> KernelClaimRelation:
         """Update review status for one claim relation row."""
-        return self._claim_relations.update_review_status(
+        relation = self._claim_relations.update_review_status(
             relation_id,
             review_status=review_status,
+        )
+        self._invalidate_relation(relation)
+        return relation
+
+    def _invalidate_relation(self, relation: KernelClaimRelation) -> None:
+        research_space_id = str(relation.research_space_id)
+        self._reasoning_path_invalidation.invalidate_for_claim_ids(
+            [str(relation.source_claim_id), str(relation.target_claim_id)],
+            research_space_id,
+        )
+        self._reasoning_path_invalidation.invalidate_for_claim_relation_ids(
+            [str(relation.id)],
+            research_space_id,
         )
 
 

--- a/services/artana_evidence_db/dependencies.py
+++ b/services/artana_evidence_db/dependencies.py
@@ -43,6 +43,9 @@ from artana_evidence_db.kernel_services import (
     KernelRelationService,
     ProvenanceService,
 )
+from artana_evidence_db.reasoning_path_service import (
+    KernelReasoningPathInvalidationService,
+)
 from fastapi import Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
@@ -223,6 +226,16 @@ def get_kernel_relation_suggestion_service(
     return create_kernel_relation_suggestion_service(session)
 
 
+def get_kernel_reasoning_path_invalidation_service(
+    session: Session = Depends(get_session),
+) -> KernelReasoningPathInvalidationService:
+    """Return reasoning-path invalidation service bound to the graph session."""
+    return KernelReasoningPathInvalidationService(
+        reasoning_path_repo=SqlAlchemyKernelReasoningPathRepository(session),
+        read_model_update_dispatcher=build_graph_read_model_update_dispatcher(session),
+    )
+
+
 def get_kernel_relation_claim_service(
     session: Session = Depends(get_session),
 ) -> KernelRelationClaimService:
@@ -230,6 +243,9 @@ def get_kernel_relation_claim_service(
     return KernelRelationClaimService(
         relation_claim_repo=SqlAlchemyKernelRelationClaimRepository(session),
         read_model_update_dispatcher=build_graph_read_model_update_dispatcher(session),
+        reasoning_path_invalidation_service=(
+            get_kernel_reasoning_path_invalidation_service(session)
+        ),
     )
 
 
@@ -259,6 +275,9 @@ def get_kernel_claim_relation_service(
     """Return kernel claim-relation service."""
     return KernelClaimRelationService(
         claim_relation_repo=SqlAlchemyKernelClaimRelationRepository(session),
+        reasoning_path_invalidation_service=(
+            get_kernel_reasoning_path_invalidation_service(session)
+        ),
     )
 
 
@@ -275,6 +294,9 @@ def get_kernel_reasoning_path_service(
     session: Session = Depends(get_session),
 ) -> KernelReasoningPathService:
     """Return reasoning-path service bound to the graph service session."""
+    reasoning_path_invalidation_service = (
+        get_kernel_reasoning_path_invalidation_service(session)
+    )
     return KernelReasoningPathService(
         reasoning_path_repo=SqlAlchemyKernelReasoningPathRepository(session),
         relation_claim_service=get_kernel_relation_claim_service(session),
@@ -283,6 +305,7 @@ def get_kernel_reasoning_path_service(
         claim_relation_service=get_kernel_claim_relation_service(session),
         relation_service=get_kernel_relation_service(session),
         read_model_update_dispatcher=build_graph_read_model_update_dispatcher(session),
+        reasoning_path_invalidation_service=reasoning_path_invalidation_service,
         session=session,
         space_registry_port=SqlAlchemyKernelSpaceRegistryRepository(session),
     )
@@ -411,6 +434,9 @@ def get_kernel_relation_projection_materialization_service(
             session,
         ),
         read_model_update_dispatcher=build_graph_read_model_update_dispatcher(session),
+        reasoning_path_invalidation_service=(
+            get_kernel_reasoning_path_invalidation_service(session)
+        ),
     )
 
 
@@ -503,6 +529,7 @@ __all__ = [
     "get_kernel_entity_service",
     "get_kernel_graph_view_service",
     "get_kernel_observation_service",
+    "get_kernel_reasoning_path_invalidation_service",
     "get_kernel_reasoning_path_service",
     "get_kernel_relation_claim_service",
     "get_kernel_relation_projection_materialization_service",

--- a/services/artana_evidence_db/kernel_services.py
+++ b/services/artana_evidence_db/kernel_services.py
@@ -31,7 +31,10 @@ from artana_evidence_db.kernel_relation_suggestion_service import (
 )
 from artana_evidence_db.observation_service import KernelObservationService
 from artana_evidence_db.provenance_service import ProvenanceService
-from artana_evidence_db.reasoning_path_service import KernelReasoningPathService
+from artana_evidence_db.reasoning_path_service import (
+    KernelReasoningPathInvalidationService,
+    KernelReasoningPathService,
+)
 from artana_evidence_db.relation_claim_service import KernelRelationClaimService
 from artana_evidence_db.relation_projection_materialization_service import (
     KernelRelationProjectionMaterializationService,
@@ -55,6 +58,7 @@ __all__ = [
     "KernelGraphViewService",
     "KernelGraphViewValidationError",
     "KernelObservationService",
+    "KernelReasoningPathInvalidationService",
     "KernelReasoningPathService",
     "KernelRelationClaimService",
     "KernelRelationProjectionMaterializationService",

--- a/services/artana_evidence_db/read_model_support.py
+++ b/services/artana_evidence_db/read_model_support.py
@@ -104,8 +104,8 @@ class ProjectorBackedGraphReadModelUpdateDispatcher:
         projector = self.projectors.get(update.model_name)
         if projector is None:
             return 0
-        trigger_name = str(getattr(update.trigger, "value", update.trigger))
-        if trigger_name == "FULL_REBUILD":
+        trigger_value = str(getattr(update.trigger, "value", update.trigger))
+        if trigger_value == GraphReadModelTrigger.FULL_REBUILD.value:
             return projector.rebuild(space_id=update.space_id)
         return projector.apply_update(update)
 

--- a/services/artana_evidence_db/reasoning_path_service.py
+++ b/services/artana_evidence_db/reasoning_path_service.py
@@ -203,6 +203,75 @@ _ALLOWED_PATH_RELATION_TYPES = frozenset(
 )
 
 
+def _normalize_ids(values: list[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        candidate = str(value).strip()
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        normalized.append(candidate)
+    return normalized
+
+
+class KernelReasoningPathInvalidationService:
+    """Keep derived reasoning paths and mechanism candidates from going stale."""
+
+    def __init__(
+        self,
+        *,
+        reasoning_path_repo: ReasoningPathRepositoryLike,
+        read_model_update_dispatcher: GraphReadModelUpdateDispatcher,
+    ) -> None:
+        self._paths = reasoning_path_repo
+        self._read_model_updates = read_model_update_dispatcher
+
+    def invalidate_for_claim_ids(
+        self,
+        claim_ids: list[str],
+        research_space_id: str,
+    ) -> int:
+        normalized_claim_ids = _normalize_ids(claim_ids)
+        if not normalized_claim_ids:
+            return 0
+        stale_count = self._paths.mark_stale_for_claim_ids(
+            research_space_id=research_space_id,
+            claim_ids=normalized_claim_ids,
+        )
+        self._read_model_updates.dispatch(
+            GraphReadModelUpdate(
+                model_name="entity_mechanism_paths",
+                trigger=GraphReadModelTrigger.CLAIM_CHANGE,
+                claim_ids=tuple(normalized_claim_ids),
+                space_id=research_space_id,
+            ),
+        )
+        return stale_count
+
+    def invalidate_for_claim_relation_ids(
+        self,
+        relation_ids: list[str],
+        research_space_id: str,
+    ) -> int:
+        normalized_relation_ids = _normalize_ids(relation_ids)
+        if not normalized_relation_ids:
+            return 0
+        stale_count = self._paths.mark_stale_for_claim_relation_ids(
+            research_space_id=research_space_id,
+            relation_ids=normalized_relation_ids,
+        )
+        self._read_model_updates.dispatch(
+            GraphReadModelUpdate(
+                model_name="entity_mechanism_paths",
+                trigger=GraphReadModelTrigger.PROJECTION_CHANGE,
+                relation_ids=tuple(normalized_relation_ids),
+                space_id=research_space_id,
+            ),
+        )
+        return stale_count
+
+
 class KernelReasoningPathService:
     """Build and serve derived mechanism paths from grounded claim chains."""
 
@@ -216,6 +285,7 @@ class KernelReasoningPathService:
         claim_relation_service: ClaimRelationServiceLike,
         relation_service: RelationServiceLike,
         read_model_update_dispatcher: GraphReadModelUpdateDispatcher,
+        reasoning_path_invalidation_service: KernelReasoningPathInvalidationService,
         session: Session | None = None,
         space_registry_port: SpaceRegistryPort | None = None,
     ) -> None:
@@ -226,6 +296,7 @@ class KernelReasoningPathService:
         self._claim_relations = claim_relation_service
         self._relations = relation_service
         self._read_model_update_dispatcher = read_model_update_dispatcher
+        self._invalidation = reasoning_path_invalidation_service
         self._session = session
         self._space_registry = space_registry_port
 
@@ -501,42 +572,25 @@ class KernelReasoningPathService:
         claim_ids: list[str],
         research_space_id: str,
     ) -> int:
-        stale_count = self._paths.mark_stale_for_claim_ids(
-            research_space_id=research_space_id,
-            claim_ids=claim_ids,
+        return self._invalidation.invalidate_for_claim_ids(
+            claim_ids,
+            research_space_id,
         )
-        self._read_model_update_dispatcher.dispatch(
-            GraphReadModelUpdate(
-                model_name="entity_mechanism_paths",
-                trigger=GraphReadModelTrigger.CLAIM_CHANGE,
-                claim_ids=tuple(claim_ids),
-                space_id=research_space_id,
-            ),
-        )
-        return stale_count
 
     def mark_stale_for_claim_relation_ids(
         self,
         relation_ids: list[str],
         research_space_id: str,
     ) -> int:
-        stale_count = self._paths.mark_stale_for_claim_relation_ids(
-            research_space_id=research_space_id,
-            relation_ids=relation_ids,
+        return self._invalidation.invalidate_for_claim_relation_ids(
+            relation_ids,
+            research_space_id,
         )
-        self._read_model_update_dispatcher.dispatch(
-            GraphReadModelUpdate(
-                model_name="entity_mechanism_paths",
-                trigger=GraphReadModelTrigger.PROJECTION_CHANGE,
-                relation_ids=tuple(relation_ids),
-                space_id=research_space_id,
-            ),
-        )
-        return stale_count
 
 
 __all__ = [
     "KernelReasoningPathDetail",
+    "KernelReasoningPathInvalidationService",
     "KernelReasoningPathService",
     "ReasoningPathListResult",
     "ReasoningPathRebuildSummary",

--- a/services/artana_evidence_db/relation_claim_service.py
+++ b/services/artana_evidence_db/relation_claim_service.py
@@ -22,6 +22,16 @@ from artana_evidence_db.relation_claim_models import (
 CertaintyBand = Literal["HIGH", "MEDIUM", "LOW"]
 
 
+class ReasoningPathInvalidationServiceLike(Protocol):
+    """Minimal reasoning-path invalidation surface for claim mutations."""
+
+    def invalidate_for_claim_ids(
+        self,
+        claim_ids: list[str],
+        research_space_id: str,
+    ) -> int: ...
+
+
 class RelationClaimRepositoryLike(Protocol):
     """Minimal repository contract required for relation-claim workflows."""
 
@@ -144,9 +154,11 @@ class KernelRelationClaimService:
         relation_claim_repo: RelationClaimRepositoryLike,
         *,
         read_model_update_dispatcher: GraphReadModelUpdateDispatcher,
+        reasoning_path_invalidation_service: ReasoningPathInvalidationServiceLike,
     ) -> None:
         self._claims = relation_claim_repo
         self._read_model_updates = read_model_update_dispatcher
+        self._reasoning_path_invalidation = reasoning_path_invalidation_service
 
     def get_claim(self, claim_id: str) -> KernelRelationClaim | None:
         return self._claims.get_by_id(claim_id)
@@ -447,18 +459,24 @@ class KernelRelationClaimService:
         return claim
 
     def _dispatch_claim_change(self, claim: KernelRelationClaim) -> None:
+        claim_id = str(claim.id)
+        research_space_id = str(claim.research_space_id)
         self._read_model_updates.dispatch(
             GraphReadModelUpdate(
                 model_name="entity_claim_summary",
                 trigger=GraphReadModelTrigger.CLAIM_CHANGE,
-                claim_ids=(str(claim.id),),
+                claim_ids=(claim_id,),
                 relation_ids=(
                     (str(claim.linked_relation_id),)
                     if claim.linked_relation_id is not None
                     else ()
                 ),
-                space_id=str(claim.research_space_id),
+                space_id=research_space_id,
             ),
+        )
+        self._reasoning_path_invalidation.invalidate_for_claim_ids(
+            [claim_id],
+            research_space_id,
         )
 
     @staticmethod

--- a/services/artana_evidence_db/relation_projection_materialization_service.py
+++ b/services/artana_evidence_db/relation_projection_materialization_service.py
@@ -72,6 +72,16 @@ if TYPE_CHECKING:
 _PROMOTABLE_CONSTRAINT_PROFILES = frozenset({"ALLOWED", "EXPECTED"})
 
 
+class ReasoningPathInvalidationServiceLike(Protocol):
+    """Minimal reasoning-path invalidation surface for projection mutations."""
+
+    def invalidate_for_claim_ids(
+        self,
+        claim_ids: list[str],
+        research_space_id: str,
+    ) -> int: ...
+
+
 class RelationRepositoryLike(Protocol):
     """Minimal canonical relation write surface needed for projection materialization."""
 
@@ -270,6 +280,7 @@ class KernelRelationProjectionMaterializationService:
         dictionary_repo: DictionaryRepositoryLike,
         relation_projection_repo: RelationProjectionSourceRepositoryLike,
         read_model_update_dispatcher: GraphReadModelUpdateDispatcher,
+        reasoning_path_invalidation_service: ReasoningPathInvalidationServiceLike,
     ) -> None:
         self._relations = relation_repo
         self._claims = relation_claim_repo
@@ -279,6 +290,7 @@ class KernelRelationProjectionMaterializationService:
         self._dictionary = dictionary_repo
         self._projection_sources = relation_projection_repo
         self._read_model_updates = read_model_update_dispatcher
+        self._reasoning_path_invalidation = reasoning_path_invalidation_service
 
     def materialize_support_claim(
         self,
@@ -873,6 +885,11 @@ class KernelRelationProjectionMaterializationService:
             ),
         )
         self._read_model_updates.dispatch_many(updates)
+        if normalized_claim_ids:
+            self._reasoning_path_invalidation.invalidate_for_claim_ids(
+                list(normalized_claim_ids),
+                research_space_id,
+            )
 
 
 __all__ = [

--- a/services/artana_evidence_db/routers/claims.py
+++ b/services/artana_evidence_db/routers/claims.py
@@ -39,7 +39,6 @@ from artana_evidence_db.dependencies import (
     get_kernel_claim_participant_service,
     get_kernel_claim_relation_service,
     get_kernel_entity_service,
-    get_kernel_reasoning_path_service,
     get_kernel_relation_claim_service,
     get_kernel_relation_projection_materialization_service,
     get_space_access_port,
@@ -54,7 +53,6 @@ from artana_evidence_db.kernel_services import (
     KernelClaimParticipantService,
     KernelClaimRelationService,
     KernelEntityService,
-    KernelReasoningPathService,
     KernelRelationClaimService,
     KernelRelationProjectionMaterializationService,
 )
@@ -670,9 +668,6 @@ def update_claim_status(  # noqa: PLR0915
     relation_projection_materialization_service: KernelRelationProjectionMaterializationService = Depends(
         get_kernel_relation_projection_materialization_service,
     ),
-    reasoning_path_service: KernelReasoningPathService = Depends(
-        get_kernel_reasoning_path_service,
-    ),
     session: Session = Depends(get_session),
 ) -> KernelRelationClaimResponse:
     require_space_role(
@@ -744,10 +739,6 @@ def update_claim_status(  # noqa: PLR0915
             updated = relation_claim_service.clear_claim_relation_link(
                 str(updated.id),
             )
-        reasoning_path_service.mark_stale_for_claim_ids(
-            [str(updated.id)],
-            str(space_id),
-        )
         session.commit()
         return KernelRelationClaimResponse.from_model(updated)
     except RelationProjectionMaterializationError as exc:
@@ -858,9 +849,6 @@ def create_claim_relation(
     claim_relation_service: KernelClaimRelationService = Depends(
         get_kernel_claim_relation_service,
     ),
-    reasoning_path_service: KernelReasoningPathService = Depends(
-        get_kernel_reasoning_path_service,
-    ),
     session: Session = Depends(get_session),
 ) -> ClaimRelationResponse:
     require_space_role(
@@ -901,10 +889,6 @@ def create_claim_relation(
             evidence_summary=request.evidence_summary,
             metadata={**request.metadata, **confidence_metadata},
         )
-        reasoning_path_service.mark_stale_for_claim_relation_ids(
-            [str(relation.id)],
-            str(space_id),
-        )
         session.commit()
         return ClaimRelationResponse.from_model(relation)
     except ValueError as exc:
@@ -935,9 +919,6 @@ def update_claim_relation_review_status(
     claim_relation_service: KernelClaimRelationService = Depends(
         get_kernel_claim_relation_service,
     ),
-    reasoning_path_service: KernelReasoningPathService = Depends(
-        get_kernel_reasoning_path_service,
-    ),
     session: Session = Depends(get_session),
 ) -> ClaimRelationResponse:
     require_space_role(
@@ -957,10 +938,6 @@ def update_claim_relation_review_status(
         updated = claim_relation_service.update_review_status(
             str(relation_id),
             review_status=normalize_review_status(request.review_status),
-        )
-        reasoning_path_service.mark_stale_for_claim_relation_ids(
-            [str(updated.id)],
-            str(space_id),
         )
         session.commit()
         return ClaimRelationResponse.from_model(updated)

--- a/services/artana_evidence_db/tests/integration/test_artana_evidence_db.py
+++ b/services/artana_evidence_db/tests/integration/test_artana_evidence_db.py
@@ -35,6 +35,7 @@ from artana_evidence_db.kernel_repositories import (
     SqlAlchemyKernelClaimEvidenceRepository,
     SqlAlchemyKernelClaimParticipantRepository,
     SqlAlchemyKernelEntityRepository,
+    SqlAlchemyKernelReasoningPathRepository,
     SqlAlchemyKernelRelationClaimRepository,
     SqlAlchemyKernelRelationProjectionSourceRepository,
     SqlAlchemyKernelRelationRepository,
@@ -43,7 +44,10 @@ from artana_evidence_db.orm_base import Base
 from artana_evidence_db.product_contract import GRAPH_SERVICE_VERSION
 from artana_evidence_db.provenance_model import ProvenanceModel
 from artana_evidence_db.read_model_support import NullGraphReadModelUpdateDispatcher
-from artana_evidence_db.read_models import EntityNeighborModel
+from artana_evidence_db.read_models import EntityMechanismPathModel, EntityNeighborModel
+from artana_evidence_db.reasoning_path_service import (
+    KernelReasoningPathInvalidationService,
+)
 from artana_evidence_db.relation_autopromotion_policy import AutoPromotionPolicy
 from artana_evidence_db.relation_claim_service import (
     KernelRelationClaimService,
@@ -147,6 +151,10 @@ def _build_projection_materializer(
             session,
         ),
         read_model_update_dispatcher=NullGraphReadModelUpdateDispatcher(),
+        reasoning_path_invalidation_service=KernelReasoningPathInvalidationService(
+            reasoning_path_repo=SqlAlchemyKernelReasoningPathRepository(session),
+            read_model_update_dispatcher=NullGraphReadModelUpdateDispatcher(),
+        ),
     )
 
 
@@ -595,6 +603,10 @@ def _create_hypothesis_claim(
     claim_service = KernelRelationClaimService(
         relation_claim_repo=SqlAlchemyKernelRelationClaimRepository(session),
         read_model_update_dispatcher=NullGraphReadModelUpdateDispatcher(),
+        reasoning_path_invalidation_service=KernelReasoningPathInvalidationService(
+            reasoning_path_repo=SqlAlchemyKernelReasoningPathRepository(session),
+            read_model_update_dispatcher=NullGraphReadModelUpdateDispatcher(),
+        ),
     )
     claim = claim_service.create_hypothesis_claim(
         research_space_id=str(space_id),
@@ -2555,6 +2567,7 @@ def test_graph_service_admin_readiness_and_rebuild_operations(
         },
     )
     assert create_relation.status_code == 200, create_relation.text
+    claim_relation_id = create_relation.json()["id"]
 
     readiness_response = graph_client.get(
         "/v1/admin/projections/readiness",
@@ -2616,6 +2629,56 @@ def test_graph_service_admin_readiness_and_rebuild_operations(
     )
     assert paths_response.status_code == 200, paths_response.text
     assert paths_response.json()["total"] >= 1
+    with graph_database.SessionLocal() as session:
+        mechanism_candidate_count = session.scalar(
+            sa.select(sa.func.count())
+            .select_from(EntityMechanismPathModel)
+            .where(EntityMechanismPathModel.research_space_id == space_id),
+        )
+    assert mechanism_candidate_count is not None
+    assert mechanism_candidate_count >= 1
+
+    reject_relation = graph_client.patch(
+        f"/v1/spaces/{space_id}/claim-relations/{claim_relation_id}",
+        headers=fixture["headers"],
+        json={"review_status": "REJECTED"},
+    )
+    assert reject_relation.status_code == 200, reject_relation.text
+
+    active_paths = graph_client.get(
+        f"/v1/spaces/{space_id}/reasoning-paths",
+        headers=fixture["headers"],
+        params={"status": "ACTIVE"},
+    )
+    assert active_paths.status_code == 200, active_paths.text
+    assert active_paths.json()["total"] == 0
+    with graph_database.SessionLocal() as session:
+        active_candidate_count = session.scalar(
+            sa.select(sa.func.count())
+            .select_from(EntityMechanismPathModel)
+            .where(EntityMechanismPathModel.research_space_id == space_id),
+        )
+    assert active_candidate_count == 0
+
+    stale_paths = graph_client.get(
+        f"/v1/spaces/{space_id}/reasoning-paths",
+        headers=fixture["headers"],
+        params={"status": "STALE"},
+    )
+    assert stale_paths.status_code == 200, stale_paths.text
+    assert stale_paths.json()["total"] >= 1
+
+    post_reject_rebuild = graph_client.post(
+        "/v1/admin/reasoning-paths/rebuild",
+        headers=admin_headers,
+        json={
+            "space_id": str(space_id),
+            "max_depth": 4,
+            "replace_existing": True,
+        },
+    )
+    assert post_reject_rebuild.status_code == 200, post_reject_rebuild.text
+    assert post_reject_rebuild.json()["summaries"][0]["rebuilt_paths"] == 0
 
 
 def test_graph_service_hypothesis_list_and_manual_create(

--- a/services/artana_evidence_db/tests/unit/test_kernel_services_bridge.py
+++ b/services/artana_evidence_db/tests/unit/test_kernel_services_bridge.py
@@ -65,6 +65,10 @@ def test_kernel_services_bridge_exports_lazy_loaded_symbols() -> None:
         == "artana_evidence_db.reasoning_path_service"
     )
     assert (
+        kernel_services.KernelReasoningPathInvalidationService.__module__
+        == "artana_evidence_db.reasoning_path_service"
+    )
+    assert (
         kernel_services.KernelRelationProjectionMaterializationService.__module__
         == "artana_evidence_db.relation_projection_materialization_service"
     )

--- a/services/artana_evidence_db/tests/unit/test_read_model_support.py
+++ b/services/artana_evidence_db/tests/unit/test_read_model_support.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from artana_evidence_db.read_model_support import (
+    GraphReadModelAuthoritativeSource,
+    GraphReadModelDefinition,
+    GraphReadModelOwner,
+    GraphReadModelTrigger,
+    GraphReadModelUpdate,
+    ProjectorBackedGraphReadModelUpdateDispatcher,
+)
+
+
+@dataclass
+class RecordingProjector:
+    rebuild_calls: list[str | None]
+    update_calls: list[GraphReadModelUpdate]
+
+    @property
+    def definition(self) -> GraphReadModelDefinition:
+        return GraphReadModelDefinition(
+            name="test_model",
+            description="Test model",
+            owner=GraphReadModelOwner.GRAPH_CORE,
+            authoritative_sources=(GraphReadModelAuthoritativeSource.CLAIM_LEDGER,),
+            triggers=(GraphReadModelTrigger.FULL_REBUILD,),
+        )
+
+    def rebuild(self, *, space_id: str | None = None) -> int:
+        self.rebuild_calls.append(space_id)
+        return 1
+
+    def apply_update(self, update: GraphReadModelUpdate) -> int:
+        self.update_calls.append(update)
+        return 1
+
+
+def test_dispatcher_routes_full_rebuild_by_enum_value() -> None:
+    projector = RecordingProjector(rebuild_calls=[], update_calls=[])
+    dispatcher = ProjectorBackedGraphReadModelUpdateDispatcher(
+        projectors={projector.definition.name: projector},
+    )
+
+    result = dispatcher.dispatch(
+        GraphReadModelUpdate(
+            model_name="test_model",
+            trigger=GraphReadModelTrigger.FULL_REBUILD,
+            space_id="space-1",
+        ),
+    )
+
+    assert result == 1
+    assert projector.rebuild_calls == ["space-1"]
+    assert projector.update_calls == []

--- a/services/artana_evidence_db/tests/unit/test_reasoning_path_invalidation_service.py
+++ b/services/artana_evidence_db/tests/unit/test_reasoning_path_invalidation_service.py
@@ -1,0 +1,510 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from artana_evidence_db.claim_relation_models import (
+    ClaimRelationReviewStatus,
+    ClaimRelationType,
+    KernelClaimRelation,
+)
+from artana_evidence_db.claim_relation_service import KernelClaimRelationService
+from artana_evidence_db.common_types import JSONObject
+from artana_evidence_db.read_model_support import (
+    GraphReadModelTrigger,
+    GraphReadModelUpdate,
+    NullGraphReadModelUpdateDispatcher,
+)
+from artana_evidence_db.reasoning_path_service import (
+    KernelReasoningPathInvalidationService,
+)
+from artana_evidence_db.relation_claim_models import (
+    KernelRelationClaim,
+    KernelRelationConflictSummary,
+    RelationClaimPersistability,
+    RelationClaimPolarity,
+    RelationClaimStatus,
+    RelationClaimValidationState,
+)
+from artana_evidence_db.relation_claim_service import (
+    CertaintyBand,
+    KernelRelationClaimService,
+)
+
+
+@dataclass
+class RecordingReadModelDispatcher:
+    updates: list[GraphReadModelUpdate] = field(default_factory=list)
+
+    def dispatch(self, update: GraphReadModelUpdate) -> int:
+        self.updates.append(update)
+        return 1
+
+    def dispatch_many(self, updates: tuple[GraphReadModelUpdate, ...]) -> int:
+        self.updates.extend(updates)
+        return len(updates)
+
+
+@dataclass
+class RecordingReasoningPathRepo:
+    claim_calls: list[tuple[str, list[str]]] = field(default_factory=list)
+    relation_calls: list[tuple[str, list[str]]] = field(default_factory=list)
+
+    def mark_stale_for_claim_ids(
+        self,
+        *,
+        research_space_id: str,
+        claim_ids: list[str],
+    ) -> int:
+        self.claim_calls.append((research_space_id, claim_ids))
+        return len(claim_ids)
+
+    def mark_stale_for_claim_relation_ids(
+        self,
+        *,
+        research_space_id: str,
+        relation_ids: list[str],
+    ) -> int:
+        self.relation_calls.append((research_space_id, relation_ids))
+        return len(relation_ids)
+
+
+@dataclass
+class RecordingReasoningPathInvalidation:
+    claim_calls: list[tuple[str, list[str]]] = field(default_factory=list)
+    relation_calls: list[tuple[str, list[str]]] = field(default_factory=list)
+
+    def invalidate_for_claim_ids(
+        self,
+        claim_ids: list[str],
+        research_space_id: str,
+    ) -> int:
+        self.claim_calls.append((research_space_id, claim_ids))
+        return len(claim_ids)
+
+    def invalidate_for_claim_relation_ids(
+        self,
+        relation_ids: list[str],
+        research_space_id: str,
+    ) -> int:
+        self.relation_calls.append((research_space_id, relation_ids))
+        return len(relation_ids)
+
+
+class ClaimRelationRepoStub:
+    def __init__(self, relation: KernelClaimRelation) -> None:
+        self._relation = relation
+
+    def create(
+        self,
+        *,
+        research_space_id: str,
+        source_claim_id: str,
+        target_claim_id: str,
+        relation_type: ClaimRelationType,
+        agent_run_id: str | None,
+        source_document_id: str | None,
+        confidence: float,
+        review_status: ClaimRelationReviewStatus,
+        evidence_summary: str | None,
+        source_document_ref: str | None = None,
+        metadata: JSONObject | None = None,
+    ) -> KernelClaimRelation:
+        del (
+            research_space_id,
+            source_claim_id,
+            target_claim_id,
+            relation_type,
+            agent_run_id,
+            source_document_id,
+            confidence,
+            review_status,
+            evidence_summary,
+            source_document_ref,
+            metadata,
+        )
+        return self._relation
+
+    def get_by_id(self, _relation_id: str) -> KernelClaimRelation | None:
+        return self._relation
+
+    def find_by_claim_ids(
+        self,
+        _research_space_id: str,
+        _claim_ids: list[str],
+        *,
+        limit: int | None = None,
+    ) -> list[KernelClaimRelation]:
+        del limit
+        return [self._relation]
+
+    def find_by_research_space(
+        self,
+        research_space_id: str,
+        *,
+        relation_type: ClaimRelationType | None = None,
+        review_status: ClaimRelationReviewStatus | None = None,
+        source_claim_id: str | None = None,
+        target_claim_id: str | None = None,
+        claim_id: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[KernelClaimRelation]:
+        del (
+            research_space_id,
+            relation_type,
+            review_status,
+            source_claim_id,
+            target_claim_id,
+            claim_id,
+            limit,
+            offset,
+        )
+        return [self._relation]
+
+    def count_by_research_space(
+        self,
+        research_space_id: str,
+        *,
+        relation_type: ClaimRelationType | None = None,
+        review_status: ClaimRelationReviewStatus | None = None,
+        source_claim_id: str | None = None,
+        target_claim_id: str | None = None,
+        claim_id: str | None = None,
+    ) -> int:
+        del (
+            research_space_id,
+            relation_type,
+            review_status,
+            source_claim_id,
+            target_claim_id,
+            claim_id,
+        )
+        return 1
+
+    def update_review_status(
+        self,
+        _relation_id: str,
+        *,
+        review_status: ClaimRelationReviewStatus,
+    ) -> KernelClaimRelation:
+        return self._relation.model_copy(update={"review_status": review_status})
+
+
+class RelationClaimRepoStub:
+    def __init__(self, claim: KernelRelationClaim) -> None:
+        self._claim = claim
+
+    def get_by_id(self, _claim_id: str) -> KernelRelationClaim | None:
+        return self._claim
+
+    def list_by_ids(self, _claim_ids: list[str]) -> list[KernelRelationClaim]:
+        return [self._claim]
+
+    def find_by_linked_relation_ids(
+        self,
+        *,
+        research_space_id: str,
+        linked_relation_ids: list[str],
+    ) -> list[KernelRelationClaim]:
+        del research_space_id, linked_relation_ids
+        return [self._claim]
+
+    def find_by_research_space(
+        self,
+        research_space_id: str,
+        *,
+        claim_status: RelationClaimStatus | None = None,
+        assertion_class: str | None = None,
+        validation_state: RelationClaimValidationState | None = None,
+        persistability: RelationClaimPersistability | None = None,
+        polarity: RelationClaimPolarity | None = None,
+        source_document_id: str | None = None,
+        relation_type: str | None = None,
+        linked_relation_id: str | None = None,
+        certainty_band: CertaintyBand | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[KernelRelationClaim]:
+        del (
+            research_space_id,
+            claim_status,
+            assertion_class,
+            validation_state,
+            persistability,
+            polarity,
+            source_document_id,
+            relation_type,
+            linked_relation_id,
+            certainty_band,
+            limit,
+            offset,
+        )
+        return [self._claim]
+
+    def count_by_research_space(
+        self,
+        research_space_id: str,
+        *,
+        claim_status: RelationClaimStatus | None = None,
+        assertion_class: str | None = None,
+        validation_state: RelationClaimValidationState | None = None,
+        persistability: RelationClaimPersistability | None = None,
+        polarity: RelationClaimPolarity | None = None,
+        source_document_id: str | None = None,
+        relation_type: str | None = None,
+        linked_relation_id: str | None = None,
+        certainty_band: CertaintyBand | None = None,
+    ) -> int:
+        del (
+            research_space_id,
+            claim_status,
+            assertion_class,
+            validation_state,
+            persistability,
+            polarity,
+            source_document_id,
+            relation_type,
+            linked_relation_id,
+            certainty_band,
+        )
+        return 1
+
+    def find_conflicts_by_research_space(
+        self,
+        research_space_id: str,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[KernelRelationConflictSummary]:
+        del research_space_id, limit, offset
+        return []
+
+    def count_conflicts_by_research_space(self, _research_space_id: str) -> int:
+        return 0
+
+    def update_triage_status(
+        self,
+        _claim_id: str,
+        *,
+        claim_status: RelationClaimStatus,
+        triaged_by: str,
+    ) -> KernelRelationClaim:
+        del triaged_by
+        return self._claim.model_copy(update={"claim_status": claim_status})
+
+    def link_relation(
+        self,
+        _claim_id: str,
+        *,
+        linked_relation_id: str,
+    ) -> KernelRelationClaim:
+        return self._claim.model_copy(update={"linked_relation_id": linked_relation_id})
+
+    def clear_relation_link(self, _claim_id: str) -> KernelRelationClaim:
+        return self._claim.model_copy(update={"linked_relation_id": None})
+
+    def set_system_status(
+        self,
+        _claim_id: str,
+        *,
+        claim_status: RelationClaimStatus,
+    ) -> KernelRelationClaim:
+        return self._claim.model_copy(update={"claim_status": claim_status})
+
+    def create(
+        self,
+        *,
+        research_space_id: str,
+        source_document_id: str | None,
+        agent_run_id: str | None,
+        source_type: str,
+        relation_type: str,
+        target_type: str,
+        source_label: str | None,
+        target_label: str | None,
+        confidence: float,
+        validation_state: RelationClaimValidationState,
+        validation_reason: str | None,
+        persistability: RelationClaimPersistability,
+        assertion_class: str = "SOURCE_BACKED",
+        claim_status: RelationClaimStatus = "OPEN",
+        polarity: RelationClaimPolarity = "UNCERTAIN",
+        claim_text: str | None = None,
+        claim_section: str | None = None,
+        linked_relation_id: str | None = None,
+        source_document_ref: str | None = None,
+        source_ref: str | None = None,
+        metadata: JSONObject | None = None,
+    ) -> KernelRelationClaim:
+        del (
+            research_space_id,
+            source_document_id,
+            agent_run_id,
+            source_type,
+            relation_type,
+            target_type,
+            source_label,
+            target_label,
+            confidence,
+            validation_state,
+            validation_reason,
+            persistability,
+            assertion_class,
+            claim_status,
+            polarity,
+            claim_text,
+            claim_section,
+            linked_relation_id,
+            source_document_ref,
+            source_ref,
+            metadata,
+        )
+        return self._claim
+
+    def get_by_source_ref(
+        self,
+        *,
+        research_space_id: str,
+        source_ref: str,
+    ) -> KernelRelationClaim | None:
+        del research_space_id, source_ref
+        return self._claim
+
+
+def _claim_relation() -> KernelClaimRelation:
+    return KernelClaimRelation(
+        id=uuid4(),
+        research_space_id=uuid4(),
+        source_claim_id=uuid4(),
+        target_claim_id=uuid4(),
+        relation_type="SUPPORTS",
+        confidence=0.9,
+        review_status="ACCEPTED",
+        evidence_summary="test",
+        created_at=datetime.now(UTC),
+    )
+
+
+def _relation_claim() -> KernelRelationClaim:
+    now = datetime.now(UTC)
+    return KernelRelationClaim(
+        id=uuid4(),
+        research_space_id=uuid4(),
+        source_type="GENE",
+        relation_type="ASSOCIATED_WITH",
+        target_type="DISEASE",
+        source_label="MED13",
+        target_label="Developmental delay",
+        confidence=0.8,
+        validation_state="ALLOWED",
+        validation_reason="test",
+        persistability="PERSISTABLE",
+        claim_status="OPEN",
+        polarity="SUPPORT",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_invalidation_marks_claim_paths_stale_and_updates_mechanism_index() -> None:
+    repo = RecordingReasoningPathRepo()
+    dispatcher = RecordingReadModelDispatcher()
+    service = KernelReasoningPathInvalidationService(
+        reasoning_path_repo=repo,
+        read_model_update_dispatcher=dispatcher,
+    )
+
+    count = service.invalidate_for_claim_ids([" claim-a ", "claim-a", ""], "space-1")
+
+    assert count == 1
+    assert repo.claim_calls == [("space-1", ["claim-a"])]
+    assert dispatcher.updates == [
+        GraphReadModelUpdate(
+            model_name="entity_mechanism_paths",
+            trigger=GraphReadModelTrigger.CLAIM_CHANGE,
+            claim_ids=("claim-a",),
+            space_id="space-1",
+        ),
+    ]
+
+
+def test_invalidation_marks_claim_relation_paths_stale() -> None:
+    repo = RecordingReasoningPathRepo()
+    dispatcher = RecordingReadModelDispatcher()
+    service = KernelReasoningPathInvalidationService(
+        reasoning_path_repo=repo,
+        read_model_update_dispatcher=dispatcher,
+    )
+
+    count = service.invalidate_for_claim_relation_ids(
+        ["relation-a", " relation-a "],
+        "space-1",
+    )
+
+    assert count == 1
+    assert repo.relation_calls == [("space-1", ["relation-a"])]
+    assert dispatcher.updates == [
+        GraphReadModelUpdate(
+            model_name="entity_mechanism_paths",
+            trigger=GraphReadModelTrigger.PROJECTION_CHANGE,
+            relation_ids=("relation-a",),
+            space_id="space-1",
+        ),
+    ]
+
+
+def test_claim_relation_service_invalidates_reasoning_paths_on_mutations() -> None:
+    relation = _claim_relation()
+    invalidation = RecordingReasoningPathInvalidation()
+    service = KernelClaimRelationService(
+        ClaimRelationRepoStub(relation),
+        reasoning_path_invalidation_service=invalidation,
+    )
+
+    service.create_claim_relation(
+        research_space_id=str(relation.research_space_id),
+        source_claim_id=str(relation.source_claim_id),
+        target_claim_id=str(relation.target_claim_id),
+        relation_type="SUPPORTS",
+        agent_run_id=None,
+        source_document_id=None,
+        confidence=0.9,
+        review_status="ACCEPTED",
+        evidence_summary="test",
+    )
+    service.update_review_status(str(relation.id), review_status="REJECTED")
+
+    touched_claim_ids = [
+        str(relation.source_claim_id),
+        str(relation.target_claim_id),
+    ]
+    assert invalidation.claim_calls == [
+        (str(relation.research_space_id), touched_claim_ids),
+        (str(relation.research_space_id), touched_claim_ids),
+    ]
+    assert invalidation.relation_calls == [
+        (str(relation.research_space_id), [str(relation.id)]),
+        (str(relation.research_space_id), [str(relation.id)]),
+    ]
+
+
+def test_relation_claim_service_invalidates_reasoning_paths_on_claim_change() -> None:
+    claim = _relation_claim()
+    invalidation = RecordingReasoningPathInvalidation()
+    service = KernelRelationClaimService(
+        RelationClaimRepoStub(claim),
+        read_model_update_dispatcher=NullGraphReadModelUpdateDispatcher(),
+        reasoning_path_invalidation_service=invalidation,
+    )
+
+    service.update_claim_status(
+        str(claim.id),
+        claim_status="RESOLVED",
+        triaged_by=str(uuid4()),
+    )
+
+    assert invalidation.claim_calls == [
+        (str(claim.research_space_id), [str(claim.id)]),
+    ]


### PR DESCRIPTION
## Summary
- centralize reasoning-path invalidation for claim, claim-relation, and projection mutations
- remove route-level reasoning-path refresh glue so graph mutation services own the invariant
- fix FULL_REBUILD read-model dispatch so mechanism-path indexes rebuild correctly
- document the STALE/admin rebuild policy and add regression coverage

## Root Cause
Reasoning-path persistence and admin rebuild endpoints existed, but freshness was enforced unevenly. Some router paths marked affected paths stale, while service-level mutation paths could bypass that behavior. The read-model dispatcher also compared the FULL_REBUILD enum value against the enum name, so compact mechanism-path candidates were not rebuilt on full rebuild updates.

## Validation
- make graph-service-checks
- Claude second-opinion pass; addressed optional invalidation wiring and new-claim-relation invalidation edge case

Closes #42