### PR TITLE
fix(auth): allow owner harness write access

### DIFF
--- a/services/artana_evidence_api/auth.py
+++ b/services/artana_evidence_api/auth.py
@@ -1,8 +1,8 @@
 """Authentication helpers for the standalone harness service.
 
 Platform roles carried by tokens and API keys are intentionally separate from
-research-space membership roles. For example, ``owner`` is a space role checked
-by the space ACL layer, not a valid platform role for ``HarnessUser``.
+research-space membership checks. ``owner`` satisfies the general write gate,
+but access to a specific space is still checked by the space ACL layer.
 """
 
 from __future__ import annotations
@@ -34,9 +34,11 @@ _FALLBACK_DEV_JWT_SECRET = "artana-platform-dev-jwt-secret-change-in-production-
 _TOKEN_ISSUER = "artana-platform"
 _TOKEN_ALGORITHM = "HS256"
 _UNKNOWN_ROLE_LOG_VALUE_MAX_LENGTH = 64
+# Owner is write-equivalent for harness actions, not admin-equivalent.
 _WRITE_ROLES = frozenset(
     {
         "admin",
+        "owner",
         "curator",
         "researcher",
     },
@@ -55,13 +57,10 @@ class HarnessUserStatus(str, Enum):
 
 
 class HarnessUserRole(str, Enum):
-    """Platform role values used by harness authorization checks.
-
-    Space ownership is represented by research-space membership records, not by
-    this platform role enum.
-    """
+    """Role values used by harness authorization checks."""
 
     ADMIN = "admin"
+    OWNER = "owner"
     CURATOR = "curator"
     RESEARCHER = "researcher"
     VIEWER = "viewer"
@@ -388,7 +387,7 @@ def require_harness_write_access(
     if current_user.role.value not in _WRITE_ROLES:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Researcher, curator, or admin role required",
+            detail="Owner, researcher, curator, or admin role required",
         )
     return current_user
 

--- a/services/artana_evidence_api/dependencies.py
+++ b/services/artana_evidence_api/dependencies.py
@@ -273,6 +273,10 @@ def _graph_call_context_for_harness_user(current_user: HarnessUser) -> GraphCall
         role = "admin"
     elif current_user.role == HarnessUserRole.CURATOR:
         role = "curator"
+    elif current_user.role == HarnessUserRole.OWNER:
+        # Space-scoped flows enforce ACLs separately. Graph RLS has no owner
+        # role, so owner callers use the same downstream role as researchers.
+        role = "researcher"
     elif current_user.role == HarnessUserRole.VIEWER:
         role = "viewer"
     else:

--- a/services/artana_evidence_api/openapi.json
+++ b/services/artana_evidence_api/openapi.json
@@ -719,7 +719,8 @@
               "viewer",
               "researcher",
               "curator",
-              "admin"
+              "admin",
+              "owner"
             ],
             "title": "Role",
             "type": "string"

--- a/services/artana_evidence_api/routers/authentication.py
+++ b/services/artana_evidence_api/routers/authentication.py
@@ -147,7 +147,7 @@ class BootstrapApiKeyRequest(BaseModel):
     email: EmailStr
     username: str | None = Field(default=None, min_length=1, max_length=50)
     full_name: str | None = Field(default=None, min_length=1, max_length=100)
-    role: Literal["viewer", "researcher", "curator", "admin"] = "researcher"
+    role: Literal["viewer", "researcher", "curator", "admin", "owner"] = "researcher"
     api_key_name: str = Field(default="Default SDK Key", min_length=1, max_length=100)
     api_key_description: str = Field(default="", max_length=500)
     create_default_space: bool = True

--- a/services/artana_evidence_api/tests/unit/test_app.py
+++ b/services/artana_evidence_api/tests/unit/test_app.py
@@ -8054,7 +8054,8 @@ def test_viewer_can_read_but_cannot_mutate_accessible_space_scoped_routes() -> N
     )
     assert write_response.status_code == 403
     assert (
-        write_response.json()["detail"] == "Researcher, curator, or admin role required"
+        write_response.json()["detail"]
+        == "Owner, researcher, curator, or admin role required"
     )
 
 

