### PR TITLE
Add Orphanet direct source plugin

### DIFF
--- a/services/artana_evidence_api/dependencies.py
+++ b/services/artana_evidence_api/dependencies.py
@@ -72,6 +72,7 @@ from artana_evidence_api.source_enrichment_bridges import (
     build_drugbank_gateway,
     build_gnomad_gateway,
     build_mgi_gateway,
+    build_orphanet_gateway,
     build_uniprot_gateway,
     build_zfin_gateway,
 )
@@ -123,6 +124,7 @@ if TYPE_CHECKING:
         ClinVarGatewayProtocol,
         DrugBankGatewayProtocol,
         GnomADGatewayProtocol,
+        OrphanetGatewayProtocol,
         UniProtGatewayProtocol,
     )
     from sqlalchemy.orm import Session
@@ -503,6 +505,14 @@ def get_zfin_source_gateway() -> AllianceGeneGatewayProtocol | None:
     return build_zfin_gateway()
 
 
+def get_orphanet_source_gateway() -> OrphanetGatewayProtocol | None:
+    """Return the Orphanet gateway when ORPHAcodes credentials are configured."""
+
+    if not os.getenv("ORPHACODE_API_KEY"):
+        return None
+    return build_orphanet_gateway()
+
+
 def get_graph_search_runner() -> HarnessGraphSearchRunner:
     """Return the harness-owned graph-search runner."""
     return HarnessGraphSearchRunner()
