### PR TITLE
fix: harden extraction gene ambiguity handling

### DIFF
--- a/services/artana_evidence_api/document_extraction_entities.py
+++ b/services/artana_evidence_api/document_extraction_entities.py
@@ -30,8 +30,16 @@ _TRAILING_CONTEXT_RE = re.compile(
 _PARENTHETICAL_SUFFIX_RE = re.compile(r"\s*\([^)]*\)\s*$")
 _ENTITY_LABEL_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9+./_-]*")
 _GENE_SYMBOL_RE = re.compile(r"\b([A-Z][A-Z0-9]{1,9}(?:[/-][A-Z0-9]+)?)\b")
+_GENE_SYMBOL_TOKEN_RE = re.compile(r"\b([A-Za-z][A-Za-z0-9]{1,9})\b")
+_GENE_SYMBOL_SLASH_SHORTHAND_RE = re.compile(
+    r"\b([A-Z]{2,}[A-Z0-9]*?)(\d+[A-Z]?)/(\d+[A-Z]?)\b",
+    re.IGNORECASE,
+)
+_GENE_SYMBOL_LIST_RE = re.compile(r"(?:\b(?:and|or|versus|vs)\b|[,/])", re.IGNORECASE)
 _MIN_COMPOUND_SEGMENT_TOKEN_COUNT = 2
 _MIN_EXACT_SPLIT_MATCH_COUNT = 2