--- a/services/artana_evidence_api/tests/unit/test_auth.py
+++ b/services/artana_evidence_api/tests/unit/test_auth.py
@@ -17,7 +17,13 @@ from artana_evidence_api.auth import (
     get_current_harness_user,
     require_harness_write_access,
 )
+from artana_evidence_api.dependencies import (
+    _graph_call_context_for_harness_user,
+    require_harness_space_write_access,
+)
+from artana_evidence_api.identity.local_gateway import LocalIdentityGateway
 from artana_evidence_api.models.user import HarnessUserModel
+from artana_evidence_api.sqlalchemy_stores import SqlAlchemyHarnessResearchSpaceStore
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
@@ -37,13 +43,15 @@ def _request_with_headers(headers: dict[str, str] | None = None) -> Request:
 def test_parse_role_preserves_platform_roles() -> None:
     assert _parse_role("ADMIN") == HarnessUserRole.ADMIN
     assert _parse_role("admin") == HarnessUserRole.ADMIN
+    assert _parse_role("OWNER") == HarnessUserRole.OWNER
+    assert _parse_role("owner") == HarnessUserRole.OWNER
     assert _parse_role("curator") == HarnessUserRole.CURATOR
     assert _parse_role("researcher") == HarnessUserRole.RESEARCHER
     assert _parse_role("viewer") == HarnessUserRole.VIEWER
     assert _parse_role("service") == HarnessUserRole.SERVICE
 
 
-def test_parse_role_treats_owner_as_invalid_platform_role(
+def test_parse_role_accepts_owner_without_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.WARNING, logger="artana_evidence_api.auth"):
@@ -52,9 +60,8 @@ def test_parse_role_treats_owner_as_invalid_platform_role(
             context="test subject 11111111-1111-1111-1111-111111111111",
         )
 
