### PR TITLE
PR15: inventory governed proposed relation types

### DIFF
--- a/docs/validation/reports/2026-07-05-pr15-governed-proposal-inventory-summary.json
+++ b/docs/validation/reports/2026-07-05-pr15-governed-proposal-inventory-summary.json
@@ -1,0 +1,78 @@
+{
+  "report": "PR-15 Governed Proposal Inventory Evidence Snapshot",
+  "date": "2026-07-05",
+  "branch": "alvaro/evidence-pr15-governed-proposal-inventory",
+  "base_branch": "alvaro/evidence-pr14-entailment-coverage-hardening",
+  "scope": [
+    "Add candidate_relation.proposed_relation_type to the relation-type inventory for structured governed proposals.",
+    "Carry governance status on relation-type inventory surfaces.",
+    "Keep candidate_relation.relation_type as the canonical PROPOSE_NEW_RELATION_TYPE sentinel.",
+    "Do not count governed proposed relation-type surfaces as raw unknown blockers.",
+    "Preserve raw-unknown blocking for ungoverned review, proposal, graph, or dictionary surfaces."
+  ],
+  "strict_live_agent_summary": {
+    "verdict": "RED",
+    "completed_agent_precision": 0.8571,
+    "completed_agent_recall": 0.72,
+    "high_value_recall": 0.9,
+    "completed_agent_valuable_rate": 0.8571,
+    "generic_relation_rate": 0.0,
+    "pruned_generic_relations": 5,
+    "quality_filtered_candidates": 7,
+    "relation_type_surface_count": 23,
+    "raw_unknown_relation_type_surface_count": 0,
+    "raw_unknown_relation_type_surface_rate": 0.0,
+    "governed_proposal_candidates": 2,
+    "governed_proposal_gold_matches": 2,
+    "governed_proposal_eligible_gold_relations": 2,
+    "governed_proposal_recall_among_proposal_eligible_gold": 1.0,
+    "candidate_curie_present_rate": 0.9048,
+    "verified_curie_match_rate": 0.7568,
+    "entailment_checked_rate": 1.0,
+    "model_curie_wrong_count": 0,
+    "fallback_cases": 0,
+    "invalid_agent_cases": 0,
+    "negative_control_leakage_cases": 0
+  },
+  "governed_proposed_relation_type_surfaces": [
+    {
+      "surface": "candidate_relation.proposed_relation_type",
+      "relation_type": "CONFERS_RESISTANCE_TO",
+      "source_ref": "MET amplification->erlotinib",
+      "governance_status": "requires_relation_review"
+    },
+    {
+      "surface": "candidate_relation.proposed_relation_type",
+      "relation_type": "CONFERS_RESISTANCE_TO",
+      "source_ref": "MET amplification->erlotinib",
+      "governance_status": "requires_relation_review"
+    }
+  ],
+  "delta_from_pr14": {
+    "completed_agent_precision": "+0.0844",
+    "completed_agent_recall": "+0.0400",
+    "high_value_recall": "+0.0500",
+    "completed_agent_valuable_rate": "+0.0844",
+    "generic_relation_rate": "-0.0455",
+    "verified_curie_match_rate": "+0.0541",
+    "governed_proposal_recall_among_proposal_eligible_gold": "+0.0000"
+  },
+  "validation": {
+    "failing_regression_reproduced": "passed",
+    "focused_governed_proposal_inventory_regression": "passed",
+    "adversarial_review_issue_addressed": "passed",
+    "relation_feasibility_audit_unit_suite": "passed",
+    "relation_feasibility_quality_gate": "passed",
+    "artana_evidence_api_lint": "passed",
+    "artana_evidence_api_type_check": "passed",
+    "service_checks": "passed",
+    "service_checks_coverage": "86.86%"
+  },
+  "artifacts": {
+    "live_agent_json": "reports/relation_feasibility/2026-07-05-pr15-governed-proposal-inventory-r2/relation_feasibility_report.json",
+    "live_agent_markdown": "reports/relation_feasibility/2026-07-05-pr15-governed-proposal-inventory-r2/relation_feasibility_report.md",
+    "live_agent_json_sha256": "b7620d0024c2b74a35a510c15056b5b3963083197a26b1e45be7c6851c5eff2b",
+    "live_agent_markdown_sha256": "b7b4f8c9dd26e79aba667468c49e4e5a580a192b2a2ffcf1b039a54c520e696a"
+  },
+  "known_remaining_risk": "The strict live-agent gate remains RED because verified CURIE-linked endpoint recovery remains below trusted graph target."
+}