+_MIN_AMBIGUOUS_GENE_SYMBOL_COUNT = 2
+_MIN_GENE_SYMBOL_FAMILY_CHARS = 3
 _SUBJECT_CONTEXT_MARKERS = (
     " that ",
     " showed ",
@@ -176,6 +184,8 @@ def clean_llm_entity_label(raw: str) -> str:
     """Clean an LLM-generated entity label to a short canonical name."""
 
     label = raw.strip().strip(".,;:\"'")
+    if _is_ambiguous_gene_symbol_mention(label):
+        return ""
     words = label.split()
     if (
         len(words) <= _MAX_ENTITY_LABEL_WORDS
@@ -249,6 +259,8 @@ def canonical_entity_label_rejection_reason(label: str) -> str | None:
         reason = "sentence_fragment_punctuation"
     elif not tokens:
         reason = "empty_entity_label"
+    elif _is_ambiguous_gene_symbol_mention(normalized_label):
+        reason = "ambiguous_gene_symbol_mention"
     elif len(tokens) > _MAX_CANONICAL_ENTITY_LABEL_TOKENS:
         reason = "entity_label_too_long"
     elif len(tokens) == 1 and tokens[0] in _STANDALONE_FRAGMENT_TOKENS:
@@ -309,7 +321,9 @@ def split_compound_entity_label(
     """Split compound object labels only when the split is likely intentional."""
 
     base_label = clean_candidate_label(label)
-    segments, contains_comma, contains_conjunction = _segment_compound_label(label)
+    segments, contains_comma, contains_and, contains_or = _segment_compound_label(
+        label,
+    )
     cleaned_segments: list[str] = []
     seen_labels: set[str] = set()
     for segment in segments:
@@ -321,36 +335,65 @@ def split_compound_entity_label(
             continue
         seen_labels.add(normalized_segment)
         cleaned_segments.append(cleaned_segment)
-    if len(cleaned_segments) <= 1:
-        if base_label != "":
-            return (base_label,)
-        return tuple(cleaned_segments)
-    if contains_comma:
-        return tuple(cleaned_segments)
-    if contains_conjunction and (
-        all(
-            _token_count(segment) >= _MIN_COMPOUND_SEGMENT_TOKEN_COUNT
-            for segment in cleaned_segments
+    if len(cleaned_segments) <= 1 or contains_or:
+        return _base_or_cleaned_entity_labels(
+            base_label=base_label,
+            cleaned_segments=cleaned_segments,
         )
-        or _count_exact_entity_matches(
-            space_id=space_id,
-            labels=cleaned_segments,
-            graph_api_gateway=graph_api_gateway,
-        )
-        >= _MIN_EXACT_SPLIT_MATCH_COUNT
+    if contains_comma or _should_split_conjunction_label(
+        space_id=space_id,
+        cleaned_segments=cleaned_segments,
+        contains_and=contains_and,
+        graph_api_gateway=graph_api_gateway,
     ):
         return tuple(cleaned_segments)
+    return _base_or_cleaned_entity_labels(
+        base_label=base_label,
+        cleaned_segments=cleaned_segments,
+    )
+
+
+def _base_or_cleaned_entity_labels(
+    *,
+    base_label: str,
+    cleaned_segments: list[str],
+) -> tuple[str, ...]:
     if base_label != "":
         return (base_label,)
     return tuple(cleaned_segments)
 
 
-def _segment_compound_label(label: str) -> tuple[list[str], bool, bool]:
+def _should_split_conjunction_label(
+    *,
+    space_id: UUID,
+    cleaned_segments: list[str],
+    contains_and: bool,
+    graph_api_gateway: GraphTransportBundle,
+) -> bool:
+    if not contains_and:
+        return False
+    if all(
+        _token_count(segment) >= _MIN_COMPOUND_SEGMENT_TOKEN_COUNT
+        for segment in cleaned_segments
+    ):
+        return True
+    return (
+        _count_exact_entity_matches(
+            space_id=space_id,
+            labels=cleaned_segments,
+            graph_api_gateway=graph_api_gateway,
+        )
+        >= _MIN_EXACT_SPLIT_MATCH_COUNT
+    )
+
+
+def _segment_compound_label(label: str) -> tuple[list[str], bool, bool, bool]:
     segments: list[str] = []
     current: list[str] = []
     parentheses_depth = 0
     contains_comma = False
-    contains_conjunction = False
+    contains_and = False
+    contains_or = False
     index = 0
     while index < len(label):
         character = label[index]
@@ -378,7 +421,7 @@ def _segment_compound_label(label: str) -> tuple[list[str], bool, bool]:
             if segment != "":
                 segments.append(segment)
             current = []
-            contains_conjunction = True
+            contains_and = True
             index += len(" and ")
             continue
         if parentheses_depth == 0 and normalized_tail.startswith(" or "):
@@ -386,7 +429,7 @@ def _segment_compound_label(label: str) -> tuple[list[str], bool, bool]:
             if segment != "":
                 segments.append(segment)
             current = []
-            contains_conjunction = True
+            contains_or = True
             index += len(" or ")
             continue
         current.append(character)
@@ -394,7 +437,93 @@ def _segment_compound_label(label: str) -> tuple[list[str], bool, bool]:
     final_segment = "".join(current).strip()
     if final_segment != "":
         segments.append(final_segment)
-    return segments, contains_comma, contains_conjunction
+    return segments, contains_comma, contains_and, contains_or
+
+
+def _is_ambiguous_gene_symbol_mention(label: str) -> bool:
+    if _GENE_SYMBOL_LIST_RE.search(label) is None:
+        return False
+
+    symbols = _collect_gene_symbol_mentions(label)
+    if len(symbols) < _MIN_AMBIGUOUS_GENE_SYMBOL_COUNT:
+        return False
+
+    return _contains_similar_gene_symbol_pair(symbols)
+
+
+def _collect_gene_symbol_mentions(label: str) -> tuple[str, ...]:
+    symbols: list[str] = []
+    seen_symbols: set[str] = set()
+
+    for match in _GENE_SYMBOL_SLASH_SHORTHAND_RE.finditer(label):
+        prefix = match.group(1)
+        for suffix in (match.group(2), match.group(3)):
+            _append_gene_symbol(
+                symbols=symbols,
+                seen_symbols=seen_symbols,
+                symbol=f"{prefix}{suffix}",
+            )
+
+    for match in _GENE_SYMBOL_TOKEN_RE.finditer(label):
+        _append_gene_symbol(
+            symbols=symbols,
+            seen_symbols=seen_symbols,
+            symbol=match.group(1),
+        )
+
+    return tuple(symbols)
+
+
+def _append_gene_symbol(
+    *,
+    symbols: list[str],
+    seen_symbols: set[str],
+    symbol: str,
+) -> None:
+    if not _is_gene_symbol_like_token(symbol):
+        return
+    normalized_symbol = symbol.casefold()
+    if normalized_symbol in _GENE_SYMBOL_STOPWORDS:
+        return
+    if normalized_symbol in seen_symbols:
+        return
+    seen_symbols.add(normalized_symbol)
+    symbols.append(symbol.upper())
+
+
+def _is_gene_symbol_like_token(symbol: str) -> bool:
+    return symbol.isupper() or (
+        any(character.isupper() for character in symbol)
+        and any(character.isdigit() for character in symbol)
+    )
+
+
+def _contains_similar_gene_symbol_pair(symbols: tuple[str, ...]) -> bool:
+    for left_index, left_symbol in enumerate(symbols):
+        for right_symbol in symbols[left_index + 1 :]:
+            if _are_similar_gene_symbols(left_symbol, right_symbol):
+                return True
+    return False
+
+
+def _are_similar_gene_symbols(left_symbol: str, right_symbol: str) -> bool:
+    if left_symbol == right_symbol:
+        return False
+
+    shorter, longer = sorted((left_symbol, right_symbol), key=len)
+    if len(shorter) >= _MIN_GENE_SYMBOL_FAMILY_CHARS and longer.startswith(shorter):
+        return True
+
+    left_stem = _gene_symbol_family_stem(left_symbol)
+    right_stem = _gene_symbol_family_stem(right_symbol)
+    return left_stem != "" and left_stem == right_stem
+
+
+def _gene_symbol_family_stem(symbol: str) -> str:
+    stem = re.sub(r"\d+[A-Z]*$", "", symbol)
+    if len(stem) < _MIN_GENE_SYMBOL_FAMILY_CHARS:
+        return ""
+    return stem
 
 
 def _token_count(label: str) -> int:

--- a/services/artana_evidence_api/tests/unit/test_document_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction.py
@@ -1085,6 +1085,66 @@ async def test_pre_resolve_entities_with_ai_caps_ai_budget(
 
 
 @pytest.mark.asyncio
+async def test_pre_resolve_entities_with_ai_skips_ambiguous_gene_family_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    exact_labels: list[str] = []
+    ai_labels: list[str] = []
+
+    def _fake_exact_match(*, space_id, label: str, graph_api_gateway):
+        del space_id, graph_api_gateway
+        exact_labels.append(label)
+
+    async def _fake_resolve_entity_with_ai(
+        *,
+        space_id,
+        label: str,
+        graph_api_gateway,
+        space_context: str = "",
+    ) -> dict[str, str] | None:
+        del space_id, graph_api_gateway, space_context
+        ai_labels.append(label)
+        return {
+            "id": f"resolved:{label}",
+            "display_label": f"{label} resolved",
+        }
+
+    monkeypatch.setattr(
+        document_extraction,
+        "resolve_exact_entity_label",
+        _fake_exact_match,
+    )
+    monkeypatch.setattr(
+        document_extraction,
+        "_resolve_entity_label_with_ai",
+        _fake_resolve_entity_with_ai,
+    )
+
+    resolved = await pre_resolve_entities_with_ai(
+        space_id=uuid4(),
+        candidates=[
+            ExtractedRelationCandidate(
+                subject_label="MED13 or MED13L",
+                relation_type="ASSOCIATED_WITH",
+                object_label="developmental disorder",
+                sentence="MED13 or MED13L was associated with developmental disorder.",
+            ),
+        ],
+        graph_api_gateway=_EmptyGraphApiGateway(),
+        space_context="Investigate MED13 family disorder evidence.",
+    )
+
+    assert exact_labels == ["developmental disorder"]
+    assert ai_labels == ["developmental disorder"]
+    assert resolved == {
+        "developmental disorder": {
+            "id": "resolved:developmental disorder",
+            "display_label": "developmental disorder resolved",
+        },
+    }
+
+
+@pytest.mark.asyncio
 async def test_pre_resolve_entities_with_ai_times_out_and_falls_back(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/services/artana_evidence_api/tests/unit/test_document_extraction_modules.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction_modules.py
@@ -217,6 +217,9 @@ def test_entity_helpers_clean_split_and_resolve_labels() -> None:
 
     assert clean_candidate_label("mutation in MED13 in patients") == "MED13"
     assert clean_llm_entity_label("Inherited pathogenic variants in BRCA1") == "BRCA1"
+    assert clean_llm_entity_label("Inherited variants in MED13 or MED13L") == ""
+    assert clean_llm_entity_label("Inherited variants in Med13 or MED13L") == ""
+    assert clean_llm_entity_label("BRCA1/2") == ""
     assert clean_llm_entity_label("were") == ""
     assert clean_llm_entity_label("Some features are common between conditions") == ""
     assert clean_llm_entity_label("and MED13L are now all") == "MED13L"
@@ -235,6 +238,26 @@ def test_entity_helpers_clean_split_and_resolve_labels() -> None:
     assert require_match_display_label(resolved) == "EGFR"
     assert require_match_id(resolved) != ""
 
+    gene_gateway = _GraphGateway(
+        {
+            "MED13": {
+                "id": uuid4(),
+                "display_label": "MED13",
+                "aliases": [],
+            },
+            "MED13L": {
+                "id": uuid4(),
+                "display_label": "MED13L",
+                "aliases": [],
+            },
+        },
+    )
+    assert split_compound_entity_label(
+        space_id=space_id,
+        label="MED13 or MED13L",
+        graph_api_gateway=gene_gateway,
+    ) == ("MED13 or MED13L",)
+
 
 @pytest.mark.parametrize(
     "label",
@@ -247,6 +270,8 @@ def test_entity_helpers_clean_split_and_resolve_labels() -> None:
         "PD-L1",
         "5-FU",
         "1q21",
+        "MED13L",
+        "BRCA2",
         "Cancer associated fibroblasts",
         "BRCA1 regulated genes",
         "T cell effector activity",
@@ -268,6 +293,14 @@ def test_canonical_entity_label_filter_accepts_entity_like_labels(label: str) ->
         ("how the Module", "leading_fragment_token"),
         ("gene expression both positively", "sentence_fragment_modifier"),
         ("Differentially expressed genes", "sentence_fragment_modifier"),
+        ("MED13 or MED13L", "ambiguous_gene_symbol_mention"),
+        ("MED13 and MED13L", "ambiguous_gene_symbol_mention"),
+        ("Med13 or MED13L", "ambiguous_gene_symbol_mention"),
+        ("BRCA1, BRCA2", "ambiguous_gene_symbol_mention"),
+        ("BRCA1/BRCA2", "ambiguous_gene_symbol_mention"),
+        ("BRCA1/2", "ambiguous_gene_symbol_mention"),
+        ("CDK8 and CDK19", "ambiguous_gene_symbol_mention"),
+        ("MED13 vs. MED13L", "ambiguous_gene_symbol_mention"),
     ],
 )
 def test_canonical_entity_label_filter_rejects_fragments(
@@ -276,6 +309,11 @@ def test_canonical_entity_label_filter_rejects_fragments(
 ) -> None:
     assert canonical_entity_label_rejection_reason(label) == reason
     assert not is_canonical_entity_label(label)
+
+
+def test_ambiguous_gene_filter_allows_different_families_joined_with_and() -> None:
+    assert canonical_entity_label_rejection_reason("BRCA1 and TP53") is None
+    assert is_canonical_entity_label("BRCA1 and TP53")
 
 
 def test_regex_extraction_drops_fragmentary_review_sentence_subjects() -> None:
@@ -377,6 +415,29 @@ def test_draft_builder_skips_non_canonical_subject_labels() -> None:
     assert skipped[0]["reason"] == "non_canonical_subject_label"
     assert skipped[0]["label"] == "were"
     assert skipped[0]["label_rejection_reason"] == "standalone_fragment_label"
+
+
+def test_draft_builder_skips_ambiguous_gene_family_subject_labels() -> None:
+    candidate = ExtractedRelationCandidate(
+        subject_label="MED13 or MED13L",
+        relation_type="ASSOCIATED_WITH",
+        object_label="developmental disorder",
+        sentence="MED13 or MED13L was associated with developmental disorder.",
+    )
+
+    drafts, skipped = build_document_extraction_drafts(
+        space_id=uuid4(),
+        document=_document(),
+        candidates=[candidate],
+        graph_api_gateway=_GraphGateway(),
+        review_context=build_document_review_context(),
+    )
+
+    assert drafts == ()
+    assert len(skipped) == 1
+    assert skipped[0]["reason"] == "non_canonical_subject_label"
+    assert skipped[0]["label"] == "MED13 or MED13L"
+    assert skipped[0]["label_rejection_reason"] == "ambiguous_gene_symbol_mention"
 
 
 def test_draft_builder_skips_non_canonical_object_labels() -> None:


### PR DESCRIPTION
## Summary

- Add a general ambiguous gene-family label guard in the evidence API extraction entity helpers.
- Prevent weak alternatives such as `MED13 or MED13L`, `BRCA1/2`, `BRCA1, BRCA2`, and `CDK8 and CDK19` from being collapsed into one confident entity.
- Keep exact/strong single-gene mentions resolvable, and keep `or` alternatives together so draft staging records them as review/skipped labels instead of split confident claims.

## Root Cause

The LLM entity-label cleanup fallback could extract the first gene-like token from an ambiguous phrase, turning weak family/alternative mentions into confident single-gene labels before draft staging or resolution could treat them safely.

## Validation

- `venv/bin/python3 -m pytest services/artana_evidence_api/tests/unit/test_document_extraction_modules.py services/artana_evidence_api/tests/unit/test_document_extraction.py -q`
- `make artana-evidence-api-service-checks`
- `git diff --check`
- Claude second-opinion review run; actionable feedback was incorporated with mixed-case, comma, `vs`, and negative-family regression tests.

Closes #41