-    assert role == HarnessUserRole.VIEWER
-    assert "Unknown harness platform role 'owner' from test subject" in caplog.text
-    assert "falling back to viewer" in caplog.text
+    assert role == HarnessUserRole.OWNER
+    assert "Unknown harness platform role" not in caplog.text
 
 
 def test_parse_role_warns_on_non_string_role_claim(
@@ -156,7 +163,7 @@ async def test_get_current_harness_user_accepts_platform_access_token(
 
 
 @pytest.mark.asyncio
-async def test_owner_platform_role_claim_falls_back_to_viewer_and_fails_write_access(
+async def test_owner_platform_role_claim_passes_harness_write_access(
     monkeypatch: pytest.MonkeyPatch,
     db_session: Session,
     caplog: pytest.LogCaptureFixture,
@@ -168,6 +175,9 @@ async def test_owner_platform_role_claim_falls_back_to_viewer_and_fails_write_ac
             "role": "owner",
             "type": "access",
             "iss": "artana-platform",
+            "email": "owner@example.com",
+            "username": "owner",
+            "full_name": "Owner",
             "iat": datetime.now(UTC),
             "exp": datetime.now(UTC) + timedelta(minutes=15),
         },
@@ -185,14 +195,171 @@ async def test_owner_platform_role_claim_falls_back_to_viewer_and_fails_write_ac
             session=db_session,
         )
 
-    assert user.role == HarnessUserRole.VIEWER
-    assert "Unknown harness platform role 'owner'" in caplog.text
-    assert "access token subject 11111111-1111-1111-1111-111111111111" in caplog.text
+    assert user.role == HarnessUserRole.OWNER
+    assert "Unknown harness platform role" not in caplog.text
+    assert require_harness_write_access(current_user=user) == user
+
+
+def test_owner_role_still_uses_real_space_membership_for_space_write_access(
+    db_session: Session,
+) -> None:
+    owner_id = UUID("11111111-1111-1111-1111-111111111111")
+    target_owner_id = UUID("22222222-2222-2222-2222-222222222222")
+    store = SqlAlchemyHarnessResearchSpaceStore(db_session)
+    target_space = store.create_space(
+        owner_id=target_owner_id,
+        owner_email="target-owner@example.com",
+        owner_username="target-owner",
+        owner_role="researcher",
+        name="Other Space",
+        description="Owned by a different user",
+    )
+    db_session.add(
+        HarnessUserModel(
+            id=owner_id,
+            email="owner@example.com",
+            username="owner",
+            full_name="Owner",
+            hashed_password="external-auth-not-applicable",
+            role="owner",
+            status="active",
+            email_verified=True,
+            login_attempts=0,
+        ),
+    )
+    db_session.commit()
+    store.add_member(
+        space_id=target_space.id,
+        user_id=owner_id,
+        role="viewer",
+    )
+    identity_gateway = LocalIdentityGateway(
+        session=db_session,
+        research_space_store=store,
+    )
+    current_user = HarnessUser(
+        id=owner_id,
+        email="owner@example.com",
+        username="owner",
+        full_name="Owner",
+        role=HarnessUserRole.OWNER,
+        status=HarnessUserStatus.ACTIVE,
+    )
+
+    decision = identity_gateway.check_space_access(
+        space_id=UUID(target_space.id),
+        user_id=current_user.id,
+        is_platform_admin=False,
+        is_service_user=False,
+        minimum_role="researcher",
+    )
+    assert require_harness_write_access(current_user=current_user) == current_user
+    assert decision.allowed is False
+    assert decision.actual_role == "viewer"
     with pytest.raises(HTTPException) as exc_info:
-        require_harness_write_access(current_user=user)
+        require_harness_space_write_access(
+            space_id=UUID(target_space.id),
+            current_user=current_user,
+            identity_gateway=identity_gateway,
+        )
 
     assert exc_info.value.status_code == 403
-    assert exc_info.value.detail == "Researcher, curator, or admin role required"
+    assert "has role 'viewer'" in exc_info.value.detail
+
+
+def test_owner_role_with_owner_membership_passes_real_space_write_access(
+    db_session: Session,
+) -> None:
+    owner_id = UUID("11111111-1111-1111-1111-111111111111")
+    store = SqlAlchemyHarnessResearchSpaceStore(db_session)
+    owned_space = store.create_space(
+        owner_id=owner_id,
+        owner_email="owner@example.com",
+        owner_username="owner",
+        owner_role="owner",
+        name="Owned Space",
+        description="Owned by the caller",
+    )
+    identity_gateway = LocalIdentityGateway(
+        session=db_session,
+        research_space_store=store,
+    )
+    current_user = HarnessUser(
+        id=owner_id,
+        email="owner@example.com",
+        username="owner",
+        full_name="Owner",
+        role=HarnessUserRole.OWNER,
+        status=HarnessUserStatus.ACTIVE,
+    )
+
+    decision = identity_gateway.check_space_access(
+        space_id=UUID(owned_space.id),
+        user_id=current_user.id,
+        is_platform_admin=False,
+        is_service_user=False,
+        minimum_role="researcher",
+    )
+
+    assert decision.allowed is True
+    assert decision.actual_role == "owner"
+    assert (
+        require_harness_space_write_access(
+            space_id=UUID(owned_space.id),
+            current_user=current_user,
+            identity_gateway=identity_gateway,
+        )
+        == current_user
+    )
+
+
+def test_owner_role_without_membership_cannot_see_space_for_write_access(
+    db_session: Session,
+) -> None:
+    owner_id = UUID("11111111-1111-1111-1111-111111111111")
+    target_owner_id = UUID("22222222-2222-2222-2222-222222222222")
+    store = SqlAlchemyHarnessResearchSpaceStore(db_session)
+    target_space = store.create_space(
+        owner_id=target_owner_id,
+        owner_email="target-owner@example.com",
+        owner_username="target-owner",
+        owner_role="researcher",
+        name="Hidden Space",
+        description="No membership for the platform owner",
+    )
+    identity_gateway = LocalIdentityGateway(
+        session=db_session,
+        research_space_store=store,
+    )
+    current_user = HarnessUser(
+        id=owner_id,
+        email="owner@example.com",
+        username="owner",
+        full_name="Owner",
+        role=HarnessUserRole.OWNER,
+        status=HarnessUserStatus.ACTIVE,
+    )
+
+    decision = identity_gateway.check_space_access(
+        space_id=UUID(target_space.id),
+        user_id=current_user.id,
+        is_platform_admin=False,
+        is_service_user=False,
+        minimum_role="researcher",
+    )
+
+    assert decision.allowed is False
+    assert decision.space is None
+    assert decision.actual_role is None
+    with pytest.raises(HTTPException) as exc_info:
+        require_harness_space_write_access(
+            space_id=UUID(target_space.id),
+            current_user=current_user,
+            identity_gateway=identity_gateway,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Space not found"
 
 
 @pytest.mark.asyncio
@@ -333,6 +500,64 @@ async def test_get_current_harness_user_accepts_artana_api_key(
     assert user.role == HarnessUserRole.RESEARCHER
 
 
+@pytest.mark.asyncio
+async def test_get_current_harness_user_accepts_owner_api_key(
+    db_session: Session,
+) -> None:
+    user_id = uuid4()
+    db_session.add(
+        HarnessUserModel(
+            id=user_id,
+            email="owner-api-key-user@example.com",
+            username="owner-api-key-user",
+            full_name="Owner API Key User",
+            hashed_password="external-auth-not-applicable",
+            role="owner",
+            status="active",
+            email_verified=True,
+            login_attempts=0,
+        ),
+    )
+    db_session.commit()
+    issued_key = issue_api_key(
+        db_session,
+        user_id=user_id,
+        name="Owner SDK Key",
+    )
+    request = _request_with_headers({"X-Artana-Key": issued_key.raw_key})
+
+    user = await get_current_harness_user(
+        request,
+        api_key=issued_key.raw_key,
+        credentials=None,
+        session=db_session,
+    )
+
+    assert user.id == user_id
+    assert user.role == HarnessUserRole.OWNER
+    assert require_harness_write_access(current_user=user) == user
+    persisted_user = db_session.get(HarnessUserModel, user.id)
+    assert persisted_user is not None
+    assert persisted_user.role == "owner"
+
+
+def test_owner_role_maps_to_researcher_graph_call_context() -> None:
+    current_user = HarnessUser(
+        id=UUID("11111111-1111-1111-1111-111111111111"),
+        email="owner@example.com",
+        username="owner",
+        full_name="Owner",
+        role=HarnessUserRole.OWNER,
+        status=HarnessUserStatus.ACTIVE,
+    )
+
+    call_context = _graph_call_context_for_harness_user(current_user)
+
+    assert call_context.user_id == str(current_user.id)
+    assert call_context.role == "researcher"
+    assert call_context.graph_admin is False
+
+
 def test_require_harness_write_access_rejects_viewer_role() -> None:
     with pytest.raises(HTTPException) as exc_info:
         require_harness_write_access(
@@ -347,4 +572,7 @@ def test_require_harness_write_access_rejects_viewer_role() -> None:
         )
 
     assert exc_info.value.status_code == 403
-    assert exc_info.value.detail == "Researcher, curator, or admin role required"
+    assert (
+        exc_info.value.detail
+        == "Owner, researcher, curator, or admin role required"
+    )

--- a/services/artana_evidence_api/tests/unit/test_authentication_router.py
+++ b/services/artana_evidence_api/tests/unit/test_authentication_router.py
@@ -98,6 +98,58 @@ def test_bootstrap_route_issues_api_key_and_default_space(
         assert create_key_payload["api_key"]["api_key"].startswith("art_sk_")
 
 
+def test_bootstrap_route_accepts_owner_role_api_key(
+    db_session: Session,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(
+        "ARTANA_EVIDENCE_API_BOOTSTRAP_KEY",
+        "bootstrap-secret",
+    )
+    app = create_app()
+    app.dependency_overrides[get_session] = lambda: db_session
+    app.dependency_overrides[get_research_space_store] = (
+        lambda: SqlAlchemyHarnessResearchSpaceStore(db_session)
+    )
+
+    with TestClient(app) as client:
+        bootstrap_response = client.post(
+            "/v1/auth/bootstrap",
+            headers={"X-Artana-Bootstrap-Key": "bootstrap-secret"},
+            json={
+                "email": "owner@example.com",
+                "username": "owner",
+                "full_name": "Owner Example",
+                "role": "owner",
+                "api_key_name": "Owner SDK Key",
+                "create_default_space": True,
+            },
+        )
+
+        assert bootstrap_response.status_code == 201
+        bootstrap_payload = bootstrap_response.json()
+        issued_api_key = bootstrap_payload["api_key"]["api_key"]
+        me_response = client.get(
+            "/v1/auth/me",
+            headers={"X-Artana-Key": issued_api_key},
+        )
+        tester_response = client.post(
+            "/v1/auth/testers",
+            headers={"X-Artana-Key": issued_api_key},
+            json={"email": "tester@example.com"},
+        )
+
+    assert bootstrap_payload["user"]["role"] == "owner"
+    assert bootstrap_payload["api_key"]["name"] == "Owner SDK Key"
+    assert bootstrap_payload["default_space"]["role"] == "owner"
+    assert me_response.status_code == 200
+    assert me_response.json()["user"]["role"] == "owner"
+    assert tester_response.status_code == 403
+    assert (
+        tester_response.json()["detail"] == "Admin role required to create tester users"
+    )
+
+
 def test_bootstrap_route_rejects_missing_bootstrap_key_when_configured(
     db_session: Session,
     monkeypatch,
@@ -299,6 +351,28 @@ def test_non_admin_cannot_create_tester_user(
         headers={"X-Artana-Key": api_key},
         json={"email": "tester@example.com"},
     )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin role required to create tester users"
+
+
+def test_owner_jwt_cannot_create_tester_user(db_session: Session) -> None:
+    app = create_app()
+    app.dependency_overrides[get_session] = lambda: db_session
+    app.dependency_overrides[get_research_space_store] = (
+        lambda: SqlAlchemyHarnessResearchSpaceStore(db_session)
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/auth/testers",
+            headers=_jwt_auth_headers(
+                user_id="11111111-1111-1111-1111-111111111111",
+                email="owner@example.com",
+                role="owner",
+            ),
+            json={"email": "tester@example.com"},
+        )
 
     assert response.status_code == 403
     assert response.json()["detail"] == "Admin role required to create tester users"

--- a/services/artana_evidence_api/tests/unit/test_spaces_router.py
+++ b/services/artana_evidence_api/tests/unit/test_spaces_router.py
@@ -394,16 +394,17 @@ def test_delete_space_rejects_non_owners() -> None:
         description="Owned by another researcher.",
     )
 
-    response = client.delete(
-        f"/v1/spaces/{record.id}",
-        headers=_auth_headers(role="researcher"),
-    )
+    for role in ("researcher", "owner"):
+        response = client.delete(
+            f"/v1/spaces/{record.id}",
+            headers=_auth_headers(role=role),
+        )
 
-    assert response.status_code == 403
-    assert (
-        response.json()["detail"]
-        == "Only the space owner or an admin can delete this space"
-    )
+        assert response.status_code == 403
+        assert (
+            response.json()["detail"]
+            == "Only the space owner or an admin can delete this space"
+        )
 
 
 def test_delete_space_requires_confirmation_for_non_empty_spaces() -> None:


### PR DESCRIPTION
## Summary
- Treat owner as a valid Evidence API harness role for general write access instead of demoting it to viewer
- Keep owner scoped by real research-space ACLs, including negative coverage for other-space and no-membership cases
- Fix the same role-vocabulary drift in bootstrap so owner API keys can be issued intentionally, while owner remains non-admin for tester creation
- Refresh the Evidence API OpenAPI artifact

## Validation
- venv/bin/python3 -m pytest services/artana_evidence_api/tests/unit/test_authentication_router.py::test_bootstrap_route_accepts_owner_role_api_key services/artana_evidence_api/tests/unit/test_authentication_router.py::test_owner_jwt_cannot_create_tester_user services/artana_evidence_api/tests/unit/test_auth.py
- make artana-evidence-api-service-checks
- Claude second-opinion pass reviewed the owner-role and bootstrap drift changes

Closes #25