--- a/docs/validation/reports/2026-07-05-pr15-governed-proposal-inventory-summary.md
+++ b/docs/validation/reports/2026-07-05-pr15-governed-proposal-inventory-summary.md
@@ -1,0 +1,102 @@
+# PR-15 Governed Proposal Inventory Evidence Snapshot
+
+Date: 2026-07-05
+
+Branch: `alvaro/evidence-pr15-governed-proposal-inventory`
+
+Base branch: `alvaro/evidence-pr14-entailment-coverage-hardening`
+
+## Scope
+
+PR-15 makes governed relation proposals auditable without promoting them as
+trusted graph edges:
+
+- Add `candidate_relation.proposed_relation_type` to the relation-type
+  inventory for structured governed proposals.
+- Carry governance status on relation-type inventory surfaces.
+- Keep `candidate_relation.relation_type` as the canonical
+  `PROPOSE_NEW_RELATION_TYPE` sentinel.
+- Do not count governed proposed relation-type surfaces as raw unknown blockers.
+- Preserve raw-unknown blocking for ungoverned review, proposal, graph, or
+  dictionary surfaces.
+
+## Repository Gates
+
+- Failing regression was reproduced before implementation.
+- Focused governed-proposal inventory regression passed.
+- Adversarial review found that proposed-type surfaces were exempted by surface
+  name alone; a negative regression now proves ungoverned proposed types block.
+- `tests/unit/test_relation_feasibility_audit.py` passed.
+- `make relation-feasibility-quality-gate` passed.
+- `make artana-evidence-api-lint` passed.
+- `make artana-evidence-api-type-check` passed.
+- `make service-checks` passed with coverage at `86.86%`.
+
+## Strict Live-Agent Result
+
+Command:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 \
+  scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-05-pr15-governed-proposal-inventory-r2
+```
+
+| Metric | PR-14 live | PR-15 live |
+|---|---:|---:|
+| Verdict | RED | RED |
+| Completed-agent precision | 0.7727 | 0.8571 |
+| Completed-agent recall | 0.6800 | 0.7200 |
+| High-value recall | 0.8500 | 0.9000 |
+| Completed-agent valuable rate | 0.7727 | 0.8571 |
+| Generic relation rate | 0.0455 | 0.0000 |
+| Pruned generic relation siblings | 5 | 5 |
+| Quality-filtered candidates | 5 | 7 |
+| Relation type inventory surfaces | not tracked in PR-14 summary | 23 |
+| Raw unknown inventory relation types | not tracked in PR-14 summary | 0 |
+| Governed proposal candidates | not tracked in PR-14 summary | 2 |
+| Governed proposal gold matches | not tracked in PR-14 summary | 2 |
+| Governed proposal-eligible gold relations | not tracked in PR-14 summary | 2 |
+| Governed proposal recall among proposal-eligible gold | 1.0000 | 1.0000 |
+| Candidate CURIE present rate | 0.8636 | 0.9048 |
+| Verified CURIE match rate | 0.7027 | 0.7568 |
+| Entailment checked rate | 1.0000 | 1.0000 |
+| Fallback cases | 0 | 0 |
+| Invalid strict-agent cases | 0 | 0 |
+| Negative-control leakage cases | 0 | 0 |
+
+Observed governed proposed relation-type inventory surfaces:
+
+| Proposed type | Source | Governance |
+|---|---|---|
+| `CONFERS_RESISTANCE_TO` | `MET amplification->erlotinib` | `requires_relation_review` |
+| `CONFERS_RESISTANCE_TO` | `MET amplification->erlotinib` | `requires_relation_review` |
+
+## Artifacts
+
+- JSON:
+  `reports/relation_feasibility/2026-07-05-pr15-governed-proposal-inventory-r2/relation_feasibility_report.json`
+- Markdown:
+  `reports/relation_feasibility/2026-07-05-pr15-governed-proposal-inventory-r2/relation_feasibility_report.md`
+
+## Hashes
+
+| Artifact | SHA-256 |
+|---|---|
+| live-agent JSON | `b7620d0024c2b74a35a510c15056b5b3963083197a26b1e45be7c6851c5eff2b` |
+| live-agent Markdown | `b7b4f8c9dd26e79aba667468c49e4e5a580a192b2a2ffcf1b039a54c520e696a` |
+
+## Interpretation
+
+The strict live-agent path completed without deterministic fallback. PR-15
+does not make governed relation proposals trusted graph evidence; it makes the
+actual proposed relation type visible in audit inventory and verifies those
+governed surfaces do not trigger raw-unknown blockers. The scorecard now checks
+the inventory surface governance status before exempting proposed relation
+types, so malformed or ungoverned proposed types still fail closed.
+
+The PR is still not trusted-graph ready by itself. The current live-agent run
+remains RED because verified CURIE-linked endpoint recovery remains below
+target.

--- a/scripts/run_relation_feasibility_audit.py
+++ b/scripts/run_relation_feasibility_audit.py
@@ -216,14 +216,27 @@ def _agent_relation_extraction_result_from_candidates(
 def _candidate_relation_type_surfaces(
     relations: tuple[ExtractedRelation, ...],
 ) -> tuple[RelationTypeSurface, ...]:
-    return tuple(
-        RelationTypeSurface(
-            surface="candidate_relation.relation_type",
-            relation_type=relation.relation_type,
-            source_ref=f"{relation.subject}->{relation.object}",
+    surfaces: list[RelationTypeSurface] = []
+    for relation in relations:
+        source_ref = f"{relation.subject}->{relation.object}"
+        surfaces.append(
+            RelationTypeSurface(
+                surface="candidate_relation.relation_type",
+                relation_type=relation.relation_type,
+                source_ref=source_ref,
+                governance_status=relation.relation_governance_status,
+            ),
         )
-        for relation in relations
-    )
+        if relation.proposed_relation_type is not None:
+            surfaces.append(
+                RelationTypeSurface(
+                    surface="candidate_relation.proposed_relation_type",
+                    relation_type=relation.proposed_relation_type,
+                    source_ref=source_ref,
+                    governance_status=relation.relation_governance_status,
+                ),
+            )
+    return tuple(surfaces)
 
 
 def main() -> int:

--- a/scripts/validation/relation_feasibility/models.py
+++ b/scripts/validation/relation_feasibility/models.py
@@ -125,6 +125,7 @@ class RelationTypeSurface:
     surface: str
     relation_type: str
     source_ref: str
+    governance_status: RelationGovernanceStatus | None = None
 
     def to_json(self) -> dict[str, object]:
         """Return a JSON-compatible representation."""
@@ -133,6 +134,7 @@ class RelationTypeSurface:
             "surface": self.surface,
             "relation_type": self.relation_type,
             "source_ref": self.source_ref,
+            "governance_status": self.governance_status,
         }
 
 

--- a/scripts/validation/relation_feasibility/scoring.py
+++ b/scripts/validation/relation_feasibility/scoring.py
@@ -202,7 +202,7 @@ def build_summary(inputs: SummaryInputs) -> FeasibilitySummary:
     raw_unknown_relation_type_surface_count = sum(
         1
         for surface in relation_type_surfaces
-        if not _is_known_relation_type(surface.relation_type)
+        if not _is_known_relation_type_surface(surface)
     )
     proposal_candidate_count = sum(
         1 for assessment in candidates if assessment.is_governed_relation_proposal
@@ -912,6 +912,17 @@ def _is_known_relation_type(relation_type: str) -> bool:
         normalized in LLM_VALID_RELATION_TYPES
         or normalized == LLM_PROPOSE_NEW_RELATION_TYPE
     )
+
+
+def _is_known_relation_type_surface(surface: RelationTypeSurface) -> bool:
+    if surface.surface == "candidate_relation.proposed_relation_type":
+        normalized = _normalize_relation_type(surface.relation_type)
+        return (
+            surface.governance_status == "requires_relation_review"
+            and normalized != ""
+            and normalized != LLM_PROPOSE_NEW_RELATION_TYPE
+        )
+    return _is_known_relation_type(surface.relation_type)
 
 
 def _is_governed_relation_proposal(candidate: ExtractedRelation) -> bool:

--- a/tests/unit/test_relation_feasibility_audit.py
+++ b/tests/unit/test_relation_feasibility_audit.py
@@ -478,6 +478,110 @@ def test_agent_adapter_preserves_candidate_provenance_and_governance_fields() ->
     assert result.relations[1].trusted_evidence_eligible is False
 
 
+def test_agent_adapter_inventory_indexes_governed_proposed_relation_type() -> None:
+    candidates = [
+        ExtractedRelationCandidate(
+            subject_label="MET amplification",
+            relation_type="PROPOSE_NEW_RELATION_TYPE",
+            proposed_relation_type="CONFERS_RESISTANCE_TO",
+            new_relation_type_rationale="Specific resistance relation.",
+            relation_governance_status="requires_relation_review",
+            object_label="erlotinib",
+            sentence="MET amplification confers resistance to erlotinib.",
+        ),
+    ]
+    diagnostics = DocumentCandidateExtractionDiagnostics(
+        llm_candidate_status="completed",
+        llm_candidate_count=1,
+    )
+
+    result = _agent_relation_extraction_result_from_candidates(
+        candidates=candidates,
+        diagnostics=diagnostics,
+    )
+    case = _case(
+        case_id="governed_proposal_inventory",
+        text="MET amplification confers resistance to erlotinib.",
+        gold=(
+            GoldRelation(
+                subject="MET amplification",
+                relation_type="CONFERS_RESISTANCE_TO",
+                object="erlotinib",
+                support_sentence="MET amplification confers resistance to erlotinib.",
+                value_level="high",
+                rationale="Relation needs dictionary governance.",
+            ),
+        ),
+    )
+
+    report = run_feasibility_audit(cases=(case,), extractor=lambda _: result)
+    markdown = render_markdown_report(report)
+    surfaces = {
+        (surface.surface, surface.relation_type)
+        for surface in report.case_results[0].relation_type_surfaces
+    }
+
+    assert surfaces == {
+        ("candidate_relation.relation_type", "PROPOSE_NEW_RELATION_TYPE"),
+        ("candidate_relation.proposed_relation_type", "CONFERS_RESISTANCE_TO"),
+    }
+    proposed_surfaces = tuple(
+        surface
+        for surface in report.case_results[0].relation_type_surfaces
+        if surface.surface == "candidate_relation.proposed_relation_type"
+    )
+
+    assert proposed_surfaces[0].governance_status == "requires_relation_review"
+    assert report.summary.relation_type_surface_count == 2
+    assert report.summary.raw_unknown_relation_type_surface_count == 0
+    assert report.summary.proposal_recall_against_proposal_eligible_gold == 1.0
+    assert (
+        "`candidate_relation.proposed_relation_type` -> `CONFERS_RESISTANCE_TO`"
+        in markdown
+    )
+
+
+def test_agent_adapter_inventory_blocks_ungoverned_proposed_relation_type() -> None:
+    candidates = [
+        ExtractedRelationCandidate(
+            subject_label="BRCA1",
+            relation_type="ACTIVATES",
+            proposed_relation_type="PROTECTS_AGAINST",
+            object_label="TP53",
+            sentence="BRCA1 activates TP53.",
+        ),
+    ]
+    diagnostics = DocumentCandidateExtractionDiagnostics(
+        llm_candidate_status="completed",
+        llm_candidate_count=1,
+    )
+
+    result = _agent_relation_extraction_result_from_candidates(
+        candidates=candidates,
+        diagnostics=diagnostics,
+    )
+    case = _case(
+        case_id="ungoverned_proposed_type_inventory",
+        text="BRCA1 activates TP53.",
+        gold=(),
+    )
+
+    report = run_feasibility_audit(cases=(case,), extractor=lambda _: result)
+    proposed_surfaces = tuple(
+        surface
+        for surface in report.case_results[0].relation_type_surfaces
+        if surface.surface == "candidate_relation.proposed_relation_type"
+    )
+
+    assert len(proposed_surfaces) == 1
+    assert proposed_surfaces[0].relation_type == "PROTECTS_AGAINST"
+    assert proposed_surfaces[0].governance_status == "canonical"
+    assert report.summary.relation_type_surface_count == 2
+    assert report.summary.raw_unknown_relation_type_surface_count == 1
+    assert report.summary.verdict == "RED"
+    assert "raw unknown relation type" in report.summary.verdict_reason
+
+
 def test_summary_reports_high_value_and_low_value_recall_separately() -> None:
     high_value_case = _case(
         case_id="high_value_mechanism",


### PR DESCRIPTION
## Summary
- add candidate_relation.proposed_relation_type to relation-type inventory surfaces
- carry governance status on inventory surfaces
- exempt proposed relation-type surfaces only when governance status is requires_relation_review
- add negative regression so ungoverned proposed relation types still block as raw inventory issues

## Validation
- reproduced failing inventory regression before implementation
- focused governed and ungoverned proposed-type regressions passed
- tests/unit/test_relation_feasibility_audit.py passed (44 tests)
- make relation-feasibility-quality-gate passed
- make artana-evidence-api-lint passed
- make artana-evidence-api-type-check passed
- strict live-agent audit r2: fallback=0, invalid_agent=0, proposal-eligible recall=1.0000, raw_unknown_relation_type_surface_count=0, relation_type_surface_count=23
- adversarial subagent review found governance-context hole; fixed with governance_status on RelationTypeSurface and negative regression
- make service-checks passed; coverage 86.86%

## Live-Agent Snapshot
Report: docs/validation/reports/2026-07-05-pr15-governed-proposal-inventory-summary.md

Still RED overall because verified CURIE-linked endpoint recovery remains below trusted graph target; this PR improves governed proposal observability only.