### PR TITLE
PR14: fail closed on unchecked entailment

### DIFF
--- a/docs/validation/reports/2026-07-05-pr14-entailment-coverage-hardening-summary.json
+++ b/docs/validation/reports/2026-07-05-pr14-entailment-coverage-hardening-summary.json
@@ -1,0 +1,62 @@
+{
+  "report": "PR-14 Entailment Coverage Hardening Evidence Snapshot",
+  "date": "2026-07-05",
+  "branch": "alvaro/evidence-pr14-entailment-coverage-hardening",
+  "base_branch": "alvaro/evidence-pr13-specificity-noise-reduction",
+  "scope": [
+    "Treat missing source grounding or missing relation arguments as checked NEUTRAL support instead of unchecked support.",
+    "Preserve the support_not_entailed quality flag for those candidates.",
+    "Preserve adversarial warnings for ungrounded evidence sentences after the fail-closed entailment change.",
+    "Remove the adversarial entailment_not_checked illusion when missing arguments are already counted as checked non-entailment.",
+    "Keep fallback/unavailable strict-agent runs ineligible for success."
+  ],
+  "strict_live_agent_summary": {
+    "verdict": "RED",
+    "completed_agent_precision": 0.7727,
+    "completed_agent_recall": 0.68,
+    "high_value_recall": 0.85,
+    "completed_agent_valuable_rate": 0.7727,
+    "generic_relation_rate": 0.0455,
+    "pruned_generic_relations": 5,
+    "quality_filtered_candidates": 5,
+    "candidate_curie_present_rate": 0.8636,
+    "verified_curie_match_rate": 0.7027,
+    "entailment_required_count": 22,
+    "entailment_checked_count": 22,
+    "entailment_checked_rate": 1.0,
+    "entailment_supported_count": 20,
+    "entailment_supported_rate": 0.9091,
+    "model_curie_wrong_count": 0,
+    "fallback_cases": 0,
+    "invalid_agent_cases": 0,
+    "negative_control_leakage_cases": 0,
+    "governed_proposal_recall_among_proposal_eligible_gold": 1.0
+  },
+  "delta_from_pr13": {
+    "completed_agent_precision": "-0.0368",
+    "completed_agent_recall": "+0.0000",
+    "high_value_recall": "+0.0000",
+    "completed_agent_valuable_rate": "-0.0368",
+    "generic_relation_rate": "+0.0455",
+    "verified_curie_match_rate": "+0.0000",
+    "entailment_checked_rate": "+0.0000"
+  },
+  "validation": {
+    "failing_regression_reproduced": "passed",
+    "focused_entailment_regressions": "passed",
+    "adversarial_review_issue_addressed": "passed",
+    "relation_feasibility_audit_unit_suite": "passed",
+    "relation_feasibility_quality_gate": "passed",
+    "artana_evidence_api_lint": "passed",
+    "artana_evidence_api_type_check": "passed",
+    "service_checks": "passed",
+    "service_checks_coverage": "86.86%"
+  },
+  "artifacts": {
+    "live_agent_json": "reports/relation_feasibility/2026-07-05-pr14-entailment-coverage-hardening/relation_feasibility_report.json",
+    "live_agent_markdown": "reports/relation_feasibility/2026-07-05-pr14-entailment-coverage-hardening/relation_feasibility_report.md",
+    "live_agent_json_sha256": "479126236f20a4bba00585e874e9a368ea5c02efa9ec223e4f0870ab481c7edd",
+    "live_agent_markdown_sha256": "7ef2e3c6db0898d2f99c77c5acd64773d384dda2cd753f65f1bf5fa7716ff012"
+  },
+  "known_remaining_risk": "The strict live-agent gate remains RED because verified CURIE-linked endpoint recovery and precision remain below trusted graph targets."
+}