@@ -628,6 +638,7 @@ __all__ = [
     "get_harness_execution_services",
     "get_identity_gateway",
     "get_mgi_source_gateway",
+    "get_orphanet_source_gateway",
     "get_pubmed_discovery_service",
     "get_pubmed_discovery_service_factory",
     "get_proposal_store",

--- a/services/artana_evidence_api/direct_source_search.py
+++ b/services/artana_evidence_api/direct_source_search.py
@@ -22,6 +22,12 @@ from artana_evidence_api.direct_sources.gnomad import (
     GnomADSourceSearchResponse,
     run_gnomad_direct_search,
 )
+from artana_evidence_api.direct_sources.orphanet import (
+    OrphanetLanguage,
+    OrphanetSourceSearchRequest,
+    OrphanetSourceSearchResponse,
+    run_orphanet_direct_search,
+)
 from artana_evidence_api.models import SourceSearchRunModel
 from artana_evidence_api.pubmed_discovery import AdvancedQueryParameters
 from artana_evidence_api.source_enrichment_bridges import (
@@ -454,6 +460,7 @@ DirectSourceSearchRecord = (
     | ClinicalTrialsSourceSearchResponse
     | MGISourceSearchResponse
     | ZFINSourceSearchResponse
+    | OrphanetSourceSearchResponse
     | MarrvelSourceSearchResponse
 )
 _DirectSourceSearchRecordT = TypeVar(
@@ -1031,6 +1038,7 @@ def _response_model_for_source_key(
         "drugbank": DrugBankSourceSearchResponse,
         "mgi": MGISourceSearchResponse,
         "zfin": ZFINSourceSearchResponse,
+        "orphanet": OrphanetSourceSearchResponse,
         "marrvel": MarrvelSourceSearchResponse,
     }
     return response_models.get(source_key)
@@ -1057,6 +1065,9 @@ __all__ = [
     "MarrvelSourceSearchResponse",
     "MGISourceSearchRequest",
     "MGISourceSearchResponse",
+    "OrphanetLanguage",
+    "OrphanetSourceSearchRequest",
+    "OrphanetSourceSearchResponse",
     "PubMedSourceSearchResponse",
     "SqlAlchemyDirectSourceSearchStore",
     "UniProtSourceSearchRequest",
@@ -1069,6 +1080,7 @@ __all__ = [
     "run_drugbank_direct_search",
     "run_gnomad_direct_search",
     "run_mgi_direct_search",
+    "run_orphanet_direct_search",
     "run_uniprot_direct_search",
     "run_zfin_direct_search",
 ]

--- a/services/artana_evidence_api/direct_sources/orphanet.py
+++ b/services/artana_evidence_api/direct_sources/orphanet.py
@@ -1,0 +1,175 @@
+"""Orphanet direct source-search contracts and runner."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal, Protocol
+from uuid import UUID, uuid4
+
+from artana_evidence_api.direct_sources.capture import (
+    build_direct_search_capture,
+    json_records,
+    single_record_external_id,
+)
+from artana_evidence_api.source_enrichment_bridges import OrphanetGatewayProtocol
+from artana_evidence_api.source_result_capture import SourceResultCapture
+from artana_evidence_api.types.common import JSONObject
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+OrphanetLanguage = Literal["CS", "DE", "EN", "ES", "FR", "IT", "NL", "PL", "PT"]
+
+
+class OrphanetSourceSearchRequest(BaseModel):
+    """Request payload for a direct Orphanet disease lookup."""
+
+    model_config = ConfigDict(strict=True)
+
+    query: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=512,
+        description="Rare-disease name or approximate preferred term to search.",
+    )
+    orphacode: int | None = Field(
+        default=None,
+        ge=1,
+        description="Exact ORPHAcode to fetch from Orphanet.",
+    )
+    language: OrphanetLanguage = Field(
+        default="EN",
+        description="ORPHAcodes API language code.",
+    )
+    max_results: int = Field(default=20, ge=1, le=50)
+
+    @field_validator("query")
+    @classmethod
+    def _normalize_query(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = " ".join(value.split())
+        return normalized or None
+
+    @field_validator("language", mode="before")
+    @classmethod
+    def _normalize_language(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip().upper()
+        return value
+
+    @model_validator(mode="after")
+    def _validate_query_input(self) -> OrphanetSourceSearchRequest:
+        if self.query and self.orphacode is not None:
+            msg = "Provide either query or orphacode, not both"
+            raise ValueError(msg)
+        if self.query or self.orphacode is not None:
+            return self
+        msg = "Provide one of query or orphacode"
+        raise ValueError(msg)
+
+    def query_text(self) -> str:
+        """Return the public query string for capture metadata."""
+
+        return (
+            f"ORPHA:{self.orphacode}"
+            if self.orphacode is not None
+            else self.query or ""
+        )
+
+
+class OrphanetSourceSearchResponse(BaseModel):
+    """Response payload for one captured Orphanet direct search."""
+
+    id: UUID
+    space_id: UUID
+    source_key: Literal["orphanet"] = "orphanet"
+    status: Literal["completed"] = "completed"
+    query: str
+    orphacode: int | None = None
+    language: OrphanetLanguage = "EN"
+    max_results: int
+    fetched_records: int
+    record_count: int
+    records: list[JSONObject] = Field(default_factory=list)
+    created_at: datetime
+    completed_at: datetime
+    source_capture: SourceResultCapture
+
+
+class OrphanetDirectSourceSearchStore(Protocol):
+    """Storage contract needed by the Orphanet direct-source runner."""
+
+    def save(
+        self,
+        record: OrphanetSourceSearchResponse,
+        *,
+        created_by: UUID | str,
+    ) -> OrphanetSourceSearchResponse:
+        """Store an Orphanet direct source-search result."""
+        ...
+
+
+async def run_orphanet_direct_search(
+    *,
+    space_id: UUID,
+    created_by: UUID | str,
+    request: OrphanetSourceSearchRequest,
+    gateway: OrphanetGatewayProtocol,
+    store: OrphanetDirectSourceSearchStore,
+) -> OrphanetSourceSearchResponse:
+    """Fetch Orphanet records and capture them as a direct source search."""
+
+    created_at = datetime.now(UTC)
+    fetch_result = await gateway.fetch_records_async(
+        query=request.query,
+        orphacode=request.orphacode,
+        language=request.language,
+        max_results=request.max_results,
+    )
+    records = json_records(fetch_result.records)
+    completed_at = datetime.now(UTC)
+    search_id = uuid4()
+    query = request.query_text()
+    capture = build_direct_search_capture(
+        source_key="orphanet",
+        search_id=search_id,
+        completed_at=completed_at,
+        query=query,
+        query_payload=request.model_dump(mode="json", exclude_none=True),
+        result_count=len(records),
+        provider="ORPHAcodes API / Orphanet Nomenclature Pack",
+        external_id=single_record_external_id(
+            records,
+            keys=("orphanet_id", "orpha_code", "ORPHAcode"),
+            expected=f"ORPHA:{request.orphacode}"
+            if request.orphacode is not None
+            else None,
+        ),
+        provenance={
+            "language": request.language,
+            "fetched_records": fetch_result.fetched_records,
+        },
+    )
+    result = OrphanetSourceSearchResponse(
+        id=search_id,
+        space_id=space_id,
+        query=query,
+        orphacode=request.orphacode,
+        language=request.language,
+        max_results=request.max_results,
+        fetched_records=fetch_result.fetched_records,
+        record_count=len(records),
+        records=records,
+        created_at=created_at,
+        completed_at=completed_at,
+        source_capture=SourceResultCapture.model_validate(capture),
+    )
+    return store.save(result, created_by=created_by)
+
+
+__all__ = [
+    "OrphanetDirectSourceSearchStore",
+    "OrphanetLanguage",
+    "OrphanetSourceSearchRequest",
+    "OrphanetSourceSearchResponse",
+    "run_orphanet_direct_search",
+]

--- a/services/artana_evidence_api/direct_sources/orphanet_gateway.py
+++ b/services/artana_evidence_api/direct_sources/orphanet_gateway.py
@@ -1,0 +1,349 @@
+"""Service-local Orphanet ORPHAcodes structured-source gateway."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from urllib.parse import quote
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://api.orphacode.org"
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_MAX_RESULTS_LIMIT = 50
+_SUPPORTED_LANGUAGES = frozenset({"CS", "DE", "EN", "ES", "FR", "IT", "NL", "PL", "PT"})
+_USER_AGENT = "artana-evidence-platform/orphanet-gateway"
+
+
+@dataclass(frozen=True)
+class OrphanetGatewayFetchResult:
+    """Result of an Orphanet ORPHAcodes fetch operation."""
+
+    records: list[dict[str, object]] = field(default_factory=list)
+    fetched_records: int = 0
+    checkpoint_after: dict[str, object] | None = None
+    checkpoint_kind: str = "none"
+
+
+class OrphanetGatewayError(RuntimeError):
+    """Raised when a configured Orphanet request cannot be completed."""
+
+
+class OrphanetSourceGateway:
+    """Fetch and normalize rare-disease records from the ORPHAcodes API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str = _DEFAULT_BASE_URL,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._api_key = (
+            api_key if api_key is not None else os.getenv("ORPHACODE_API_KEY")
+        )
+        self._base_url = base_url.rstrip("/")
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def fetch_records(
+        self,
+        *,
+        query: str | None = None,
+        orphacode: int | None = None,
+        language: str = "EN",
+        max_results: int = 20,
+    ) -> OrphanetGatewayFetchResult:
+        """Fetch Orphanet records for a disease query or exact ORPHAcode."""
+
+        return asyncio.run(
+            self.fetch_records_async(
+                query=query,
+                orphacode=orphacode,
+                language=language,
+                max_results=max_results,
+            ),
+        )
+
+    async def fetch_records_async(
+        self,
+        *,
+        query: str | None = None,
+        orphacode: int | None = None,
+        language: str = "EN",
+        max_results: int = 20,
+    ) -> OrphanetGatewayFetchResult:
+        """Fetch Orphanet records from async callers."""
+
+        if not self._api_key:
+            logger.info(
+                "ORPHAcodes API key not configured; set ORPHACODE_API_KEY to "
+                "enable Orphanet structured enrichment.",
+            )
+            return OrphanetGatewayFetchResult()
+        normalized_language = _normalize_language(language)
+        if orphacode is None and not _clean(query):
+            return OrphanetGatewayFetchResult()
+
+        async with self._build_client() as client:
+            if orphacode is not None:
+                record = await self._fetch_summary(
+                    client=client,
+                    language=normalized_language,
+                    orphacode=orphacode,
+                    matched_query=_clean(query),
+                )
+                records = [record] if record is not None else []
+                return OrphanetGatewayFetchResult(
+                    records=records,
+                    fetched_records=len(records),
+                )
+
+            records = await self._search_by_name(
+                client=client,
+                language=normalized_language,
+                query=_clean(query),
+                max_results=max_results,
+            )
+        return OrphanetGatewayFetchResult(records=records, fetched_records=len(records))
+
+    def _build_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=f"{self._base_url}/",
+            headers={
+                "apiKey": self._api_key or "",
+                "User-Agent": _USER_AGENT,
+            },
+            timeout=self._timeout_seconds,
+            transport=self._transport,
+        )
+
+    async def _search_by_name(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        language: str,
+        query: str,
+        max_results: int,
+    ) -> list[dict[str, object]]:
+        encoded_query = quote(query, safe="")
+        payload = await self._get_json(
+            client=client,
+            endpoint=f"{language}/ClinicalEntity/ApproximateName/{encoded_query}",
+        )
+        candidates = _candidate_records(payload)[
+            : max(1, min(max_results, _MAX_RESULTS_LIMIT))
+        ]
+        records: list[dict[str, object]] = []
+        for candidate in candidates:
+            orphacode = _orpha_code(candidate)
+            if orphacode is None:
+                normalized = _normalize_record(candidate, matched_query=query)
+            else:
+                normalized = await self._fetch_summary(
+                    client=client,
+                    language=language,
+                    orphacode=orphacode,
+                    matched_query=query,
+                )
+                if normalized is None:
+                    normalized = _normalize_record(candidate, matched_query=query)
+            if normalized is not None:
+                records.append(normalized)
+        return records
+
+    async def _fetch_summary(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        language: str,
+        orphacode: int,
+        matched_query: str | None,
+    ) -> dict[str, object] | None:
+        payload = await self._get_json(
+            client=client,
+            endpoint=f"{language}/ClinicalEntity/orphacode/{orphacode}",
+        )
+        return _normalize_record(payload, matched_query=matched_query)
+
+    @staticmethod
+    async def _get_json(
+        *,
+        client: httpx.AsyncClient,
+        endpoint: str,
+    ) -> object:
+        try:
+            response = await client.get(endpoint)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            msg = f"ORPHAcodes API request failed for {endpoint}: {exc}"
+            raise OrphanetGatewayError(msg) from exc
+        return response.json()
+
+
+def _candidate_records(payload: object) -> list[dict[str, object]]:
+    if isinstance(payload, list | tuple):
+        return _dict_values(payload)
+    mapping = _dict_value(payload)
+    if mapping is None:
+        return []
+    for key in ("results", "data", "items"):
+        value = mapping.get(key)
+        if isinstance(value, list | tuple):
+            return _dict_values(value)
+    if _orpha_code(mapping) is not None:
+        return [mapping]
+    return []
+
+
+def _normalize_record(
+    payload: object,
+    *,
+    matched_query: str | None,
+) -> dict[str, object] | None:
+    record = _dict_value(payload)
+    if record is None:
+        return None
+    orphacode = _orpha_code(record)
+    preferred_term = _first_string(record, ("Preferred term", "preferred_term", "name"))
+    if orphacode is None and preferred_term is None:
+        return None
+    normalized: dict[str, object] = {
+        "orpha_code": "" if orphacode is None else str(orphacode),
+        "orphanet_id": "" if orphacode is None else f"ORPHA:{orphacode}",
+        "preferred_term": preferred_term or "",
+        "name": preferred_term or "",
+        "synonyms": _string_list(record.get("Synonym") or record.get("synonyms")),
+        "definition": _first_string(record, ("Definition", "definition")) or "",
+        "typology": _first_string(record, ("Typology", "typology")) or "",
+        "status": _first_string(record, ("Status", "status")) or "",
+        "classification_level": _first_string(
+            record,
+            ("ClassificationLevel", "Classification Level", "classification_level"),
+        )
+        or "",
+        "orphanet_url": _first_string(
+            record,
+            ("OrphanetUrl", "OrphanetURL", "orphanet_url"),
+        )
+        or "",
+        "date": _first_string(record, ("Date", "Data", "date")) or "",
+        "matched_query": matched_query or "",
+        "preferential_parent": _parent_record(
+            record.get("Preferential parent") or record.get("Preferential Parent"),
+        ),
+        "source": "orphanet",
+    }
+    return {
+        key: value for key, value in normalized.items() if value not in ("", [], {})
+    }
+
+
+def _parent_record(value: object) -> dict[str, object]:
+    parent = _dict_value(value)
+    if parent is None:
+        return {}
+    orphacode = _orpha_code(parent)
+    preferred_term = _first_string(parent, ("Preferred term", "preferred_term", "name"))
+    payload: dict[str, object] = {
+        "orpha_code": "" if orphacode is None else str(orphacode),
+        "orphanet_id": "" if orphacode is None else f"ORPHA:{orphacode}",
+        "preferred_term": preferred_term or "",
+    }
+    return {key: item for key, item in payload.items() if item}
+
+
+def _dict_values(values: list[object] | tuple[object, ...]) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for item in values:
+        record = _dict_value(item)
+        if record is not None:
+            records.append(record)
+    return records
+
+
+def _dict_value(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    return {str(key): item for key, item in value.items()}
+
+
+def _orpha_code(record: Mapping[str, object]) -> int | None:
+    for key in ("ORPHAcode", "orpha_code", "orphacode", "orphaCode"):
+        value = record.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            return value
+        if isinstance(value, str) and value.strip():
+            digits = value.strip().removeprefix("ORPHA:").removeprefix("ORPHA")
+            if digits.isdigit() and int(digits) > 0:
+                return int(digits)
+    return None
+
+
+def _first_string(
+    mapping: Mapping[str, object],
+    keys: tuple[str, ...],
+) -> str | None:
+    for key in keys:
+        values = _string_list(mapping.get(key))
+        if values:
+            return values[0]
+    return None
+
+
+def _string_list(value: object) -> list[str]:
+    if value is None or isinstance(value, dict | bool):
+        return []
+    if isinstance(value, str):
+        cleaned = _clean(value)
+        return [cleaned] if cleaned else []
+    if isinstance(value, int | float):
+        return [str(value)]
+    if isinstance(value, list | tuple):
+        values: list[str] = []
+        for item in value:
+            values.extend(_string_list(item))
+        return _unique_non_empty(values)
+    return []
+
+
+def _clean(value: str | None) -> str:
+    if value is None:
+        return ""
+    return " ".join(value.split())
+
+
+def _normalize_language(value: str) -> str:
+    normalized = value.strip().upper()
+    if normalized in _SUPPORTED_LANGUAGES:
+        return normalized
+    msg = f"Unsupported ORPHAcodes language '{value}'."
+    raise OrphanetGatewayError(msg)
+
+
+def _unique_non_empty(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        cleaned = _clean(value)
+        if not cleaned:
+            continue
+        key = cleaned.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(cleaned)
+    return result
+
+
+__all__ = [
+    "OrphanetGatewayError",
+    "OrphanetGatewayFetchResult",
+    "OrphanetSourceGateway",
+]

--- a/services/artana_evidence_api/openapi.json
+++ b/services/artana_evidence_api/openapi.json
@@ -9495,6 +9495,170 @@
         "title": "MechanismDiscoveryRunResponse",
         "type": "object"
       },
+      "OrphanetSourceSearchRequest": {
+        "description": "Request payload for a direct Orphanet disease lookup.",
+        "properties": {
+          "language": {
+            "default": "EN",
+            "description": "ORPHAcodes API language code.",
+            "enum": [
+              "CS",
+              "DE",
+              "EN",
+              "ES",
+              "FR",
+              "IT",
+              "NL",
+              "PL",
+              "PT"
+            ],
+            "title": "Language",
+            "type": "string"
+          },
+          "max_results": {
+            "default": 20,
+            "maximum": 50.0,
+            "minimum": 1.0,
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "orphacode": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Exact ORPHAcode to fetch from Orphanet.",
+            "title": "Orphacode"
+          },
+          "query": {
+            "anyOf": [
+              {
+                "maxLength": 512,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Rare-disease name or approximate preferred term to search.",
+            "title": "Query"
+          }
+        },
+        "title": "OrphanetSourceSearchRequest",
+        "type": "object"
+      },
+      "OrphanetSourceSearchResponse": {
+        "description": "Response payload for one captured Orphanet direct search.",
+        "properties": {
+          "completed_at": {
+            "format": "date-time",
+            "title": "Completed At",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "fetched_records": {
+            "title": "Fetched Records",
+            "type": "integer"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "language": {
+            "default": "EN",
+            "enum": [
+              "CS",
+              "DE",
+              "EN",
+              "ES",
+              "FR",
+              "IT",
+              "NL",
+              "PL",
+              "PT"
+            ],
+            "title": "Language",
+            "type": "string"
+          },
+          "max_results": {
+            "title": "Max Results",
+            "type": "integer"
+          },
+          "orphacode": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Orphacode"
+          },
+          "query": {
+            "title": "Query",
+            "type": "string"
+          },
+          "record_count": {
+            "title": "Record Count",
+            "type": "integer"
+          },
+          "records": {
+            "items": {
+              "additionalProperties": {
+                "$ref": "#/components/schemas/JSONValue-Output"
+              },
+              "type": "object"
+            },
+            "title": "Records",
+            "type": "array"
+          },
+          "source_capture": {
+            "$ref": "#/components/schemas/SourceResultCapture"
+          },
+          "source_key": {
+            "const": "orphanet",
+            "default": "orphanet",
+            "title": "Source Key",
+            "type": "string"
+          },
+          "space_id": {
+            "format": "uuid",
+            "title": "Space Id",
+            "type": "string"
+          },
+          "status": {
+            "const": "completed",
+            "default": "completed",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "space_id",
+          "query",
+          "max_results",
+          "fetched_records",
+          "record_count",
+          "created_at",
+          "completed_at",
+          "source_capture"
+        ],
+        "title": "OrphanetSourceSearchResponse",
+        "type": "object"
+      },
       "ProcessHealth": {
         "description": "Health status of a background process.",
         "properties": {
@@ -11017,6 +11181,10 @@
           },
           "mondo": {
             "title": "Mondo",
+            "type": "boolean"
+          },
+          "orphanet": {
+            "title": "Orphanet",
             "type": "boolean"
           },
           "pdf": {
@@ -25370,6 +25538,130 @@
           }
         ],
         "summary": "Get MGI evidence source search",
+        "tags": [
+          "sources"
+        ]
+      }
+    },
+    "/v2/spaces/{space_id}/sources/orphanet/searches": {
+      "post": {
+        "description": "Typed v2 route for Orphanet source search.",
+        "operationId": "create_orphanet_source_search_v2_spaces__space_id__sources_orphanet_searches_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Space Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrphanetSourceSearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrphanetSourceSearchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Search Orphanet evidence source",
+        "tags": [
+          "sources"
+        ]
+      }
+    },
+    "/v2/spaces/{space_id}/sources/orphanet/searches/{search_id}": {
+      "get": {
+        "description": "Typed v2 route for Orphanet source-search lookup.",
+        "operationId": "get_orphanet_source_search_v2_spaces__space_id__sources_orphanet_searches__search_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Space Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "search_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Search Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrphanetSourceSearchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          },
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Orphanet evidence source search",
         "tags": [
           "sources"
         ]

--- a/services/artana_evidence_api/research_init_completion_runtime.py
+++ b/services/artana_evidence_api/research_init_completion_runtime.py
@@ -41,6 +41,7 @@ from artana_evidence_api.research_init_observation_bridge import (
     _append_unique_entity_ids,
     _proposal_payload_entity_ids,
 )
+from artana_evidence_api.source_registry import get_source_definition
 from artana_evidence_api.types.common import (
     JSONObject,
     ResearchSpaceSourcePreferences,
@@ -62,6 +63,7 @@ if TYPE_CHECKING:
 
 _TOTAL_PROGRESS_STEPS = 5
 _MIN_CHASE_ENTITIES = 3
+_CORE_BOOTSTRAP_SOURCE_KEYS = frozenset({"pubmed", "marrvel", "mondo", "pdf", "text"})
 _BootstrapSourceResolver = Callable[..., str | None]
 
 
@@ -71,6 +73,18 @@ def _resolve_bootstrap_source_type(**kwargs: object) -> str | None:
     if candidate is None or candidate is _resolve_bootstrap_source_type:
         candidate = _default_resolve_bootstrap_source_type
     return cast("_BootstrapSourceResolver", candidate)(**kwargs)
+
+
+def _pending_deferred_source_keys(
+    source_results: dict[str, JSONObject],
+) -> tuple[str, ...]:
+    return tuple(
+        source_key
+        for source_key, source_result in source_results.items()
+        if source_key not in _CORE_BOOTSTRAP_SOURCE_KEYS
+        and get_source_definition(source_key) is not None
+        and source_result.get("status") == "pending"
+    )
 
 
 async def _generate_and_store_research_brief(
@@ -511,14 +525,7 @@ async def complete_research_init_run(  # noqa: PLR0912, PLR0913, PLR0915
             errors.append(f"Chase round {chase_round} failed: {exc}")
             break
 
-    for pending_source in (
-        "clinvar",
-        "drugbank",
-        "alphafold",
-        "gnomad",
-        "uniprot",
-        "hgnc",
-    ):
+    for pending_source in _pending_deferred_source_keys(source_results):
         if source_results.get(pending_source, {}).get("status") == "pending":
             source_results[pending_source]["status"] = "deferred"
 

--- a/services/artana_evidence_api/research_init_source_results.py
+++ b/services/artana_evidence_api/research_init_source_results.py
@@ -7,6 +7,7 @@ from typing import cast
 
 from artana_evidence_api.source_plugins.registry import evidence_source_plugin_keys
 from artana_evidence_api.source_registry import (
+    SourceCapability,
     SourceDefinition,
     get_source_definition,
 )
@@ -104,7 +105,7 @@ def build_source_results(
         source_key: _source_result_summary(
             sources=sources,
             source_key=source_key,
-            extra=dict(_SOURCE_RESULT_COUNTERS[source_key]),
+            extra=_source_result_counters(source_key),
         )
         for source_key in registry_source_result_keys()
     }
@@ -141,6 +142,20 @@ def _source_registry_summary(source: SourceDefinition) -> JSONObject:
         "source_result_capture": source.result_capture,
         "proposal_flow": source.proposal_flow,
     }
+
+
+def _source_result_counters(source_key: str) -> JSONObject:
+    counters = _SOURCE_RESULT_COUNTERS.get(source_key)
+    if counters is not None:
+        return dict(counters)
+
+    source = get_source_definition(source_key)
+    if source is None:
+        msg = f"Unknown source key in research-init counters: {source_key}"
+        raise ValueError(msg)
+    if SourceCapability.SEARCH in source.capabilities:
+        return {"records_processed": 0}
+    return {}
 
 
 def registry_source_result_keys() -> tuple[str, ...]:

--- a/services/artana_evidence_api/source_enrichment_bridges.py
+++ b/services/artana_evidence_api/source_enrichment_bridges.py
@@ -143,6 +143,19 @@ class AllianceGeneGatewayProtocol(Protocol):
     ) -> GatewayFetchResultProtocol: ...
 
 
+class OrphanetGatewayProtocol(Protocol):
+    """Orphanet ORPHAcodes gateway contract used by direct source search."""
+
+    async def fetch_records_async(
+        self,
+        *,
+        query: str | None = None,
+        orphacode: int | None = None,
+        language: str = "EN",
+        max_results: int = 20,
+    ) -> GatewayFetchResultProtocol: ...
+
+
 class MarrvelDiscoveryServiceProtocol(Protocol):
     """Local MARRVEL discovery contract used by structured enrichment."""
 
@@ -222,8 +235,27 @@ def build_zfin_gateway() -> AllianceGeneGatewayProtocol | None:
     return cast("AllianceGeneGatewayProtocol", ZFINSourceGateway())
 
 
+def build_orphanet_gateway() -> OrphanetGatewayProtocol | None:
+    """Construct the service-local Orphanet ORPHAcodes gateway."""
+    from artana_evidence_api.direct_sources.orphanet_gateway import (
+        OrphanetSourceGateway,
+    )
+
+    return cast("OrphanetGatewayProtocol", OrphanetSourceGateway())
+
+
 __all__ = [
+    "AllianceGeneGatewayProtocol",
+    "AlphaFoldGatewayProtocol",
+    "ClinicalTrialsGatewayProtocol",
+    "ClinVarGatewayProtocol",
     "ClinVarQueryConfig",
+    "DrugBankGatewayProtocol",
+    "GatewayFetchResultProtocol",
+    "GnomADGatewayProtocol",
+    "MarrvelDiscoveryServiceProtocol",
+    "OrphanetGatewayProtocol",
+    "UniProtGatewayProtocol",
     "build_alphafold_gateway",
     "build_clinicaltrials_gateway",
     "build_clinvar_gateway",
@@ -231,6 +263,7 @@ __all__ = [
     "build_gnomad_gateway",
     "build_marrvel_discovery_service",
     "build_mgi_gateway",
+    "build_orphanet_gateway",
     "build_uniprot_gateway",
     "build_zfin_gateway",
 ]

--- a/services/artana_evidence_api/source_plugins/rare_disease/__init__.py
+++ b/services/artana_evidence_api/source_plugins/rare_disease/__init__.py
@@ -1,0 +1,1 @@
+"""Rare-disease source plugins."""

--- a/services/artana_evidence_api/source_plugins/rare_disease/orphanet.py
+++ b/services/artana_evidence_api/source_plugins/rare_disease/orphanet.py
@@ -1,0 +1,328 @@
+"""Orphanet datasource plugin."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from artana_evidence_api.direct_source_search import (
+    DirectSourceSearchRecord,
+    OrphanetSourceSearchRequest,
+    run_orphanet_direct_search,
+)
+from artana_evidence_api.source_enrichment_bridges import (
+    OrphanetGatewayProtocol,
+    build_orphanet_gateway,
+)
+from artana_evidence_api.source_plugins._helpers import (
+    assert_intent_source_key,
+    assert_search_source_key,
+    compact_json_object,
+    json_value_field,
+    metadata_from_definition,
+    normalized_extraction_payload,
+    planning_payload,
+    proposal_summary,
+    required_text,
+    review_item_summary,
+    string_field,
+)
+from artana_evidence_api.source_plugins.contracts import (
+    EvidenceSelectionSourceSearchError,
+    SourceCandidateContext,
+    SourcePluginMetadata,
+    SourceQueryIntent,
+    SourceReviewPolicy,
+    SourceSearchExecutionContext,
+    SourceSearchInput,
+)
+from artana_evidence_api.source_registry import SourceCapability, SourceDefinition
+from artana_evidence_api.types.common import JSONObject
+
+_ORPHACODE_PATTERN = re.compile(r"^(?:ORPHA:?)?([1-9][0-9]*)$", re.IGNORECASE)
+
+_SOURCE_DEFINITION = SourceDefinition(
+    source_key="orphanet",
+    display_name="Orphanet",
+    description="Rare disease nomenclature and clinical-entity context from Orphanet.",
+    source_family="rare_disease",
+    capabilities=(
+        SourceCapability.SEARCH,
+        SourceCapability.ENRICHMENT,
+        SourceCapability.DOCUMENT_CAPTURE,
+        SourceCapability.PROPOSAL_GENERATION,
+        SourceCapability.RESEARCH_PLAN,
+    ),
+    direct_search_enabled=True,
+    research_plan_enabled=True,
+    default_research_plan_enabled=False,
+    live_network_required=True,
+    requires_credentials=True,
+    credential_names=("ORPHACODE_API_KEY",),
+    request_schema_ref="OrphanetSourceSearchRequest",
+    result_schema_ref="OrphanetSourceSearchResponse",
+    result_capture=(
+        "Orphanet records are captured as direct source-search results with "
+        "ORPHAcodes API provenance."
+    ),
+    proposal_flow=(
+        "Rare-disease nomenclature candidates require curator review before "
+        "graph promotion or MONDO mapping."
+    ),
+)
+_SOURCE_METADATA = metadata_from_definition(_SOURCE_DEFINITION)
+
+_REVIEW_POLICY = SourceReviewPolicy(
+    source_key="orphanet",
+    proposal_type="rare_disease_context_candidate",
+    review_type="rare_disease_source_record_review",
+    evidence_role="rare disease nomenclature context candidate",
+    limitations=(
+        "Orphanet nomenclature is disease context, not treatment or diagnosis advice.",
+        "ORPHAcode matches require curator review before graph promotion.",
+        "Do not infer MONDO mappings from Orphanet records without an explicit mapping layer.",
+    ),
+    normalized_fields=(
+        "orphanet_id",
+        "orpha_code",
+        "preferred_term",
+        "synonyms",
+        "definition",
+        "typology",
+        "status",
+        "classification_level",
+        "orphanet_url",
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OrphanetSourcePlugin:
+    """Source-owned behavior for Orphanet."""
+
+    gateway_factory: (
+        Callable[
+            [],
+            OrphanetGatewayProtocol | None,
+        ]
+        | None
+    ) = None
+
+    @property
+    def source_key(self) -> str:
+        return _SOURCE_DEFINITION.source_key
+
+    @property
+    def source_family(self) -> str:
+        return _SOURCE_DEFINITION.source_family
+
+    @property
+    def display_name(self) -> str:
+        return _SOURCE_DEFINITION.display_name
+
+    @property
+    def direct_search_supported(self) -> bool:
+        return _SOURCE_DEFINITION.direct_search_enabled
+
+    @property
+    def handoff_target_kind(self) -> str:
+        return "source_document"
+
+    @property
+    def request_schema_ref(self) -> str | None:
+        return _SOURCE_DEFINITION.request_schema_ref
+
+    @property
+    def result_schema_ref(self) -> str | None:
+        return _SOURCE_DEFINITION.result_schema_ref
+
+    @property
+    def metadata(self) -> SourcePluginMetadata:
+        return _SOURCE_METADATA
+
+    @property
+    def supported_objective_intents(self) -> tuple[str, ...]:
+        return ("rare disease nomenclature", "disease context")
+
+    @property
+    def result_interpretation_hints(self) -> tuple[str, ...]:
+        return ("Treat ORPHAcodes as nomenclature context pending curator review.",)
+
+    @property
+    def non_goals(self) -> tuple[str, ...]:
+        return ("Do not treat Orphanet lookup results as MONDO mappings.",)
+
+    @property
+    def handoff_eligible(self) -> bool:
+        return True
+
+    @property
+    def review_policy(self) -> SourceReviewPolicy:
+        return _REVIEW_POLICY
+
+    def source_definition(self) -> SourceDefinition:
+        """Return this plugin's public source definition."""
+
+        return _SOURCE_DEFINITION
+
+    def build_query_payload(self, intent: SourceQueryIntent) -> JSONObject:
+        """Build a validated Orphanet direct-search payload."""
+
+        assert_intent_source_key(intent, source_key=self.source_key)
+        query = intent.disease or intent.phenotype or intent.query
+        orphacode = _parse_orphacode(query)
+        if orphacode is not None:
+            payload: JSONObject = {"orphacode": orphacode}
+        else:
+            payload = {
+                "query": required_text(
+                    query,
+                    source_key=self.source_key,
+                    field_name="query",
+                ),
+            }
+        return planning_payload(OrphanetSourceSearchRequest.model_validate(payload))
+
+    def validate_live_search(self, search: SourceSearchInput) -> None:
+        """Validate an Orphanet direct-search payload."""
+
+        _validated_request(search)
+
+    async def run_direct_search(
+        self,
+        *,
+        context: SourceSearchExecutionContext,
+        search: SourceSearchInput,
+    ) -> DirectSourceSearchRecord:
+        """Run an Orphanet direct search through the configured gateway."""
+
+        request = _validated_request(search)
+        gateway = self._gateway()
+        if gateway is None:
+            raise EvidenceSelectionSourceSearchError("Orphanet gateway is unavailable.")
+        return await run_orphanet_direct_search(
+            space_id=context.space_id,
+            created_by=context.created_by,
+            request=request,
+            gateway=gateway,
+            store=context.store,
+        )
+
+    def _gateway(self) -> OrphanetGatewayProtocol | None:
+        factory = self.gateway_factory or build_orphanet_gateway
+        return factory()
+
+    def normalize_record(self, record: JSONObject) -> JSONObject:
+        """Return normalized Orphanet record fields."""
+
+        return compact_json_object(
+            {
+                "orphanet_id": self.provider_external_id(record),
+                "orpha_code": string_field(record, "orpha_code", "ORPHAcode"),
+                "preferred_term": string_field(record, "preferred_term", "name"),
+                "synonyms": json_value_field(record, "synonyms", "Synonym"),
+                "definition": string_field(record, "definition", "Definition"),
+                "typology": string_field(record, "typology", "Typology"),
+                "status": string_field(record, "status", "Status"),
+                "classification_level": string_field(
+                    record,
+                    "classification_level",
+                    "ClassificationLevel",
+                ),
+                "orphanet_url": string_field(
+                    record,
+                    "orphanet_url",
+                    "OrphanetUrl",
+                    "OrphanetURL",
+                ),
+            },
+        )
+
+    def provider_external_id(self, record: JSONObject) -> str | None:
+        """Return the stable ORPHA identifier for one record."""
+
+        orphanet_id = string_field(record, "orphanet_id")
+        if orphanet_id is not None:
+            return orphanet_id
+        orphacode = string_field(record, "orpha_code", "ORPHAcode", "orphacode")
+        return f"ORPHA:{orphacode}" if orphacode is not None else None
+
+    def recommends_variant_aware(self, record: JSONObject) -> bool:
+        """Orphanet records are not variant-aware extraction inputs."""
+
+        del record
+        return False
+
+    def normalized_extraction_payload(self, record: JSONObject) -> JSONObject:
+        """Return reviewer-facing Orphanet extraction metadata."""
+
+        return normalized_extraction_payload(
+            source_key=self.source_key,
+            review_policy=self.review_policy,
+            record=record,
+        )
+
+    def proposal_summary(self, selection_reason: str) -> str:
+        """Return a source-specific proposal summary."""
+
+        return proposal_summary(
+            source_key=self.source_key,
+            review_policy=self.review_policy,
+            selection_reason=selection_reason,
+        )
+
+    def review_item_summary(self, selection_reason: str) -> str:
+        """Return a source-specific review-item summary."""
+
+        return review_item_summary(
+            source_key=self.source_key,
+            review_policy=self.review_policy,
+            selection_reason=selection_reason,
+        )
+
+    def build_candidate_context(self, record: JSONObject) -> SourceCandidateContext:
+        """Return normalized Orphanet context for candidate screening."""
+
+        return SourceCandidateContext(
+            source_key=self.source_key,
+            source_family=self.source_family,
+            display_name=self.display_name,
+            normalized_record=self.normalize_record(record),
+            variant_aware_recommended=self.recommends_variant_aware(record),
+            handoff_target_kind=self.handoff_target_kind,
+            provider_external_id=self.provider_external_id(record),
+            proposal_type=self.review_policy.proposal_type,
+            review_type=self.review_policy.review_type,
+            evidence_role=self.review_policy.evidence_role,
+            limitations=self.review_policy.limitations,
+            normalized_fields=self.review_policy.normalized_fields,
+        )
+
+
+def _payload_with_limit(search: SourceSearchInput) -> JSONObject:
+    payload: JSONObject = dict(search.query_payload)
+    if search.max_records is not None and "max_results" not in payload:
+        payload["max_results"] = search.max_records
+    return payload
+
+
+def _validated_request(search: SourceSearchInput) -> OrphanetSourceSearchRequest:
+    assert_search_source_key(
+        search,
+        source_key=_SOURCE_DEFINITION.source_key,
+        display_name=_SOURCE_DEFINITION.display_name,
+    )
+    return OrphanetSourceSearchRequest.model_validate(_payload_with_limit(search))
+
+
+def _parse_orphacode(value: str | None) -> int | None:
+    if value is None:
+        return None
+    match = _ORPHACODE_PATTERN.fullmatch(value.strip())
+    return int(match.group(1)) if match is not None else None
+
+
+ORPHANET_PLUGIN = OrphanetSourcePlugin()
+
+__all__ = ["ORPHANET_PLUGIN", "OrphanetSourcePlugin"]

--- a/services/artana_evidence_api/source_plugins/registry.py
+++ b/services/artana_evidence_api/source_plugins/registry.py
@@ -33,9 +33,14 @@ from artana_evidence_api.source_plugins.pubmed import (
     PUBMED_PLUGIN,
     build_pubmed_execution_plugin,
 )
+from artana_evidence_api.source_plugins.rare_disease.orphanet import ORPHANET_PLUGIN
 from artana_evidence_api.source_plugins.uniprot import UNIPROT_PLUGIN
 from artana_evidence_api.source_plugins.zfin import ZFIN_PLUGIN
 from artana_evidence_api.source_registry import SourceDefinition, normalize_source_key
+
+PublicSourcePlugin = (
+    EvidenceSourcePlugin | AuthoritySourcePlugin | DocumentIngestionSourcePlugin
+)
 
 _SOURCE_PLUGINS: tuple[EvidenceSourcePlugin, ...] = (
     PUBMED_PLUGIN,
@@ -48,6 +53,7 @@ _SOURCE_PLUGINS: tuple[EvidenceSourcePlugin, ...] = (
     CLINICAL_TRIALS_PLUGIN,
     MGI_PLUGIN,
     ZFIN_PLUGIN,
+    ORPHANET_PLUGIN,
 )
 
 _AUTHORITY_SOURCE_PLUGINS: tuple[AuthoritySourcePlugin, ...] = (
@@ -60,10 +66,7 @@ _DOCUMENT_INGESTION_SOURCE_PLUGINS: tuple[DocumentIngestionSourcePlugin, ...] = 
     TEXT_INGESTION_PLUGIN,
 )
 
-_PUBLIC_SOURCE_PLUGINS: tuple[
-    EvidenceSourcePlugin | AuthoritySourcePlugin | DocumentIngestionSourcePlugin,
-    ...,
-] = (
+_PUBLIC_SOURCE_PLUGINS: tuple[PublicSourcePlugin, ...] = (
     PUBMED_PLUGIN,
     MARRVEL_PLUGIN,
     CLINVAR_PLUGIN,
@@ -78,16 +81,9 @@ _PUBLIC_SOURCE_PLUGINS: tuple[
     CLINICAL_TRIALS_PLUGIN,
     MGI_PLUGIN,
     ZFIN_PLUGIN,
+    ORPHANET_PLUGIN,
 )
 
-
-SourceExecutionPluginBuilder = Callable[
-    [
-        Callable[[], AbstractContextManager[PubMedDiscoveryService]] | None,
-        Callable[[], MarrvelDiscoveryServiceProtocol | None] | None,
-    ],
-    EvidenceSourcePlugin,
-]
 
 _SOURCE_EXECUTION_PLUGIN_FACTORIES = (
     (PUBMED_PLUGIN.source_key, build_pubmed_execution_plugin),
@@ -183,7 +179,10 @@ def source_plugin_for_execution(
     """Return a source plugin with runner-scoped execution dependencies."""
 
     normalized_source_key = normalize_source_key(source_key)
-    for factory_source_key, build_execution_plugin in _SOURCE_EXECUTION_PLUGIN_FACTORIES:
+    for (
+        factory_source_key,
+        build_execution_plugin,
+    ) in _SOURCE_EXECUTION_PLUGIN_FACTORIES:
         if factory_source_key == normalized_source_key:
             return build_execution_plugin(
                 pubmed_discovery_service_factory,
@@ -221,10 +220,7 @@ def validate_source_plugin_registry() -> None:
 
 def _validate_plugin_group(
     *,
-    plugins: tuple[
-        EvidenceSourcePlugin | AuthoritySourcePlugin | DocumentIngestionSourcePlugin,
-        ...,
-    ],
+    plugins: tuple[PublicSourcePlugin, ...],
     group_name: str,
     direct_search_expected: bool,
 ) -> None:
@@ -234,7 +230,9 @@ def _validate_plugin_group(
         raise RuntimeError(msg)
     definition_keys = tuple(plugin.source_definition().source_key for plugin in plugins)
     if keys != definition_keys:
-        msg = f"{group_name} source plugin registry keys do not match plugin definitions."
+        msg = (
+            f"{group_name} source plugin registry keys do not match plugin definitions."
+        )
         raise RuntimeError(msg)
     metadata_keys = tuple(plugin.metadata.source_key for plugin in plugins)
     if keys != metadata_keys:
@@ -253,7 +251,7 @@ def _validate_plugin_group(
 
 def _validate_plugin_metadata(
     *,
-    plugin: EvidenceSourcePlugin | AuthoritySourcePlugin | DocumentIngestionSourcePlugin,
+    plugin: PublicSourcePlugin,
     definition: SourceDefinition,
 ) -> None:
     expected = {
@@ -261,7 +259,9 @@ def _validate_plugin_metadata(
         "display_name": definition.display_name,
         "description": definition.description,
         "source_family": definition.source_family,
-        "capabilities": tuple(capability.value for capability in definition.capabilities),
+        "capabilities": tuple(
+            capability.value for capability in definition.capabilities
+        ),
         "direct_search_supported": definition.direct_search_enabled,
         "research_plan_supported": definition.research_plan_enabled,
         "default_research_plan_enabled": definition.default_research_plan_enabled,
@@ -277,10 +277,7 @@ def _validate_plugin_metadata(
     for field_name, expected_value in expected.items():
         if getattr(metadata, field_name) == expected_value:
             continue
-        msg = (
-            f"Plugin metadata field '{field_name}' drifted for "
-            f"'{plugin.source_key}'."
-        )
+        msg = f"Plugin metadata field '{field_name}' drifted for '{plugin.source_key}'."
         raise RuntimeError(msg)
 
 
@@ -325,8 +322,7 @@ def _validated_authority_source_plugins() -> tuple[AuthoritySourcePlugin, ...]:
 
 @lru_cache(maxsize=1)
 def _validated_document_ingestion_source_plugins() -> tuple[
-    DocumentIngestionSourcePlugin,
-    ...,
+    DocumentIngestionSourcePlugin, ...
 ]:
     validate_source_plugin_registry()
     return _DOCUMENT_INGESTION_SOURCE_PLUGINS
@@ -340,8 +336,7 @@ def _source_plugins_by_key() -> dict[str, EvidenceSourcePlugin]:
 @lru_cache(maxsize=1)
 def _authority_source_plugins_by_key() -> dict[str, AuthoritySourcePlugin]:
     return {
-        plugin.source_key: plugin
-        for plugin in _validated_authority_source_plugins()
+        plugin.source_key: plugin for plugin in _validated_authority_source_plugins()
     }
 
 

--- a/services/artana_evidence_api/source_registry.py
+++ b/services/artana_evidence_api/source_registry.py
@@ -124,6 +124,10 @@ _SOURCE_KEY_ALIASES = {
     "clinical_trials.gov": "clinical_trials",
     "clinical-trials": "clinical_trials",
     "clinical-trials-gov": "clinical_trials",
+    "orpha": "orphanet",
+    "orpha_code": "orphanet",
+    "orphacode": "orphanet",
+    "orpha-code": "orphanet",
 }
 
 

--- a/services/artana_evidence_api/source_route_dependencies.py
+++ b/services/artana_evidence_api/source_route_dependencies.py
@@ -11,6 +11,7 @@ from artana_evidence_api.dependencies import (
     get_drugbank_source_gateway,
     get_gnomad_source_gateway,
     get_mgi_source_gateway,
+    get_orphanet_source_gateway,
     get_pubmed_discovery_service,
     get_uniprot_source_gateway,
     get_zfin_source_gateway,
@@ -25,6 +26,7 @@ from artana_evidence_api.source_enrichment_bridges import (
     ClinVarGatewayProtocol,
     DrugBankGatewayProtocol,
     GnomADGatewayProtocol,
+    OrphanetGatewayProtocol,
     UniProtGatewayProtocol,
 )
 from artana_evidence_api.source_route_contracts import (
@@ -49,6 +51,7 @@ _GNOMAD_SOURCE_GATEWAY_DEPENDENCY = Depends(get_gnomad_source_gateway)
 _DRUGBANK_SOURCE_GATEWAY_DEPENDENCY = Depends(get_drugbank_source_gateway)
 _MGI_SOURCE_GATEWAY_DEPENDENCY = Depends(get_mgi_source_gateway)
 _ZFIN_SOURCE_GATEWAY_DEPENDENCY = Depends(get_zfin_source_gateway)
+_ORPHANET_SOURCE_GATEWAY_DEPENDENCY = Depends(get_orphanet_source_gateway)
 
 
 def direct_source_route_dependencies(
@@ -79,6 +82,9 @@ def direct_source_route_dependencies(
     ),
     mgi_gateway: AllianceGeneGatewayProtocol | None = _MGI_SOURCE_GATEWAY_DEPENDENCY,
     zfin_gateway: AllianceGeneGatewayProtocol | None = _ZFIN_SOURCE_GATEWAY_DEPENDENCY,
+    orphanet_gateway: OrphanetGatewayProtocol | None = (
+        _ORPHANET_SOURCE_GATEWAY_DEPENDENCY
+    ),
 ) -> DirectSourceRouteDependencies:
     """Collect route dependencies without exposing source-specific fields."""
 
@@ -96,6 +102,7 @@ def direct_source_route_dependencies(
             "drugbank": drugbank_gateway,
             "mgi": mgi_gateway,
             "zfin": zfin_gateway,
+            "orphanet": orphanet_gateway,
         },
     )
 

--- a/services/artana_evidence_api/source_route_plugins.py
+++ b/services/artana_evidence_api/source_route_plugins.py
@@ -27,6 +27,7 @@ from artana_evidence_api.source_route_pubmed import pubmed_typed_route_plugin
 from artana_evidence_api.source_route_uniprot import uniprot_typed_route_plugin
 from artana_evidence_api.source_route_zfin import zfin_typed_route_plugin
 from artana_evidence_api.source_routes.gnomad import gnomad_typed_route_plugin
+from artana_evidence_api.source_routes.orphanet import orphanet_typed_route_plugin
 from artana_evidence_api.types.common import JSONObject
 from fastapi import APIRouter
 
@@ -49,6 +50,7 @@ _DIRECT_SOURCE_ROUTE_PLUGINS = (
     clinical_trials_typed_route_plugin(),
     mgi_typed_route_plugin(),
     zfin_typed_route_plugin(),
+    orphanet_typed_route_plugin(),
 )
 
 

--- a/services/artana_evidence_api/source_routes/orphanet.py
+++ b/services/artana_evidence_api/source_routes/orphanet.py
@@ -1,0 +1,198 @@
+"""Orphanet typed public direct-source routes."""
+
+from __future__ import annotations
+
+from typing import cast
+from uuid import UUID
+
+from artana_evidence_api.auth import HarnessUser, get_current_harness_user
+from artana_evidence_api.dependencies import (
+    get_direct_source_search_store,
+    get_orphanet_source_gateway,
+    require_harness_space_read_access,
+    require_harness_space_write_access,
+)
+from artana_evidence_api.direct_source_search import (
+    DirectSourceSearchStore,
+    OrphanetSourceSearchRequest,
+    OrphanetSourceSearchResponse,
+    run_orphanet_direct_search,
+)
+from artana_evidence_api.source_enrichment_bridges import OrphanetGatewayProtocol
+from artana_evidence_api.source_route_contracts import (
+    DirectSourceRouteDependencies,
+    DirectSourceRoutePlugin,
+    DirectSourceTypedRoute,
+)
+from artana_evidence_api.source_route_helpers import (
+    gateway_unavailable,
+    parse_source_search_payload,
+    require_gateway,
+    source_result_payload,
+    stored_source_search_payload,
+)
+from artana_evidence_api.types.common import JSONObject
+from fastapi import Depends, status
+
+_CURRENT_USER_DEPENDENCY = Depends(get_current_harness_user)
+_ORPHANET_SOURCE_GATEWAY_DEPENDENCY = Depends(get_orphanet_source_gateway)
+_DIRECT_SOURCE_SEARCH_STORE_DEPENDENCY = Depends(get_direct_source_search_store)
+
+
+def orphanet_typed_route_plugin() -> DirectSourceRoutePlugin:
+    """Return the typed public Orphanet route plugin."""
+
+    return DirectSourceRoutePlugin(
+        source_key="orphanet",
+        routes=(
+            DirectSourceTypedRoute(
+                path="/v2/spaces/{space_id}/sources/orphanet/searches",
+                method="POST",
+                endpoint=create_orphanet_source_search,
+                response_model=OrphanetSourceSearchResponse,
+                status_code=status.HTTP_201_CREATED,
+                summary="Search Orphanet evidence source",
+                dependencies=(Depends(require_harness_space_write_access),),
+            ),
+            DirectSourceTypedRoute(
+                path="/v2/spaces/{space_id}/sources/orphanet/searches/{search_id}",
+                method="GET",
+                endpoint=get_orphanet_source_search,
+                response_model=OrphanetSourceSearchResponse,
+                summary="Get Orphanet evidence source search",
+                dependencies=(Depends(require_harness_space_read_access),),
+            ),
+        ),
+        create_payload=create_orphanet_route_payload,
+        get_payload=get_orphanet_route_payload,
+    )
+
+
+async def create_orphanet_source_search(
+    space_id: UUID,
+    request: OrphanetSourceSearchRequest,
+    *,
+    current_user: HarnessUser = _CURRENT_USER_DEPENDENCY,
+    orphanet_gateway: OrphanetGatewayProtocol | None = (
+        _ORPHANET_SOURCE_GATEWAY_DEPENDENCY
+    ),
+    direct_source_search_store: DirectSourceSearchStore = (
+        _DIRECT_SOURCE_SEARCH_STORE_DEPENDENCY
+    ),
+) -> JSONObject:
+    """Typed v2 route for Orphanet source search."""
+
+    return await create_orphanet_source_search_payload(
+        space_id=space_id,
+        request=request,
+        current_user=current_user,
+        orphanet_gateway=orphanet_gateway,
+        direct_source_search_store=direct_source_search_store,
+    )
+
+
+def get_orphanet_source_search(
+    space_id: UUID,
+    search_id: UUID,
+    *,
+    direct_source_search_store: DirectSourceSearchStore = (
+        _DIRECT_SOURCE_SEARCH_STORE_DEPENDENCY
+    ),
+) -> JSONObject:
+    """Typed v2 route for Orphanet source-search lookup."""
+
+    return get_orphanet_source_search_payload(
+        space_id=space_id,
+        search_id=search_id,
+        direct_source_search_store=direct_source_search_store,
+    )
+
+
+async def create_orphanet_source_search_payload(
+    *,
+    space_id: UUID,
+    request: OrphanetSourceSearchRequest,
+    current_user: HarnessUser,
+    orphanet_gateway: OrphanetGatewayProtocol | None,
+    direct_source_search_store: DirectSourceSearchStore,
+) -> JSONObject:
+    """Create an Orphanet direct-source search response."""
+
+    gateway = require_gateway(
+        orphanet_gateway,
+        unavailable_detail="Orphanet credentials are not configured.",
+    )
+    try:
+        result = await run_orphanet_direct_search(
+            space_id=space_id,
+            created_by=current_user.id,
+            request=request,
+            gateway=gateway,
+            store=direct_source_search_store,
+        )
+    except RuntimeError as exc:
+        raise gateway_unavailable(exc) from exc
+    return source_result_payload(result)
+
+
+def get_orphanet_source_search_payload(
+    *,
+    space_id: UUID,
+    search_id: UUID,
+    direct_source_search_store: DirectSourceSearchStore,
+) -> JSONObject:
+    """Return a stored Orphanet direct-source search response."""
+
+    return stored_source_search_payload(
+        space_id=space_id,
+        source_key="orphanet",
+        search_id=search_id,
+        direct_source_search_store=direct_source_search_store,
+    )
+
+
+async def create_orphanet_route_payload(
+    space_id: UUID,
+    request_payload: JSONObject,
+    dependencies: DirectSourceRouteDependencies,
+) -> JSONObject:
+    """Create an Orphanet search from the generic route payload."""
+
+    orphanet_gateway = cast(
+        "OrphanetGatewayProtocol | None",
+        dependencies.source_dependency("orphanet"),
+    )
+    return await create_orphanet_source_search_payload(
+        space_id=space_id,
+        request=parse_source_search_payload(
+            request_payload, OrphanetSourceSearchRequest
+        ),
+        current_user=dependencies.current_user,
+        orphanet_gateway=orphanet_gateway,
+        direct_source_search_store=dependencies.direct_source_search_store,
+    )
+
+
+def get_orphanet_route_payload(
+    space_id: UUID,
+    search_id: UUID,
+    dependencies: DirectSourceRouteDependencies,
+) -> JSONObject:
+    """Return an Orphanet search from the generic route lookup."""
+
+    return get_orphanet_source_search_payload(
+        space_id=space_id,
+        search_id=search_id,
+        direct_source_search_store=dependencies.direct_source_search_store,
+    )
+
+
+__all__ = [
+    "create_orphanet_route_payload",
+    "create_orphanet_source_search",
+    "create_orphanet_source_search_payload",
+    "get_orphanet_route_payload",
+    "get_orphanet_source_search",
+    "get_orphanet_source_search_payload",
+    "orphanet_typed_route_plugin",
+]

--- a/services/artana_evidence_api/tests/unit/test_direct_source_search_routes.py
+++ b/services/artana_evidence_api/tests/unit/test_direct_source_search_routes.py
@@ -21,6 +21,7 @@ from artana_evidence_api.dependencies import (
     get_drugbank_source_gateway,
     get_gnomad_source_gateway,
     get_mgi_source_gateway,
+    get_orphanet_source_gateway,
     get_pubmed_discovery_service,
     get_research_space_store,
     get_run_registry,
@@ -34,6 +35,9 @@ from artana_evidence_api.direct_source_search import (
     SqlAlchemyDirectSourceSearchStore,
 )
 from artana_evidence_api.direct_sources.gnomad_gateway import GnomADGatewayFetchResult
+from artana_evidence_api.direct_sources.orphanet_gateway import (
+    OrphanetGatewayFetchResult,
+)
 from artana_evidence_api.document_store import HarnessDocumentStore
 from artana_evidence_api.drugbank_gateway import DrugBankGatewayFetchResult
 from artana_evidence_api.marrvel_discovery import MarrvelDiscoveryResult
@@ -86,7 +90,9 @@ class _StubClinVarGateway:
     def __init__(self) -> None:
         self.configs: list[ClinVarQueryConfig] = []
 
-    async def fetch_records(self, config: ClinVarQueryConfig) -> list[dict[str, object]]:
+    async def fetch_records(
+        self, config: ClinVarQueryConfig
+    ) -> list[dict[str, object]]:
         self.configs.append(config)
         return [
             {
@@ -104,7 +110,9 @@ class _StubClinVarGateway:
 
 
 class _FailingClinVarGateway:
-    async def fetch_records(self, config: ClinVarQueryConfig) -> list[dict[str, object]]:
+    async def fetch_records(
+        self, config: ClinVarQueryConfig
+    ) -> list[dict[str, object]]:
         del config
         raise RuntimeError("clinvar offline")
 
@@ -361,6 +369,35 @@ class _StubAllianceGeneGateway:
         )
 
 
+class _StubOrphanetGateway:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str | None, int | None, str, int]] = []
+
+    async def fetch_records_async(
+        self,
+        *,
+        query: str | None = None,
+        orphacode: int | None = None,
+        language: str = "EN",
+        max_results: int = 20,
+    ) -> OrphanetGatewayFetchResult:
+        assert (query is None) is (orphacode is not None)
+        self.calls.append((query, orphacode, language, max_results))
+        return OrphanetGatewayFetchResult(
+            records=[
+                {
+                    "orpha_code": str(orphacode or 558),
+                    "orphanet_id": f"ORPHA:{orphacode or 558}",
+                    "preferred_term": query or "Marfan syndrome",
+                    "name": query or "Marfan syndrome",
+                    "definition": "A connective tissue disorder.",
+                    "source": "orphanet",
+                },
+            ],
+            fetched_records=1,
+        )
+
+
 class _StubMarrvelDiscoveryService:
     def __init__(self) -> None:
         self.results: dict[UUID, MarrvelDiscoveryResult] = {}
@@ -450,6 +487,7 @@ def _build_client(
     drugbank_gateway: object | None = None,
     mgi_gateway: object | None = None,
     zfin_gateway: object | None = None,
+    orphanet_gateway: object | None = None,
     marrvel_discovery_service: object | None = None,
     pubmed_discovery_service: object | None = None,
 ) -> _BuiltClient:
@@ -476,6 +514,7 @@ def _build_client(
         drugbank_gateway=drugbank_gateway,
         mgi_gateway=mgi_gateway,
         zfin_gateway=zfin_gateway,
+        orphanet_gateway=orphanet_gateway,
         marrvel_discovery_service=marrvel_discovery_service,
         pubmed_discovery_service=pubmed_discovery_service,
     )
@@ -503,6 +542,7 @@ def _build_client_for_space(
     drugbank_gateway: object | None = None,
     mgi_gateway: object | None = None,
     zfin_gateway: object | None = None,
+    orphanet_gateway: object | None = None,
     marrvel_discovery_service: object | None = None,
     pubmed_discovery_service: object | None = None,
 ) -> TestClient:
@@ -529,6 +569,7 @@ def _build_client_for_space(
     app.dependency_overrides[get_drugbank_source_gateway] = lambda: drugbank_gateway
     app.dependency_overrides[get_mgi_source_gateway] = lambda: mgi_gateway
     app.dependency_overrides[get_zfin_source_gateway] = lambda: zfin_gateway
+    app.dependency_overrides[get_orphanet_source_gateway] = lambda: orphanet_gateway
     if marrvel_discovery_service is not None:
         app.dependency_overrides[marrvel.get_marrvel_discovery_service] = (
             lambda: marrvel_discovery_service
@@ -830,6 +871,14 @@ def test_source_search_handoff_creates_non_variant_source_document() -> None:
             "provider_id",
             "ZFIN:1",
         ),
+        (
+            "orphanet",
+            {"orphanet_gateway": _StubOrphanetGateway()},
+            {"query": "Marfan syndrome"},
+            "rare_disease",
+            "orphanet_id",
+            "ORPHA:558",
+        ),
     ],
 )
 def test_non_variant_source_handoffs_create_normalized_source_documents(
@@ -866,8 +915,7 @@ def test_non_variant_source_handoffs_create_normalized_source_documents(
     assert document.source_type == source_key
     assert document.metadata["source_family"] == expected_family
     assert (
-        document.metadata["normalization_profile"]
-        == f"{source_key}_source_document_v1"
+        document.metadata["normalization_profile"] == f"{source_key}_source_document_v1"
     )
     assert document.metadata["normalized_record"][normalized_field] == expected_value
     assert "Normalized Fields" in document.text_content
@@ -1130,7 +1178,9 @@ def test_create_clinvar_source_search_returns_503_when_gateway_fails() -> None:
     assert "clinvar offline" in response.json()["detail"]
 
 
-def test_create_clinicaltrials_source_search_returns_records_and_capture_metadata() -> None:
+def test_create_clinicaltrials_source_search_returns_records_and_capture_metadata() -> (
+    None
+):
     clinicaltrials_gateway = _StubClinicalTrialsGateway()
     built = _build_client(clinicaltrials_gateway=clinicaltrials_gateway)
 
@@ -1192,6 +1242,7 @@ def test_mixed_case_source_keys_route_through_generic_dispatch() -> None:
         drugbank_gateway=_StubDrugBankGateway(),
         mgi_gateway=_StubAllianceGeneGateway(source_key="mgi"),
         zfin_gateway=_StubAllianceGeneGateway(source_key="zfin"),
+        orphanet_gateway=_StubOrphanetGateway(),
     )
     cases: tuple[tuple[str, dict[str, object], str], ...] = (
         ("ClinVar", {"gene_symbol": "BRCA1"}, "clinvar"),
@@ -1201,6 +1252,7 @@ def test_mixed_case_source_keys_route_through_generic_dispatch() -> None:
         ("DrugBank", {"drug_name": "Olaparib"}, "drugbank"),
         ("MGI", {"query": "BRCA1"}, "mgi"),
         ("ZFIN", {"query": "BRCA1"}, "zfin"),
+        ("ORPHAcode", {"orphacode": 558}, "orphanet"),
     )
 
     for source_key, request_payload, expected_source_key in cases:
@@ -1329,7 +1381,9 @@ def test_durable_source_search_routes_survive_fresh_app_and_store_instances() ->
     try:
         second_client = _build_client_for_space(
             research_space_store=research_space_store,
-            direct_source_search_store=SqlAlchemyDirectSourceSearchStore(second_session),
+            direct_source_search_store=SqlAlchemyDirectSourceSearchStore(
+                second_session
+            ),
         )
 
         clinvar_get = second_client.get(
@@ -1369,7 +1423,9 @@ def test_create_alphafold_source_search_returns_records_and_capture_metadata() -
     assert payload["source_capture"]["query"] == "P38398"
 
 
-def test_create_gnomad_gene_source_search_returns_records_and_capture_metadata() -> None:
+def test_create_gnomad_gene_source_search_returns_records_and_capture_metadata() -> (
+    None
+):
     gnomad_gateway = _StubGnomADGateway()
     built = _build_client(gnomad_gateway=gnomad_gateway)
 
@@ -1476,7 +1532,9 @@ def test_create_drugbank_source_search_returns_records_and_capture_metadata() ->
     assert payload["source_capture"]["external_id"] == "DB01234"
 
 
-def test_create_alliance_gene_source_searches_return_records_and_capture_metadata() -> None:
+def test_create_alliance_gene_source_searches_return_records_and_capture_metadata() -> (
+    None
+):
     built = _build_client(
         mgi_gateway=_StubAllianceGeneGateway(source_key="mgi"),
         zfin_gateway=_StubAllianceGeneGateway(source_key="zfin"),
@@ -1497,6 +1555,115 @@ def test_create_alliance_gene_source_searches_return_records_and_capture_metadat
         assert payload["source_capture"]["source_key"] == source_key
         assert payload["source_capture"]["query_payload"]["max_results"] == 4
         assert payload["source_capture"]["external_id"] == f"{source_key.upper()}:1"
+
+
+def test_create_orphanet_source_search_requires_configured_credentials() -> None:
+    built = _build_client(orphanet_gateway=None)
+
+    response = built.client.post(
+        f"/v2/spaces/{built.space_id}/sources/orphanet/searches",
+        headers=_auth_headers(),
+        json={"query": "Marfan syndrome"},
+    )
+
+    assert response.status_code == 503
+    assert "Orphanet credentials are not configured" in response.json()["detail"]
+
+
+def test_orphanet_source_gateway_dependency_requires_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ORPHACODE_API_KEY", raising=False)
+
+    assert get_orphanet_source_gateway() is None
+
+    monkeypatch.setenv("ORPHACODE_API_KEY", "test-api-key")
+
+    assert get_orphanet_source_gateway() is not None
+
+
+def test_create_orphanet_source_search_returns_records_and_capture_metadata() -> None:
+    orphanet_gateway = _StubOrphanetGateway()
+    built = _build_client(orphanet_gateway=orphanet_gateway)
+
+    response = built.client.post(
+        f"/v2/spaces/{built.space_id}/sources/orphanet/searches",
+        headers=_auth_headers(),
+        json={"query": "Marfan syndrome", "max_results": 2},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["source_key"] == "orphanet"
+    assert payload["query"] == "Marfan syndrome"
+    assert payload["language"] == "EN"
+    assert payload["records"][0]["orphanet_id"] == "ORPHA:558"
+    assert payload["source_capture"]["source_key"] == "orphanet"
+    assert payload["source_capture"]["result_count"] == 1
+    assert payload["source_capture"]["external_id"] == "ORPHA:558"
+    assert payload["source_capture"]["provenance"]["provider"] == (
+        "ORPHAcodes API / Orphanet Nomenclature Pack"
+    )
+    assert orphanet_gateway.calls == [("Marfan syndrome", None, "EN", 2)]
+
+    get_response = built.client.get(
+        f"/v2/spaces/{built.space_id}/sources/orphanet/searches/{payload['id']}",
+        headers=_auth_headers(),
+    )
+    assert get_response.status_code == 200
+    assert get_response.json()["id"] == payload["id"]
+
+
+def test_create_orphanet_source_search_fetches_orphacode_only() -> None:
+    orphanet_gateway = _StubOrphanetGateway()
+    built = _build_client(orphanet_gateway=orphanet_gateway)
+
+    response = built.client.post(
+        f"/v2/spaces/{built.space_id}/sources/orphanet/searches",
+        headers=_auth_headers(),
+        json={"orphacode": 558, "language": "fr", "max_results": 1},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["source_key"] == "orphanet"
+    assert payload["query"] == "ORPHA:558"
+    assert payload["orphacode"] == 558
+    assert payload["language"] == "FR"
+    assert payload["records"][0]["orphanet_id"] == "ORPHA:558"
+    assert payload["source_capture"]["query"] == "ORPHA:558"
+    assert payload["source_capture"]["query_payload"] == {
+        "orphacode": 558,
+        "language": "FR",
+        "max_results": 1,
+    }
+    assert orphanet_gateway.calls == [(None, 558, "FR", 1)]
+
+
+@pytest.mark.parametrize(
+    ("request_payload", "expected_message"),
+    [
+        ({}, "Provide one of query or orphacode"),
+        (
+            {"query": "Marfan syndrome", "orphacode": 558},
+            "Provide either query or orphacode, not both",
+        ),
+    ],
+)
+def test_create_orphanet_source_search_rejects_invalid_lookup_shape(
+    request_payload: dict[str, object],
+    expected_message: str,
+) -> None:
+    built = _build_client(orphanet_gateway=_StubOrphanetGateway())
+
+    response = built.client.post(
+        f"/v2/spaces/{built.space_id}/sources/orphanet/searches",
+        headers=_auth_headers(),
+        json=request_payload,
+    )
+
+    assert response.status_code == 422
+    assert expected_message in response.text
 
 
 def test_get_direct_source_search_rejects_wrong_space() -> None:

--- a/services/artana_evidence_api/tests/unit/test_direct_source_search_store.py
+++ b/services/artana_evidence_api/tests/unit/test_direct_source_search_store.py
@@ -16,6 +16,7 @@ from artana_evidence_api.direct_source_search import (
     GnomADSourceSearchResponse,
     InMemoryDirectSourceSearchStore,
     MGISourceSearchResponse,
+    OrphanetSourceSearchResponse,
     PubMedSourceSearchResponse,
     SqlAlchemyDirectSourceSearchStore,
     UniProtSourceSearchResponse,
@@ -94,6 +95,7 @@ def _records() -> tuple[DirectSourceSearchRecord, ...]:
     drugbank_id = uuid4()
     mgi_id = uuid4()
     zfin_id = uuid4()
+    orphanet_id = uuid4()
     return (
         ClinVarSourceSearchResponse(
             id=clinvar_id,
@@ -251,7 +253,27 @@ def _records() -> tuple[DirectSourceSearchRecord, ...]:
             records=[{"zfin_id": "ZFIN:1"}],
             created_at=created_at,
             completed_at=completed_at,
-            source_capture=_capture(source_key="zfin", search_id=zfin_id, query="brca1"),
+            source_capture=_capture(
+                source_key="zfin", search_id=zfin_id, query="brca1"
+            ),
+        ),
+        OrphanetSourceSearchResponse(
+            id=orphanet_id,
+            space_id=space_id,
+            query="Marfan syndrome",
+            orphacode=None,
+            language="EN",
+            max_results=1,
+            fetched_records=1,
+            record_count=1,
+            records=[{"orphanet_id": "ORPHA:558", "orpha_code": "558"}],
+            created_at=created_at,
+            completed_at=completed_at,
+            source_capture=_capture(
+                source_key="orphanet",
+                search_id=orphanet_id,
+                query="Marfan syndrome",
+            ),
         ),
     )
 

--- a/services/artana_evidence_api/tests/unit/test_orphanet_gateway.py
+++ b/services/artana_evidence_api/tests/unit/test_orphanet_gateway.py
@@ -1,0 +1,147 @@
+"""Unit tests for the Orphanet ORPHAcodes gateway."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from artana_evidence_api.direct_sources.orphanet_gateway import (
+    OrphanetGatewayError,
+    OrphanetSourceGateway,
+)
+
+
+@pytest.mark.asyncio
+async def test_orphanet_gateway_search_normalizes_summaries() -> None:
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.url.raw_path.decode())
+        if request.url.path == "/EN/ClinicalEntity/ApproximateName/Marfan syndrome":
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "ORPHAcode": 558,
+                        "Preferred term": "Marfan syndrome",
+                        "Date": "2020-06-29T11:48:08Z",
+                    },
+                ],
+            )
+        if request.url.path == "/EN/ClinicalEntity/orphacode/558":
+            return httpx.Response(
+                200,
+                json={
+                    "ORPHAcode": 558,
+                    "Preferred term": "Marfan syndrome",
+                    "Synonym": ["MFS", "Marfan disease"],
+                    "Definition": "A connective tissue disorder.",
+                    "Typology": "Disease",
+                    "Status": "Active",
+                    "ClassificationLevel": "Disorder",
+                    "OrphanetUrl": "https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=558",
+                    "Preferential parent": {
+                        "ORPHAcode": 98023,
+                        "Preferred term": "Rare systemic or rheumatologic disease",
+                    },
+                    "Date": "2020-06-29T11:48:08Z",
+                },
+            )
+        return httpx.Response(404, json={"detail": "not found"})
+
+    gateway = OrphanetSourceGateway(
+        api_key="test-api-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = await gateway.fetch_records_async(
+        query=" Marfan   syndrome ", max_results=5
+    )
+
+    assert requests == [
+        "/EN/ClinicalEntity/ApproximateName/Marfan%20syndrome",
+        "/EN/ClinicalEntity/orphacode/558",
+    ]
+    assert result.fetched_records == 1
+    assert result.records == [
+        {
+            "orpha_code": "558",
+            "orphanet_id": "ORPHA:558",
+            "preferred_term": "Marfan syndrome",
+            "name": "Marfan syndrome",
+            "synonyms": ["MFS", "Marfan disease"],
+            "definition": "A connective tissue disorder.",
+            "typology": "Disease",
+            "status": "Active",
+            "classification_level": "Disorder",
+            "orphanet_url": "https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Expert=558",
+            "date": "2020-06-29T11:48:08Z",
+            "matched_query": "Marfan syndrome",
+            "preferential_parent": {
+                "orpha_code": "98023",
+                "orphanet_id": "ORPHA:98023",
+                "preferred_term": "Rare systemic or rheumatologic disease",
+            },
+            "source": "orphanet",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_orphanet_gateway_fetches_exact_orphacode() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["apiKey"] == "test-api-key"
+        assert request.url.path == "/EN/ClinicalEntity/orphacode/558"
+        return httpx.Response(
+            200,
+            json={"ORPHAcode": 558, "Preferred term": "Marfan syndrome"},
+        )
+
+    gateway = OrphanetSourceGateway(
+        api_key="test-api-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = await gateway.fetch_records_async(orphacode=558)
+
+    assert result.fetched_records == 1
+    assert result.records[0]["orphanet_id"] == "ORPHA:558"
+    assert result.records[0]["preferred_term"] == "Marfan syndrome"
+
+
+@pytest.mark.asyncio
+async def test_orphanet_gateway_returns_empty_without_api_key() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"unexpected request to {request.url}")
+
+    gateway = OrphanetSourceGateway(api_key="", transport=httpx.MockTransport(handler))
+
+    result = await gateway.fetch_records_async(query="Marfan syndrome")
+
+    assert result.records == []
+    assert result.fetched_records == 0
+
+
+@pytest.mark.asyncio
+async def test_orphanet_gateway_returns_empty_for_malformed_payload() -> None:
+    gateway = OrphanetSourceGateway(
+        api_key="test-api-key",
+        transport=httpx.MockTransport(lambda _request: httpx.Response(200, json={})),
+    )
+
+    result = await gateway.fetch_records_async(query="Marfan syndrome")
+
+    assert result.records == []
+    assert result.fetched_records == 0
+
+
+@pytest.mark.asyncio
+async def test_orphanet_gateway_raises_configured_request_errors() -> None:
+    gateway = OrphanetSourceGateway(
+        api_key="test-api-key",
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(401, json={"detail": "unauthorized"}),
+        ),
+    )
+
+    with pytest.raises(OrphanetGatewayError, match="ORPHAcodes API request failed"):
+        await gateway.fetch_records_async(query="Marfan syndrome")

--- a/services/artana_evidence_api/tests/unit/test_orphanet_plugin.py
+++ b/services/artana_evidence_api/tests/unit/test_orphanet_plugin.py
@@ -1,0 +1,185 @@
+"""Orphanet source plugin metadata, planning, and execution tests."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from artana_evidence_api.direct_source_search import InMemoryDirectSourceSearchStore
+from artana_evidence_api.direct_sources.orphanet_gateway import (
+    OrphanetGatewayFetchResult,
+)
+from artana_evidence_api.evidence_selection_source_planning import PlannedSourceIntent
+from artana_evidence_api.evidence_selection_source_search import (
+    EvidenceSelectionLiveSourceSearch,
+)
+from artana_evidence_api.source_plugins.contracts import (
+    EvidenceSelectionSourceSearchError,
+    SourceSearchExecutionContext,
+)
+from artana_evidence_api.source_plugins.rare_disease.orphanet import (
+    OrphanetSourcePlugin,
+)
+from artana_evidence_api.source_registry import get_source_definition
+from pydantic import ValidationError
+
+
+def test_orphanet_plugin_metadata_requires_orphacode_credentials() -> None:
+    plugin = OrphanetSourcePlugin()
+    definition = get_source_definition("orphanet")
+
+    assert definition is not None
+    assert plugin.source_definition() == definition
+    assert plugin.source_key == "orphanet"
+    assert plugin.source_family == "rare_disease"
+    assert plugin.metadata.requires_credentials is True
+    assert plugin.metadata.credential_names == ("ORPHACODE_API_KEY",)
+    assert plugin.request_schema_ref == "OrphanetSourceSearchRequest"
+    assert plugin.result_schema_ref == "OrphanetSourceSearchResponse"
+
+
+def test_orphanet_plugin_builds_query_payload_from_disease_context() -> None:
+    plugin = OrphanetSourcePlugin()
+    intent = PlannedSourceIntent(
+        source_key="orphanet",
+        disease=" Marfan   syndrome ",
+        phenotype="connective tissue disorder",
+        evidence_role="rare disease nomenclature",
+        reason="Ground rare disease context.",
+    )
+
+    assert plugin.build_query_payload(intent) == {"query": "Marfan syndrome"}
+
+
+def test_orphanet_plugin_builds_orphacode_payload_from_query() -> None:
+    plugin = OrphanetSourcePlugin()
+    intent = PlannedSourceIntent(
+        source_key="orphanet",
+        query="ORPHA:558",
+        evidence_role="rare disease nomenclature",
+        reason="Fetch exact ORPHAcode.",
+    )
+
+    assert plugin.build_query_payload(intent) == {"orphacode": 558}
+
+
+def test_orphanet_plugin_normalizes_candidate_context() -> None:
+    plugin = OrphanetSourcePlugin()
+
+    context = plugin.build_candidate_context(_orphanet_record()).to_json()
+
+    assert context["source_key"] == "orphanet"
+    assert context["source_family"] == "rare_disease"
+    assert context["provider_external_id"] == "ORPHA:558"
+    assert context["variant_aware_recommended"] is False
+    assert context["normalized_record"] == {
+        "orphanet_id": "ORPHA:558",
+        "orpha_code": "558",
+        "preferred_term": "Marfan syndrome",
+        "synonyms": ["MFS"],
+        "definition": "A connective tissue disorder.",
+        "typology": "Disease",
+        "status": "Active",
+        "classification_level": "Disorder",
+        "orphanet_url": "https://orpha.example/558",
+    }
+    assert context["extraction_policy"]["proposal_type"] == (
+        "rare_disease_context_candidate"
+    )
+
+
+def test_orphanet_plugin_validates_source_key_mismatch() -> None:
+    plugin = OrphanetSourcePlugin()
+
+    with pytest.raises(
+        EvidenceSelectionSourceSearchError,
+        match="Orphanet plugin requires canonical source_key 'orphanet'",
+    ):
+        plugin.validate_live_search(
+            EvidenceSelectionLiveSourceSearch(
+                source_key="clinvar",
+                query_payload={"query": "Marfan syndrome"},
+            ),
+        )
+
+
+def test_orphanet_plugin_rejects_invalid_live_search_payload() -> None:
+    plugin = OrphanetSourcePlugin()
+
+    with pytest.raises(ValidationError, match="Provide one of query or orphacode"):
+        plugin.validate_live_search(
+            EvidenceSelectionLiveSourceSearch(
+                source_key="orphanet",
+                query_payload={},
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_orphanet_plugin_runs_existing_direct_search_path() -> None:
+    plugin = OrphanetSourcePlugin(gateway_factory=lambda: _FakeOrphanetGateway())
+    store = InMemoryDirectSourceSearchStore()
+    context = SourceSearchExecutionContext(
+        space_id=uuid4(),
+        created_by=uuid4(),
+        store=store,
+    )
+
+    result = await plugin.run_direct_search(
+        context=context,
+        search=EvidenceSelectionLiveSourceSearch(
+            source_key="orphanet",
+            query_payload={"query": "Marfan syndrome"},
+            max_records=1,
+        ),
+    )
+
+    assert result.source_key == "orphanet"
+    assert result.query == "Marfan syndrome"
+    assert result.max_results == 1
+    assert result.record_count == 1
+    assert result.records == [_orphanet_record()]
+    assert result.source_capture.source_key == "orphanet"
+    assert result.source_capture.external_id == "ORPHA:558"
+    assert (
+        store.get(
+            space_id=result.space_id,
+            source_key="orphanet",
+            search_id=result.id,
+        )
+        == result
+    )
+
+
+class _FakeOrphanetGateway:
+    async def fetch_records_async(
+        self,
+        *,
+        query: str | None = None,
+        orphacode: int | None = None,
+        language: str = "EN",
+        max_results: int = 20,
+    ) -> OrphanetGatewayFetchResult:
+        assert query == "Marfan syndrome"
+        assert orphacode is None
+        assert language == "EN"
+        assert max_results == 1
+        return OrphanetGatewayFetchResult(
+            records=[_orphanet_record()], fetched_records=1
+        )
+
+
+def _orphanet_record() -> dict[str, object]:
+    return {
+        "orpha_code": "558",
+        "orphanet_id": "ORPHA:558",
+        "preferred_term": "Marfan syndrome",
+        "name": "Marfan syndrome",
+        "synonyms": ["MFS"],
+        "definition": "A connective tissue disorder.",
+        "typology": "Disease",
+        "status": "Active",
+        "classification_level": "Disorder",
+        "orphanet_url": "https://orpha.example/558",
+        "source": "orphanet",
+    }

--- a/services/artana_evidence_api/tests/unit/test_research_init.py
+++ b/services/artana_evidence_api/tests/unit/test_research_init.py
@@ -14,10 +14,12 @@ from uuid import UUID, uuid4
 import pytest
 from artana_evidence_api import (
     full_ai_orchestrator_runtime,
+    research_init_completion_runtime,
     research_init_guarded,
     research_init_helpers,
     research_init_observation_bridge,
     research_init_runtime,
+    research_init_source_results,
 )
 from artana_evidence_api.approval_store import HarnessApprovalStore
 from artana_evidence_api.artifact_store import (
@@ -1310,9 +1312,12 @@ async def test_create_research_init_captures_pubmed_replay_bundle(
     assert replay_artifact.content["selection_errors"] == [
         "captured in research-init router",
     ]
-    assert run_registry.list_runs(space_id=space_record.id)[0].input_payload[
-        "source_caps"
-    ]["pubmed_max_results_per_query"] == 10
+    assert (
+        run_registry.list_runs(space_id=space_record.id)[0].input_payload[
+            "source_caps"
+        ]["pubmed_max_results_per_query"]
+        == 10
+    )
 
 
 @pytest.mark.asyncio
@@ -6884,6 +6889,7 @@ def test_build_source_results_includes_registry_metadata() -> None:
     assert result["drugbank"]["direct_search_enabled"] is True
     assert result["mgi"]["direct_search_enabled"] is True
     assert result["zfin"]["direct_search_enabled"] is True
+    assert result["orphanet"]["direct_search_enabled"] is True
     assert result["mondo"]["direct_search_enabled"] is False
     assert result["clinvar"]["research_plan_enabled"] is True
     assert "source_result_capture" in result["clinvar"]
@@ -6902,6 +6908,25 @@ def test_build_source_results_gnomad_skipped_by_default() -> None:
     result = research_init_runtime._build_source_results(sources={})
     assert result["gnomad"]["status"] == "skipped"
     assert result["gnomad"]["selected"] is False
+
+
+def test_build_source_results_orphanet_skipped_by_default() -> None:
+    """orphanet defaults to skipped (False) when not specified."""
+    result = research_init_runtime._build_source_results(sources={})
+    assert result["orphanet"]["status"] == "skipped"
+    assert result["orphanet"]["selected"] is False
+    assert result["orphanet"]["records_processed"] == 0
+
+
+def test_source_result_counters_fall_back_for_registered_search_sources() -> None:
+    assert research_init_source_results._source_result_counters("orphanet") == {
+        "records_processed": 0,
+    }
+
+
+def test_source_result_counters_reject_unknown_sources() -> None:
+    with pytest.raises(ValueError, match="Unknown source key"):
+        research_init_source_results._source_result_counters("custom_source")
 
 
 def test_build_source_results_gnomad_pending_when_enabled() -> None:
@@ -6989,24 +7014,21 @@ def test_pending_sources_are_marked_deferred_at_end_of_run() -> None:
             "clinical_trials": True,
             "mgi": True,
             "zfin": True,
+            "orphanet": True,
         },
     )
 
     # All sources start as "pending" when enabled.
     for key in source_results:
-        assert (
-            source_results[key]["status"] == "pending"
-        ), f"Expected {key!r} to start as 'pending', got {source_results[key]['status']!r}"
+        assert source_results[key]["status"] == "pending", (
+            f"Expected {key!r} to start as 'pending', got {source_results[key]['status']!r}"
+        )
 
-    # Apply the deferred-marking loop exactly as in execute_research_init_run.
-    for pending_source in (
-        "clinvar",
-        "drugbank",
-        "alphafold",
-        "gnomad",
-        "uniprot",
-        "hgnc",
-    ):
+    # Apply the deferred-marking loop exactly as in complete_research_init_run.
+    pending_sources = research_init_completion_runtime._pending_deferred_source_keys(
+        source_results,
+    )
+    for pending_source in pending_sources:
         if source_results.get(pending_source, {}).get("status") == "pending":
             source_results[pending_source]["status"] = "deferred"
 
@@ -7017,6 +7039,10 @@ def test_pending_sources_are_marked_deferred_at_end_of_run() -> None:
     assert source_results["gnomad"]["status"] == "deferred"
     assert source_results["uniprot"]["status"] == "deferred"
     assert source_results["hgnc"]["status"] == "deferred"
+    assert source_results["clinical_trials"]["status"] == "deferred"
+    assert source_results["mgi"]["status"] == "deferred"
+    assert source_results["zfin"]["status"] == "deferred"
+    assert source_results["orphanet"]["status"] == "deferred"
 
     # Sources outside the deferred loop are unaffected.
     assert source_results["pubmed"]["status"] == "pending"
@@ -7036,27 +7062,40 @@ def test_skipped_sources_are_not_changed_to_deferred() -> None:
             "gnomad": False,
             "uniprot": False,
             "hgnc": False,
+            "orphanet": False,
         },
     )
 
     # All these are skipped because they are disabled.
-    for key in ("clinvar", "drugbank", "alphafold", "gnomad", "uniprot", "hgnc"):
-        assert source_results[key]["status"] == "skipped"
-
-    # Apply the loop.
-    for pending_source in (
+    for key in (
         "clinvar",
         "drugbank",
         "alphafold",
         "gnomad",
         "uniprot",
         "hgnc",
+        "orphanet",
     ):
+        assert source_results[key]["status"] == "skipped"
+
+    # Apply the loop.
+    pending_sources = research_init_completion_runtime._pending_deferred_source_keys(
+        source_results,
+    )
+    for pending_source in pending_sources:
         if source_results.get(pending_source, {}).get("status") == "pending":
             source_results[pending_source]["status"] = "deferred"
 
     # Still skipped — not upgraded to deferred.
-    for key in ("clinvar", "drugbank", "alphafold", "gnomad", "uniprot", "hgnc"):
+    for key in (
+        "clinvar",
+        "drugbank",
+        "alphafold",
+        "gnomad",
+        "uniprot",
+        "hgnc",
+        "orphanet",
+    ):
         assert source_results[key]["status"] == "skipped"
 
 

--- a/services/artana_evidence_api/tests/unit/test_source_adapter_registry.py
+++ b/services/artana_evidence_api/tests/unit/test_source_adapter_registry.py
@@ -201,5 +201,6 @@ def _valid_query_payload(source_key: str) -> JSONObject:
         "drugbank": {"drugbank_id": "DB08820"},
         "mgi": {"query": "Med13"},
         "zfin": {"query": "med13"},
+        "orphanet": {"query": "MED13 syndrome"},
     }
     return payloads[source_key]

--- a/services/artana_evidence_api/tests/unit/test_source_plugin_architecture.py
+++ b/services/artana_evidence_api/tests/unit/test_source_plugin_architecture.py
@@ -62,6 +62,7 @@ def test_source_plugins_do_not_collapse_into_single_monolith() -> None:
     assert (_SOURCE_PLUGINS_ROOT / "clinical_trials.py").exists()
     assert (_SOURCE_PLUGINS_ROOT / "mgi.py").exists()
     assert (_SOURCE_PLUGINS_ROOT / "zfin.py").exists()
+    assert (_SOURCE_PLUGINS_ROOT / "rare_disease" / "orphanet.py").exists()
     assert (_SOURCE_PLUGINS_ROOT / "authority" / "base.py").exists()
     assert (_SOURCE_PLUGINS_ROOT / "authority" / "mondo.py").exists()
     assert (_SOURCE_PLUGINS_ROOT / "authority" / "hgnc.py").exists()
@@ -90,7 +91,9 @@ def test_source_plugin_modules_stay_small_and_focused() -> None:
 def test_source_plugin_package_init_has_no_plugin_import_side_effects() -> None:
     tree = ast.parse((_SOURCE_PLUGINS_ROOT / "__init__.py").read_text(encoding="utf-8"))
 
-    imports = [node for node in ast.walk(tree) if isinstance(node, ast.Import | ast.ImportFrom)]
+    imports = [
+        node for node in ast.walk(tree) if isinstance(node, ast.Import | ast.ImportFrom)
+    ]
 
     assert imports == []
 

--- a/services/artana_evidence_api/tests/unit/test_source_plugin_contracts.py
+++ b/services/artana_evidence_api/tests/unit/test_source_plugin_contracts.py
@@ -39,12 +39,14 @@ def test_source_plugin_registry_is_explicit_and_consistent() -> None:
         "clinical_trials",
         "mgi",
         "zfin",
+        "orphanet",
     )
 
     assert source_plugin_keys() == expected_keys
-    assert tuple(
-        plugin.source_definition().source_key for plugin in source_plugins()
-    ) == expected_keys
+    assert (
+        tuple(plugin.source_definition().source_key for plugin in source_plugins())
+        == expected_keys
+    )
     assert [plugin.source_key for plugin in source_plugins()] == [
         *expected_keys,
     ]
@@ -82,7 +84,9 @@ def test_execution_registry_wraps_only_when_runner_dependencies_are_supplied() -
     assert wrapped_marrvel.discovery_service_factory is marrvel_factory
 
 
-def test_source_plugin_registry_rejects_metadata_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_source_plugin_registry_rejects_metadata_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     plugin = source_plugin("pubmed")
     assert plugin is not None
     drifted_plugin = _MetadataDriftPlugin(plugin)

--- a/services/artana_evidence_api/tests/unit/test_source_plugin_parity.py
+++ b/services/artana_evidence_api/tests/unit/test_source_plugin_parity.py
@@ -65,7 +65,9 @@ def test_plugin_record_policy_matches_legacy_policy(source_key: str) -> None:
     assert plugin.request_schema_ref == policy.request_schema_ref
     assert plugin.result_schema_ref == policy.result_schema_ref
     assert plugin.provider_external_id(record) == policy.provider_external_id(record)
-    assert plugin.recommends_variant_aware(record) is policy.recommends_variant_aware(record)
+    assert plugin.recommends_variant_aware(record) is policy.recommends_variant_aware(
+        record
+    )
     assert plugin.normalize_record(record) == policy.normalize_record(record)
 
 
@@ -156,6 +158,12 @@ def _planning_intent(source_key: str) -> PlannedSourceIntent:
             disease="heart development",
             evidence_role="zebrafish model",
             reason="Search zebrafish model evidence.",
+        ),
+        "orphanet": PlannedSourceIntent(
+            source_key="orphanet",
+            disease="Marfan syndrome",
+            evidence_role="rare disease nomenclature",
+            reason="Search Orphanet disease context.",
         ),
     }
     return intents[source_key]
@@ -256,6 +264,17 @@ def _record(source_key: str) -> JSONObject:
             "species": "Danio rerio",
             "phenotype_statements": ["abnormal cardiac ventricle morphology"],
             "expression_terms": ["heart"],
+        },
+        "orphanet": {
+            "orpha_code": "558",
+            "orphanet_id": "ORPHA:558",
+            "preferred_term": "Marfan syndrome",
+            "synonyms": ["MFS"],
+            "definition": "A connective tissue disorder.",
+            "typology": "Disease",
+            "status": "Active",
+            "classification_level": "Disorder",
+            "orphanet_url": "https://orpha.example/558",
         },
     }
     return records[source_key]

--- a/services/artana_evidence_api/tests/unit/test_source_registry.py
+++ b/services/artana_evidence_api/tests/unit/test_source_registry.py
@@ -40,6 +40,7 @@ def test_source_registry_lists_all_research_plan_sources() -> None:
         "clinical_trials",
         "mgi",
         "zfin",
+        "orphanet",
     ]
     assert set(research_plan_source_keys()) == set(source_keys)
 
@@ -56,6 +57,7 @@ def test_source_registry_marks_direct_search_sources() -> None:
         "clinical_trials",
         "mgi",
         "zfin",
+        "orphanet",
     )
 
     pubmed = get_source_definition("pubmed")
@@ -72,6 +74,7 @@ def test_source_registry_marks_direct_search_sources() -> None:
             "uniprot",
             "mgi",
             "zfin",
+            "orphanet",
         )
     ]
 
@@ -104,14 +107,8 @@ def test_source_registry_marks_direct_search_sources() -> None:
     assert clinical_trials.research_plan_enabled is True
     assert clinvar.request_schema_ref == "ClinVarSourceSearchRequest"
     assert clinvar.result_schema_ref == "ClinVarSourceSearchResponse"
-    assert (
-        clinical_trials.request_schema_ref
-        == "ClinicalTrialsSourceSearchRequest"
-    )
-    assert (
-        clinical_trials.result_schema_ref
-        == "ClinicalTrialsSourceSearchResponse"
-    )
+    assert clinical_trials.request_schema_ref == "ClinicalTrialsSourceSearchRequest"
+    assert clinical_trials.result_schema_ref == "ClinicalTrialsSourceSearchResponse"
 
 
 def test_direct_source_schema_refs_resolve_to_public_models() -> None:
@@ -151,7 +148,22 @@ def test_source_registry_defaults_match_research_init_behavior() -> None:
         "clinical_trials": False,
         "mgi": False,
         "zfin": False,
+        "orphanet": False,
     }
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        "orpha",
+        "orpha_code",
+        "orpha-code",
+        "ORPHAcode",
+    ],
+)
+def test_source_registry_normalizes_orphanet_public_aliases(alias: str) -> None:
+    assert normalize_source_key(alias) == "orphanet"
+    assert get_source_definition(alias) == get_source_definition("orphanet")
 
 
 def test_source_registry_normalizes_public_aliases() -> None:

--- a/services/artana_evidence_api/tests/unit/test_source_route_plugins.py
+++ b/services/artana_evidence_api/tests/unit/test_source_route_plugins.py
@@ -106,9 +106,12 @@ def test_generic_route_dependency_keys_match_route_plugin_keys() -> None:
         drugbank_gateway=None,
         mgi_gateway=None,
         zfin_gateway=None,
+        orphanet_gateway=None,
     )
 
-    assert set(dependencies.source_dependencies) == set(direct_source_route_plugin_keys())
+    assert set(dependencies.source_dependencies) == set(
+        direct_source_route_plugin_keys()
+    )
 
 
 def test_typed_route_endpoint_map_is_read_only() -> None:
@@ -280,7 +283,10 @@ def test_gateway_source_get_returns_404_for_missing_stored_result() -> None:
         )
 
     assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
-    assert exc_info.value.detail == "Source search was not found for this space and source."
+    assert (
+        exc_info.value.detail
+        == "Source search was not found for this space and source."
+    )
 
 
 @pytest.mark.asyncio

--- a/services/artana_evidence_api/tests/unit/test_source_toggle_regression.py
+++ b/services/artana_evidence_api/tests/unit/test_source_toggle_regression.py
@@ -67,6 +67,7 @@ class TestSourcesConfigParsing:
             "clinical_trials": False,
             "mgi": False,
             "zfin": False,
+            "orphanet": False,
         }
 
     def test_request_sources_override_saved_settings(self) -> None:
@@ -101,6 +102,7 @@ class TestSourcesConfigParsing:
             "clinical_trials": False,
             "mgi": False,
             "zfin": False,
+            "orphanet": False,
         }
 
     def test_partial_request_sources_are_authoritative(self) -> None:
@@ -133,6 +135,7 @@ class TestSourcesConfigParsing:
             "clinical_trials": False,
             "mgi": False,
             "zfin": False,
+            "orphanet": False,
         }
 
     def test_saved_settings_apply_when_request_omits_sources(self) -> None:
@@ -162,6 +165,7 @@ class TestSourcesConfigParsing:
             "clinical_trials": False,
             "mgi": False,
             "zfin": False,
+            "orphanet": False,
         }
 
     def test_unknown_source_keys_are_reported_for_request_validation(self) -> None:

--- a/services/artana_evidence_api/tests/unit/test_v2_public_routes.py
+++ b/services/artana_evidence_api/tests/unit/test_v2_public_routes.py
@@ -432,6 +432,8 @@ def test_source_search_openapi_keeps_typed_routes_and_capture_contract() -> None
     assert "MGISourceSearchResponse" in schemas
     assert "ZFINSourceSearchRequest" in schemas
     assert "ZFINSourceSearchResponse" in schemas
+    assert "OrphanetSourceSearchRequest" in schemas
+    assert "OrphanetSourceSearchResponse" in schemas
 
     clinvar_post = cast(
         "dict[str, object]",
@@ -478,6 +480,7 @@ def test_direct_source_route_plugin_registry_has_no_source_payloads() -> None:
         "run_drugbank_direct_search",
         "run_mgi_direct_search",
         "run_zfin_direct_search",
+        "run_orphanet_direct_search",
         "create_clinvar_source_search_payload",
         "create_clinicaltrials_source_search_payload",
         "create_uniprot_source_search_payload",
@@ -485,6 +488,7 @@ def test_direct_source_route_plugin_registry_has_no_source_payloads() -> None:
         "create_drugbank_source_search_payload",
         "create_mgi_source_search_payload",
         "create_zfin_source_search_payload",
+        "create_orphanet_source_search_payload",
     )
     for snippet in forbidden_snippets:
         assert snippet not in source
@@ -598,13 +602,24 @@ def test_direct_source_typed_route_plugins_define_expected_public_routes() -> No
             ("/v2/spaces/{space_id}/sources/zfin/searches", "POST", 201),
             ("/v2/spaces/{space_id}/sources/zfin/searches/{search_id}", "GET", None),
         ),
+        "orphanet": (
+            ("/v2/spaces/{space_id}/sources/orphanet/searches", "POST", 201),
+            (
+                "/v2/spaces/{space_id}/sources/orphanet/searches/{search_id}",
+                "GET",
+                None,
+            ),
+        ),
     }
 
     assert tuple(expected_routes) == direct_search_source_keys()
     for plugin in direct_source_route_plugins():
-        assert tuple(
-            (route.path, route.method, route.status_code) for route in plugin.routes
-        ) == expected_routes[plugin.source_key]
+        assert (
+            tuple(
+                (route.path, route.method, route.status_code) for route in plugin.routes
+            )
+            == expected_routes[plugin.source_key]
+        )
         assert all(route.response_model is not None for route in plugin.routes)
         assert all(route.dependencies for route in plugin.routes)
 

--- a/services/artana_evidence_api/types/common.py
+++ b/services/artana_evidence_api/types/common.py
@@ -117,6 +117,7 @@ class ResearchSpaceSourcePreferences(TypedDict, total=False):
     clinical_trials: bool
     mgi: bool
     zfin: bool
+    orphanet: bool
 
 
 class ResearchSpaceSettings(TypedDict, total=False):


### PR DESCRIPTION
## Summary
- add an Orphanet/ORPHAcodes gateway, direct-source contract, source plugin, and typed/generic source-search routes
- register Orphanet in public source metadata, source preferences, route dependencies, and OpenAPI
- generalize source-result counters and pending-source deferral so new source plugins do not break research-init/full-orchestrator summaries
- add unit and route coverage for Orphanet query, ORPHAcode, credential, validation, alias, plugin, and gateway behavior

## Validation
- make all
- make live-service-checks
- RUN_LIVE_EXTERNAL_API_TESTS=1 PYTHONPATH="/Users/alvaro/Documents/Code/artana-evidence-platform/services:/Users/alvaro/Documents/Code/artana-evidence-platform" venv/bin/python3 -m pytest services/artana_evidence_api/tests/integration/test_research_init_live_pipeline.py -q -rs
- ARTANA_EVIDENCE_API_BOOTSTRAP_KEY="artana-evidence-api-bootstrap-key-for-development-2026-03" PYTHONPATH="/Users/alvaro/Documents/Code/artana-evidence-platform/services:/Users/alvaro/Documents/Code/artana-evidence-platform" venv/bin/python3 -m pytest tests/e2e/artana_evidence_api/test_live_endpoint_contract.py -q -rs

Note: existing live suites do not include a real ORPHAcodes network test; Orphanet is covered by unit/route/gateway tests in this branch.