--- a/docs/validation/reports/2026-07-05-pr14-entailment-coverage-hardening-summary.md
+++ b/docs/validation/reports/2026-07-05-pr14-entailment-coverage-hardening-summary.md
@@ -1,0 +1,88 @@
+# PR-14 Entailment Coverage Hardening Evidence Snapshot
+
+Date: 2026-07-05
+
+Branch: `alvaro/evidence-pr14-entailment-coverage-hardening`
+
+Base branch: `alvaro/evidence-pr13-specificity-noise-reduction`
+
+## Scope
+
+PR-14 makes the relation feasibility scorecard fail closed for required
+entailment checks:
+
+- Treat missing source grounding or missing relation arguments as checked
+  `NEUTRAL` support instead of unchecked support.
+- Preserve the `support_not_entailed` quality flag for those candidates.
+- Preserve adversarial warnings for ungrounded evidence sentences after the
+  fail-closed entailment change.
+- Remove the adversarial `entailment_not_checked` illusion when missing
+  arguments are already counted as checked non-entailment.
+- Keep fallback/unavailable strict-agent runs ineligible for success.
+
+## Repository Gates
+
+- Failing regression was reproduced before implementation.
+- Focused entailment regressions passed.
+- Adversarial review found a missing report-level warning for ungrounded
+  sentences; a regression and `source_sentence_not_grounded` finding were added.
+- `tests/unit/test_relation_feasibility_audit.py` passed.
+- `make relation-feasibility-quality-gate` passed.
+- `make artana-evidence-api-lint` passed.
+- `make artana-evidence-api-type-check` passed.
+- `make service-checks` passed with coverage at `86.86%`.
+
+## Strict Live-Agent Result
+
+Command:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 \
+  scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-05-pr14-entailment-coverage-hardening
+```
+
+| Metric | PR-13 live | PR-14 live |
+|---|---:|---:|
+| Verdict | RED | RED |
+| Completed-agent precision | 0.8095 | 0.7727 |
+| Completed-agent recall | 0.6800 | 0.6800 |
+| High-value recall | 0.8500 | 0.8500 |
+| Completed-agent valuable rate | 0.8095 | 0.7727 |
+| Generic relation rate | 0.0000 | 0.0455 |
+| Pruned generic relation siblings | 6 | 5 |
+| Quality-filtered candidates | 5 | 5 |
+| Candidate CURIE present rate | 0.9048 | 0.8636 |
+| Verified CURIE match rate | 0.7027 | 0.7027 |
+| Entailment checked rate | 1.0000 | 1.0000 |
+| Entailment supported rate | 0.9048 | 0.9091 |
+| Fallback cases | 0 | 0 |
+| Invalid strict-agent cases | 0 | 0 |
+| Negative-control leakage cases | 0 | 0 |
+| Governed proposal recall among proposal-eligible gold | 1.0000 | 1.0000 |
+
+## Artifacts
+
+- JSON:
+  `reports/relation_feasibility/2026-07-05-pr14-entailment-coverage-hardening/relation_feasibility_report.json`
+- Markdown:
+  `reports/relation_feasibility/2026-07-05-pr14-entailment-coverage-hardening/relation_feasibility_report.md`
+
+## Hashes
+
+| Artifact | SHA-256 |
+|---|---|
+| live-agent JSON | `479126236f20a4bba00585e874e9a368ea5c02efa9ec223e4f0870ab481c7edd` |
+| live-agent Markdown | `7ef2e3c6db0898d2f99c77c5acd64773d384dda2cd753f65f1bf5fa7716ff012` |
+
+## Interpretation
+
+The strict live-agent path completed without deterministic fallback. PR-14
+hardens the scorecard so required entailment can no longer disappear into an
+unchecked bucket when grounding or argument evidence is broken.
+
+The PR is still not trusted-graph ready by itself. The current live-agent run
+remains RED because verified CURIE-linked endpoint recovery is below target,
+and precision is still below the trusted graph construction target.

--- a/scripts/validation/relation_feasibility/adversarial.py
+++ b/scripts/validation/relation_feasibility/adversarial.py
@@ -64,6 +64,16 @@ def find_quality_illusions(report: FeasibilityReport) -> tuple[AdversarialFindin
                 ),
             ),
         )
+    if summary.grounded_sentence_rate < 1.0 and summary.candidate_count > 0:
+        findings.append(
+            AdversarialFinding(
+                code="source_sentence_not_grounded",
+                message=(
+                    "At least one candidate evidence sentence could not be "
+                    "grounded in the source text."
+                ),
+            ),
+        )
     if summary.raw_unknown_relation_type_count > 0:
         findings.append(
             AdversarialFinding(

--- a/scripts/validation/relation_feasibility/scoring.py
+++ b/scripts/validation/relation_feasibility/scoring.py
@@ -759,7 +759,7 @@ def _support_verification(
     if not requires_entailment:
         return None
     if not grounded_sentence or not both_arguments_in_sentence:
-        return None
+        return "NEUTRAL"
     return verify_triple_support(
         sentence=candidate.sentence,
         subject=candidate.subject,

--- a/tests/unit/test_relation_feasibility_audit.py
+++ b/tests/unit/test_relation_feasibility_audit.py
@@ -132,9 +132,15 @@ def test_audit_rejects_off_target_support_sentence_for_matching_triple() -> None
     assert assessment.has_object_in_sentence is False
     assert assessment.has_both_arguments_in_sentence is False
     assert assessment.has_gold_support_sentence is False
+    assert assessment.support_verification == "NEUTRAL"
+    assert assessment.has_support_verification is True
+    assert assessment.has_entailment_support is False
     assert assessment.is_valuable is False
     assert "missing_relation_arguments" in assessment.quality_flags
     assert "support_sentence_mismatch" in assessment.quality_flags
+    assert "support_not_entailed" in assessment.quality_flags
+    assert "support_not_checked" not in assessment.quality_flags
+    assert report.summary.entailment_checked_rate == 1.0
 
 
 def test_audit_requires_entailment_support_for_valuable_candidate() -> None:
@@ -960,10 +966,52 @@ def test_adversarial_findings_warn_when_relation_arguments_are_missing() -> None
 
     assert report.summary.grounded_sentence_rate == 0.5
     assert report.summary.both_arguments_present_rate == 0.5
-    assert {finding.code for finding in findings} >= {
-        "entailment_not_checked",
-        "relation_arguments_missing_from_sentence",
-    }
+    finding_codes = {finding.code for finding in findings}
+
+    assert "entailment_not_checked" not in finding_codes
+    assert "relation_arguments_missing_from_sentence" in finding_codes
+    assert report.summary.entailment_checked_rate == 1.0
+
+
+def test_adversarial_findings_warn_when_source_sentence_is_not_grounded() -> None:
+    cases = (
+        _case(
+            case_id="ungrounded_sentence",
+            text="MED13 activates cardiac septal development.",
+            gold=(),
+        ),
+    )
+
+    def extractor(_: str) -> list[ExtractedRelation]:
+        return [
+            ExtractedRelation(
+                subject="MED13",
+                relation_type="ACTIVATES",
+                object="cardiac septal development",
+                sentence=(
+                    "MED13 activates cardiac septal development in a separate "
+                    "unpublished note."
+                ),
+            ),
+        ]
+
+    report = run_feasibility_audit(cases=cases, extractor=extractor)
+    findings = find_quality_illusions(report)
+    finding_codes = {finding.code for finding in findings}
+    assessment = report.case_results[0].candidate_assessments[0]
+
+    assert assessment.has_grounded_sentence is False
+    assert assessment.has_both_arguments_in_sentence is True
+    assert assessment.support_verification == "NEUTRAL"
+    assert "missing_source_sentence" in assessment.quality_flags
+    assert "support_not_entailed" in assessment.quality_flags
+    assert "support_not_checked" not in assessment.quality_flags
+    assert report.summary.grounded_sentence_rate == 0.0
+    assert report.summary.both_arguments_present_rate == 1.0
+    assert report.summary.entailment_checked_rate == 1.0
+    assert "source_sentence_not_grounded" in finding_codes
+    assert "entailment_not_checked" not in finding_codes
+    assert "relation_arguments_missing_from_sentence" not in finding_codes
 
 
 def test_report_serializes_to_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make required-entailment candidates fail closed to NEUTRAL when grounding or relation arguments are missing
- add adversarial source-grounding warning so fail-closed checks do not hide ungrounded evidence
- add tracked PR14 validation snapshot with strict live-agent metrics and artifact hashes

## Validation
- reproduced failing regressions before implementation
- focused entailment/adversarial regressions passed
- tests/unit/test_relation_feasibility_audit.py passed (42 tests)
- make relation-feasibility-quality-gate passed
- make artana-evidence-api-lint passed
- make artana-evidence-api-type-check passed
- strict live-agent audit passed lane criteria: fallback=0, invalid_agent=0, entailment_checked_rate=1.0000
- adversarial subagent review found missing ungrounded-sentence warning; fixed with source_sentence_not_grounded regression
- make service-checks passed; coverage 86.86%

## Live-Agent Snapshot
Report: docs/validation/reports/2026-07-05-pr14-entailment-coverage-hardening-summary.md

Still RED overall because verified CURIE-linked endpoint recovery and precision remain below trusted graph targets; this PR hardens entailment coverage measurement only.