### PR TITLE
PR16: add relation repeatability readiness gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ coverage-check: ## Enforce service coverage threshold
 
 relation-feasibility-quality-gate: ## Run relation feasibility quality regression tests
 	$(call check_venv)
-	PYTHONPATH="$(CURDIR)/services:$(CURDIR)" $(USE_PYTHON) -m pytest tests/unit/test_relation_feasibility_audit.py -q
+	PYTHONPATH="$(CURDIR)/services:$(CURDIR)" $(USE_PYTHON) -m pytest tests/unit/test_relation_feasibility_audit.py tests/unit/test_relation_feasibility_readiness_gate.py -q
 
 artana-evidence-api-static-checks-core: ## Run evidence API static gates except repo-wide size check
 	@$(MAKE) -s artana-evidence-api-lint

--- a/docs/validation/reports/2026-07-05-pr16-repeatability-readiness-summary.json
+++ b/docs/validation/reports/2026-07-05-pr16-repeatability-readiness-summary.json
@@ -1,0 +1,122 @@
+{
+  "report": "PR-16 Repeatability Readiness Evidence Snapshot",
+  "date": "2026-07-05",
+  "branch": "alvaro/evidence-pr16-repeatability-readiness",
+  "base_branch": "alvaro/evidence-pr15-governed-proposal-inventory",
+  "scope": [
+    "Aggregate multiple strict live-agent feasibility reports.",
+    "Require a minimum number of repeated strict runs before any trusted-graph readiness claim.",
+    "Fail closed on fallback, invalid agent completion, negative-control leakage, raw unknown relation surfaces, and wrong verified CURIE links.",
+    "Fail closed on malformed or schema-drifted input reports, including missing or non-numeric required metrics.",
+    "Fail closed if any source feasibility audit is already RED.",
+    "Evaluate worst-run precision, recall, high-value recall, valuable-candidate rate, generic relation rate, verified CURIE recovery, and entailment coverage.",
+    "Keep the default CLI non-destructive for evidence generation, with --fail-on-not-ready available for hard CI gating."
+  ],
+  "strict_live_agent_runs": [
+    {
+      "run": "run1",
+      "completed_agent_precision": 0.8095,
+      "completed_agent_recall": 0.68,
+      "high_value_recall": 0.85,
+      "completed_agent_valuable_rate": 0.8095,
+      "generic_relation_rate": 0.0,
+      "curie_linked_gold_endpoint_rate": 0.7027,
+      "governed_proposal_recall_among_proposal_eligible_gold": 0.5,
+      "fallback_cases": 0,
+      "invalid_agent_cases": 0,
+      "negative_control_leakage_cases": 0
+    },
+    {
+      "run": "run2",
+      "completed_agent_precision": 0.7619,
+      "completed_agent_recall": 0.64,
+      "high_value_recall": 0.8,
+      "completed_agent_valuable_rate": 0.7619,
+      "generic_relation_rate": 0.0,
+      "curie_linked_gold_endpoint_rate": 0.6486,
+      "governed_proposal_recall_among_proposal_eligible_gold": 0.5,
+      "fallback_cases": 0,
+      "invalid_agent_cases": 0,
+      "negative_control_leakage_cases": 0
+    },
+    {
+      "run": "run3",
+      "completed_agent_precision": 0.8095,
+      "completed_agent_recall": 0.68,
+      "high_value_recall": 0.85,
+      "completed_agent_valuable_rate": 0.8095,
+      "generic_relation_rate": 0.0,
+      "curie_linked_gold_endpoint_rate": 0.7027,
+      "governed_proposal_recall_among_proposal_eligible_gold": 1.0,
+      "fallback_cases": 0,
+      "invalid_agent_cases": 0,
+      "negative_control_leakage_cases": 0
+    }
+  ],
+  "readiness_gate": {
+    "trusted_graph_ready": false,
+    "readiness_status": "not_ready",
+    "run_count": 3,
+    "required_run_count": 3,
+    "red_source_report_count": 3,
+    "required_metric_errors": [],
+    "blocking_reasons": [
+      "3 source audit reports were RED.",
+      "Worst-run completed-agent precision is below target.",
+      "Worst-run high-value recall is below target.",
+      "Worst-run CURIE-linked gold endpoint rate is below target."
+    ],
+    "hard_failure_counts": {
+      "fallback_case_count": 0,
+      "invalid_agent_case_count": 0,
+      "negative_control_leakage_count": 0,
+      "raw_unknown_relation_type_count": 0,
+      "raw_unknown_relation_type_surface_count": 0,
+      "wrong_verified_curie_link_count": 0
+    },
+    "worst_metrics": {
+      "completed_agent_precision_against_gold": 0.7619,
+      "completed_agent_recall_against_gold": 0.64,
+      "high_value_recall": 0.8,
+      "completed_agent_valuable_candidate_rate": 0.7619,
+      "curie_linked_gold_endpoint_rate": 0.6486,
+      "verified_curie_match_rate": 0.6486,
+      "entailment_checked_rate": 1.0,
+      "generic_relation_rate": 0.0
+    },
+    "mean_metrics": {
+      "completed_agent_precision_against_gold": 0.7936,
+      "completed_agent_recall_against_gold": 0.6667,
+      "high_value_recall": 0.8333,
+      "completed_agent_valuable_candidate_rate": 0.7936,
+      "curie_linked_gold_endpoint_rate": 0.6847,
+      "verified_curie_match_rate": 0.6847,
+      "entailment_checked_rate": 1.0,
+      "generic_relation_rate": 0.0
+    }
+  },
+  "validation": {
+    "failing_import_regression_reproduced": "passed",
+    "relation_feasibility_readiness_unit_tests": "passed",
+    "adversarial_review_issue_addressed": "passed",
+    "relation_feasibility_quality_gate": "passed",
+    "artana_evidence_api_lint": "passed",
+    "artana_evidence_api_type_check": "passed",
+    "fail_on_not_ready_exit_status": "1",
+    "service_checks": "passed",
+    "service_checks_coverage": "86.86%"
+  },
+  "artifacts": {
+    "run1_json": "reports/relation_feasibility/2026-07-05-pr16-repeatability-run1/relation_feasibility_report.json",
+    "run2_json": "reports/relation_feasibility/2026-07-05-pr16-repeatability-run2/relation_feasibility_report.json",
+    "run3_json": "reports/relation_feasibility/2026-07-05-pr16-repeatability-run3/relation_feasibility_report.json",
+    "readiness_json": "reports/relation_feasibility_readiness/2026-07-05-pr16-repeatability-readiness-r2/relation_feasibility_readiness_report.json",
+    "readiness_markdown": "reports/relation_feasibility_readiness/2026-07-05-pr16-repeatability-readiness-r2/relation_feasibility_readiness_report.md",
+    "run1_json_sha256": "9f68f62e3754886d5d3356b182167d9c7dd9381fc9f32485f1cef8674ab1702a",
+    "run2_json_sha256": "3a02fc86772401818d08df11fcd0322db334e509506132ffc90b31ee7d13fa88",
+    "run3_json_sha256": "e62048277442a23068688a64e8d7a20fb0d50367d37a52b0a1a87cc99d991d28",
+    "readiness_json_sha256": "59d0921b80e4161396de0df56458c4e81caf2bec04fab5dfd45bbe714eb0b79d",
+    "readiness_markdown_sha256": "c8c93114756703c330f82978f654487bca52b37c8dbc0d157cf5f510e561ca75"
+  },
+  "known_remaining_risk": "The current stack is not trusted-graph ready. Auto-promotion should remain blocked until repeated runs clear precision, high-value recall, and verified CURIE recovery targets."
+}

--- a/docs/validation/reports/2026-07-05-pr16-repeatability-readiness-summary.md
+++ b/docs/validation/reports/2026-07-05-pr16-repeatability-readiness-summary.md
@@ -1,0 +1,161 @@
+# PR-16 Repeatability Readiness Evidence Snapshot
+
+Date: 2026-07-05
+
+Branch: `alvaro/evidence-pr16-repeatability-readiness`
+
+Base branch: `alvaro/evidence-pr15-governed-proposal-inventory`
+
+## Scope
+
+PR-16 adds a repeatability/readiness gate for relation feasibility reports:
+
+- Aggregate multiple strict live-agent feasibility reports.
+- Require a minimum number of repeated strict runs before any trusted-graph
+  readiness claim.
+- Fail closed on fallback, invalid agent completion, negative-control leakage,
+  raw unknown relation surfaces, and wrong verified CURIE links.
+- Fail closed on malformed or schema-drifted input reports, including missing
+  or non-numeric required metrics.
+- Fail closed if any source feasibility audit is already `RED`.
+- Evaluate worst-run precision, recall, high-value recall, valuable-candidate
+  rate, generic relation rate, verified CURIE recovery, and entailment coverage.
+- Keep the default CLI non-destructive for evidence generation, with
+  `--fail-on-not-ready` available for hard CI gating.
+
+## Repository Gates
+
+- Failing import regression was reproduced before implementation.
+- `tests/unit/test_relation_feasibility_readiness_gate.py` passed.
+- Adversarial review found fail-open handling for malformed reports and
+  upstream `RED` reports; both now have negative regressions.
+- `make relation-feasibility-quality-gate` now includes the readiness tests and
+  passed.
+- `make artana-evidence-api-lint` passed.
+- `make artana-evidence-api-type-check` passed.
+- `--fail-on-not-ready` returned exit status `1` for the current NOT READY
+  repeatability gate, as expected.
+- `make service-checks` passed with coverage at `86.86%`.
+
+## Strict Live-Agent Repeatability Runs
+
+Commands:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-05-pr16-repeatability-run1
+
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-05-pr16-repeatability-run2
+
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-05-pr16-repeatability-run3
+```
+
+| Run | Precision | Recall | High-value recall | Valuable rate | Generic rate | CURIE endpoint rate | Proposal-eligible recall | Fallback | Invalid agent | Negative leakage |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| run1 | 0.8095 | 0.6800 | 0.8500 | 0.8095 | 0.0000 | 0.7027 | 0.5000 | 0 | 0 | 0 |
+| run2 | 0.7619 | 0.6400 | 0.8000 | 0.7619 | 0.0000 | 0.6486 | 0.5000 | 0 | 0 | 0 |
+| run3 | 0.8095 | 0.6800 | 0.8500 | 0.8095 | 0.0000 | 0.7027 | 1.0000 | 0 | 0 | 0 |
+
+## Readiness Gate
+
+Command:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_readiness_gate.py \
+  --report reports/relation_feasibility/2026-07-05-pr16-repeatability-run1 \
+  --report reports/relation_feasibility/2026-07-05-pr16-repeatability-run2 \
+  --report reports/relation_feasibility/2026-07-05-pr16-repeatability-run3 \
+  --output-dir reports/relation_feasibility_readiness/2026-07-05-pr16-repeatability-readiness-r2
+```
+
+Result: `not_ready`
+
+Blocking reasons:
+
+- Worst-run completed-agent precision is below target.
+- Worst-run high-value recall is below target.
+- Worst-run CURIE-linked gold endpoint rate is below target.
+- 3 source audit reports were RED.
+
+Required metric errors: none.
+
+Hard failure counts:
+
+| Failure | Count |
+|---|---:|
+| Fallback cases | 0 |
+| Invalid strict-agent cases | 0 |
+| Negative-control leakage | 0 |
+| Raw unknown candidate relation types | 0 |
+| Raw unknown inventory relation-type surfaces | 0 |
+| Wrong verified CURIE links | 0 |
+
+Worst metrics:
+
+| Metric | Value |
+|---|---:|
+| Completed-agent precision | 0.7619 |
+| Completed-agent recall | 0.6400 |
+| High-value recall | 0.8000 |
+| Completed-agent valuable rate | 0.7619 |
+| Generic relation rate | 0.0000 |
+| CURIE-linked gold endpoint rate | 0.6486 |
+| Verified CURIE match rate | 0.6486 |
+| Entailment checked rate | 1.0000 |
+
+Mean metrics:
+
+| Metric | Value |
+|---|---:|
+| Completed-agent precision | 0.7936 |
+| Completed-agent recall | 0.6667 |
+| High-value recall | 0.8333 |
+| Completed-agent valuable rate | 0.7936 |
+| Generic relation rate | 0.0000 |
+| CURIE-linked gold endpoint rate | 0.6847 |
+| Verified CURIE match rate | 0.6847 |
+| Entailment checked rate | 1.0000 |
+
+## Artifacts
+
+- Run 1 JSON:
+  `reports/relation_feasibility/2026-07-05-pr16-repeatability-run1/relation_feasibility_report.json`
+- Run 2 JSON:
+  `reports/relation_feasibility/2026-07-05-pr16-repeatability-run2/relation_feasibility_report.json`
+- Run 3 JSON:
+  `reports/relation_feasibility/2026-07-05-pr16-repeatability-run3/relation_feasibility_report.json`
+- Readiness JSON:
+  `reports/relation_feasibility_readiness/2026-07-05-pr16-repeatability-readiness-r2/relation_feasibility_readiness_report.json`
+- Readiness Markdown:
+  `reports/relation_feasibility_readiness/2026-07-05-pr16-repeatability-readiness-r2/relation_feasibility_readiness_report.md`
+
+## Hashes
+
+| Artifact | SHA-256 |
+|---|---|
+| run1 JSON | `9f68f62e3754886d5d3356b182167d9c7dd9381fc9f32485f1cef8674ab1702a` |
+| run2 JSON | `3a02fc86772401818d08df11fcd0322db334e509506132ffc90b31ee7d13fa88` |
+| run3 JSON | `e62048277442a23068688a64e8d7a20fb0d50367d37a52b0a1a87cc99d991d28` |
+| readiness JSON | `59d0921b80e4161396de0df56458c4e81caf2bec04fab5dfd45bbe714eb0b79d` |
+| readiness Markdown | `c8c93114756703c330f82978f654487bca52b37c8dbc0d157cf5f510e561ca75` |
+
+## Interpretation
+
+The current stack is materially better than the original live-agent path:
+fallback, invalid-agent cases, negative leakage, raw unknown relation surfaces,
+generic relation noise, and unchecked entailment are all controlled in these
+three runs.
+
+It is still not trusted-graph ready. The repeated runs show live variance, and
+the worst run misses precision, high-value recall, and verified CURIE recovery
+targets. Auto-promotion should remain blocked until entity linking and
+precision/recall stability clear this repeatability gate.

--- a/scripts/run_relation_feasibility_readiness_gate.py
+++ b/scripts/run_relation_feasibility_readiness_gate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Build a repeatability readiness gate from relation feasibility reports."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SERVICES_ROOT = _REPO_ROOT / "services"
+for _path in (_REPO_ROOT, _SERVICES_ROOT):
+    _path_text = str(_path)
+    if _path_text not in sys.path:
+        sys.path.insert(0, _path_text)
+
+from scripts.validation.relation_feasibility.readiness import (  # noqa: E402
+    build_readiness_report,
+    write_readiness_report,
+)
+
+_DEFAULT_REPORT_ROOT = _REPO_ROOT / "reports" / "relation_feasibility_readiness"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Aggregate repeated strict live-agent relation feasibility reports "
+            "into a trusted-graph readiness gate."
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        action="append",
+        type=Path,
+        required=True,
+        help=(
+            "Path to relation_feasibility_report.json, or a directory containing "
+            "that file. Repeat for each strict live-agent run."
+        ),
+    )
+    parser.add_argument(
+        "--min-runs",
+        type=int,
+        default=3,
+        help="Minimum repeated strict runs required for readiness.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Output directory. Defaults to reports/relation_feasibility_readiness/<timestamp>.",
+    )
+    parser.add_argument(
+        "--fail-on-not-ready",
+        action="store_true",
+        help="Exit nonzero when the readiness gate is not ready.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the readiness gate and write artifacts."""
+
+    args = parse_args(argv)
+    report_paths = tuple(_resolve_report_path(path) for path in args.report)
+    output_dir = args.output_dir or _timestamped_output_dir()
+    report = build_readiness_report(
+        report_paths=report_paths,
+        min_runs=args.min_runs,
+    )
+    manifest = write_readiness_report(report=report, output_dir=output_dir)
+    status = report["readiness_status"]
+    print(
+        "relation_feasibility_readiness "
+        f"status={status} "
+        f"runs={report['run_count']}/{report['required_run_count']} "
+        f"blocking_reasons={len(report['blocking_reasons'])}",
+    )
+    print(f"Wrote JSON report: {manifest['json_path']}")
+    print(f"Wrote Markdown report: {manifest['markdown_path']}")
+    if args.fail_on_not_ready and report.get("trusted_graph_ready") is not True:
+        return 1
+    return 0
+
+
+def _resolve_report_path(path: Path) -> Path:
+    if path.is_dir():
+        return path / "relation_feasibility_report.json"
+    return path
+
+
+def _timestamped_output_dir() -> Path:
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return _DEFAULT_REPORT_ROOT / timestamp
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/relation_feasibility/readiness.py
+++ b/scripts/validation/relation_feasibility/readiness.py
@@ -1,0 +1,356 @@
+"""Repeatability readiness gate for relation feasibility reports."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+JSONObject = dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class ReadinessThresholds:
+    """Thresholds for trusted graph repeatability readiness."""
+
+    min_precision: float = 0.8
+    min_recall: float = 0.6
+    min_high_value_recall: float = 0.85
+    min_valuable_rate: float = 0.7
+    max_generic_rate: float = 0.05
+    min_curie_linked_endpoint_rate: float = 0.95
+    min_entailment_checked_rate: float = 1.0
+
+
+_LOWER_IS_BETTER_METRICS = ("generic_relation_rate",)
+_HIGHER_IS_BETTER_METRICS = (
+    "completed_agent_precision_against_gold",
+    "completed_agent_recall_against_gold",
+    "high_value_recall",
+    "completed_agent_valuable_candidate_rate",
+    "curie_linked_gold_endpoint_rate",
+    "verified_curie_match_rate",
+    "entailment_checked_rate",
+)
+_HARD_FAILURE_COUNT_KEYS = (
+    "fallback_case_count",
+    "invalid_agent_case_count",
+    "negative_control_leakage_count",
+    "raw_unknown_relation_type_count",
+    "raw_unknown_relation_type_surface_count",
+    "wrong_verified_curie_link_count",
+)
+_REQUIRED_NUMERIC_METRICS = (
+    *_HIGHER_IS_BETTER_METRICS,
+    *_LOWER_IS_BETTER_METRICS,
+    *_HARD_FAILURE_COUNT_KEYS,
+)
+
+
+def build_readiness_report(
+    *,
+    report_paths: Sequence[Path],
+    min_runs: int = 3,
+    thresholds: ReadinessThresholds = ReadinessThresholds(),
+) -> JSONObject:
+    """Build a repeatability readiness report from single-run audit reports."""
+
+    summaries = tuple(_load_summary(path) for path in report_paths)
+    run_count = len(summaries)
+    metric_errors = _required_metric_errors(summaries)
+    red_source_report_count = sum(
+        1 for summary in summaries if summary.get("verdict") == "RED"
+    )
+    worst_metrics = _worst_metrics(summaries)
+    mean_metrics = _mean_metrics(summaries)
+    hard_failure_counts = {
+        key: sum(_int_metric(summary, key) for summary in summaries)
+        for key in _HARD_FAILURE_COUNT_KEYS
+    }
+    blocking_reasons = _blocking_reasons(
+        run_count=run_count,
+        min_runs=min_runs,
+        worst_metrics=worst_metrics,
+        hard_failure_counts=hard_failure_counts,
+        metric_errors=metric_errors,
+        red_source_report_count=red_source_report_count,
+        thresholds=thresholds,
+    )
+    trusted_graph_ready = len(blocking_reasons) == 0
+    return {
+        "trusted_graph_ready": trusted_graph_ready,
+        "readiness_status": "ready" if trusted_graph_ready else "not_ready",
+        "run_count": run_count,
+        "required_run_count": min_runs,
+        "input_reports": [str(path) for path in report_paths],
+        "red_source_report_count": red_source_report_count,
+        "hard_failure_counts": hard_failure_counts,
+        "required_metric_errors": metric_errors,
+        "worst_metrics": worst_metrics,
+        "mean_metrics": mean_metrics,
+        "blocking_reasons": blocking_reasons,
+        "thresholds": {
+            "min_precision": thresholds.min_precision,
+            "min_recall": thresholds.min_recall,
+            "min_high_value_recall": thresholds.min_high_value_recall,
+            "min_valuable_rate": thresholds.min_valuable_rate,
+            "max_generic_rate": thresholds.max_generic_rate,
+            "min_curie_linked_endpoint_rate": (
+                thresholds.min_curie_linked_endpoint_rate
+            ),
+            "min_entailment_checked_rate": thresholds.min_entailment_checked_rate,
+        },
+    }
+
+
+def render_readiness_markdown(report: JSONObject) -> str:
+    """Render a repeatability readiness report as Markdown."""
+
+    ready = report.get("trusted_graph_ready") is True
+    status = "READY" if ready else "NOT READY"
+    lines = [
+        "# Relation Feasibility Repeatability Readiness",
+        "",
+        f"- Trusted graph readiness: **{status}**",
+        f"- Runs evaluated: {report.get('run_count')} / {report.get('required_run_count')}",
+        "",
+        "## Blocking Reasons",
+        "",
+    ]
+    blocking_reasons = _string_list(report.get("blocking_reasons"))
+    if blocking_reasons:
+        lines.extend(f"- {reason}" for reason in blocking_reasons)
+    else:
+        lines.append("- none")
+    lines.extend(
+        [
+            "",
+            "## Required Metric Errors",
+            "",
+        ],
+    )
+    required_metric_errors = _string_list(report.get("required_metric_errors"))
+    if required_metric_errors:
+        lines.extend(f"- {reason}" for reason in required_metric_errors)
+    else:
+        lines.append("- none")
+    lines.extend(
+        [
+            "",
+            "## Hard Failure Counts",
+            "",
+        ],
+    )
+    lines.extend(_metric_lines(report.get("hard_failure_counts")))
+    lines.extend(
+        [
+            "",
+            "## Worst Metrics",
+            "",
+        ],
+    )
+    lines.extend(_metric_lines(report.get("worst_metrics")))
+    lines.extend(
+        [
+            "",
+            "## Mean Metrics",
+            "",
+        ],
+    )
+    lines.extend(_metric_lines(report.get("mean_metrics")))
+    return "\n".join(lines) + "\n"
+
+
+def write_readiness_report(*, report: JSONObject, output_dir: Path) -> JSONObject:
+    """Write readiness JSON and Markdown artifacts."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "relation_feasibility_readiness_report.json"
+    markdown_path = output_dir / "relation_feasibility_readiness_report.md"
+    json_path.write_text(json.dumps(report, indent=2) + "\n")
+    markdown_path.write_text(render_readiness_markdown(report))
+    return {
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+
+
+def _load_summary(path: Path) -> JSONObject:
+    payload = json.loads(path.read_text())
+    if not isinstance(payload, dict):
+        msg = f"{path} does not contain a JSON object"
+        raise ValueError(msg)
+    summary = payload.get("summary")
+    if not isinstance(summary, dict):
+        msg = f"{path} does not contain a summary object"
+        raise ValueError(msg)
+    return dict(summary)
+
+
+def _worst_metrics(summaries: tuple[JSONObject, ...]) -> JSONObject:
+    worst: JSONObject = {}
+    for key in _HIGHER_IS_BETTER_METRICS:
+        worst[key] = _round_metric(
+            min((_float_metric(summary, key) for summary in summaries), default=0.0),
+        )
+    for key in _LOWER_IS_BETTER_METRICS:
+        worst[key] = _round_metric(
+            max((_float_metric(summary, key) for summary in summaries), default=0.0),
+        )
+    return worst
+
+
+def _mean_metrics(summaries: tuple[JSONObject, ...]) -> JSONObject:
+    metrics: JSONObject = {}
+    for key in (*_HIGHER_IS_BETTER_METRICS, *_LOWER_IS_BETTER_METRICS):
+        values = tuple(_float_metric(summary, key) for summary in summaries)
+        metrics[key] = _round_metric(sum(values) / len(values)) if values else 0.0
+    return metrics
+
+
+def _blocking_reasons(
+    *,
+    run_count: int,
+    min_runs: int,
+    worst_metrics: JSONObject,
+    hard_failure_counts: JSONObject,
+    metric_errors: list[str],
+    red_source_report_count: int,
+    thresholds: ReadinessThresholds,
+) -> list[str]:
+    reasons: list[str] = []
+    if run_count < min_runs:
+        reasons.append(
+            f"At least {min_runs} strict live-agent runs are required; got {run_count}.",
+        )
+    reasons.extend(metric_errors)
+    if red_source_report_count > 0:
+        reasons.append(
+            f"{red_source_report_count} source audit reports were RED.",
+        )
+    if _int_from_object(hard_failure_counts.get("fallback_case_count")) > 0:
+        reasons.append("Fallback cases were observed in strict live-agent runs.")
+    if _int_from_object(hard_failure_counts.get("invalid_agent_case_count")) > 0:
+        reasons.append("Invalid strict-agent completions were observed.")
+    if (
+        _int_from_object(hard_failure_counts.get("negative_control_leakage_count"))
+        > 0
+    ):
+        reasons.append("Negative-control leakage was observed.")
+    if _int_from_object(hard_failure_counts.get("raw_unknown_relation_type_count")) > 0:
+        reasons.append("Raw unknown candidate relation types were observed.")
+    if (
+        _int_from_object(
+            hard_failure_counts.get("raw_unknown_relation_type_surface_count"),
+        )
+        > 0
+    ):
+        reasons.append("Raw unknown inventory relation-type surfaces were observed.")
+    if _int_from_object(hard_failure_counts.get("wrong_verified_curie_link_count")) > 0:
+        reasons.append("Wrong verified CURIE links were observed.")
+    if (
+        _float_from_object(
+            worst_metrics.get("completed_agent_precision_against_gold"),
+        )
+        < thresholds.min_precision
+    ):
+        reasons.append("Worst-run completed-agent precision is below target.")
+    if (
+        _float_from_object(worst_metrics.get("completed_agent_recall_against_gold"))
+        < thresholds.min_recall
+    ):
+        reasons.append("Worst-run completed-agent recall is below target.")
+    if (
+        _float_from_object(worst_metrics.get("high_value_recall"))
+        < thresholds.min_high_value_recall
+    ):
+        reasons.append("Worst-run high-value recall is below target.")
+    if (
+        _float_from_object(
+            worst_metrics.get("completed_agent_valuable_candidate_rate"),
+        )
+        < thresholds.min_valuable_rate
+    ):
+        reasons.append("Worst-run valuable candidate rate is below target.")
+    if (
+        _float_from_object(worst_metrics.get("generic_relation_rate"))
+        > thresholds.max_generic_rate
+    ):
+        reasons.append("Worst-run generic relation rate is above target.")
+    if (
+        _float_from_object(worst_metrics.get("curie_linked_gold_endpoint_rate"))
+        < thresholds.min_curie_linked_endpoint_rate
+    ):
+        reasons.append("Worst-run CURIE-linked gold endpoint rate is below target.")
+    if (
+        _float_from_object(worst_metrics.get("entailment_checked_rate"))
+        < thresholds.min_entailment_checked_rate
+    ):
+        reasons.append("Worst-run entailment checked rate is below target.")
+    return reasons
+
+
+def _required_metric_errors(summaries: tuple[JSONObject, ...]) -> list[str]:
+    errors: list[str] = []
+    for index, summary in enumerate(summaries, start=1):
+        for key in _REQUIRED_NUMERIC_METRICS:
+            if key not in summary:
+                errors.append(f"run{index} missing required metric {key}.")
+                continue
+            if isinstance(summary[key], bool) or not isinstance(
+                summary[key],
+                int | float,
+            ):
+                errors.append(f"run{index} has invalid required metric {key}.")
+    return errors
+
+
+def _metric_lines(value: object) -> list[str]:
+    if not isinstance(value, dict) or not value:
+        return ["- none"]
+    return [f"- {key}: {metric_value}" for key, metric_value in sorted(value.items())]
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _float_metric(summary: JSONObject, key: str) -> float:
+    return _float_from_object(summary.get(key))
+
+
+def _int_metric(summary: JSONObject, key: str) -> int:
+    return _int_from_object(summary.get(key))
+
+
+def _float_from_object(value: object) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, int | float):
+        return float(value)
+    return 0.0
+
+
+def _int_from_object(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+def _round_metric(value: float) -> float:
+    return round(value, 4)
+
+
+__all__ = [
+    "ReadinessThresholds",
+    "build_readiness_report",
+    "render_readiness_markdown",
+    "write_readiness_report",
+]

--- a/tests/unit/test_relation_feasibility_readiness_gate.py
+++ b/tests/unit/test_relation_feasibility_readiness_gate.py
@@ -1,0 +1,160 @@
+"""Regression tests for relation feasibility repeatability readiness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.validation.relation_feasibility.readiness import (
+    build_readiness_report,
+    render_readiness_markdown,
+)
+
+
+def _write_report(
+    tmp_path: Path,
+    name: str,
+    *,
+    precision: float = 0.86,
+    recall: float = 0.72,
+    high_value_recall: float = 0.9,
+    valuable_rate: float = 0.84,
+    generic_rate: float = 0.0,
+    verified_curie_rate: float = 0.96,
+    entailment_checked_rate: float = 1.0,
+    fallback_cases: int = 0,
+    invalid_agent_cases: int = 0,
+    negative_control_leakage_cases: int = 0,
+    raw_unknown_candidate_types: int = 0,
+    raw_unknown_inventory_types: int = 0,
+    wrong_verified_curie_links: int = 0,
+    verdict: str = "YELLOW",
+    blocking_reasons: list[str] | None = None,
+) -> Path:
+    path = tmp_path / f"{name}.json"
+    payload = {
+        "summary": {
+            "verdict": verdict,
+            "blocking_reasons": blocking_reasons or [],
+            "completed_agent_precision_against_gold": precision,
+            "completed_agent_recall_against_gold": recall,
+            "high_value_recall": high_value_recall,
+            "completed_agent_valuable_candidate_rate": valuable_rate,
+            "generic_relation_rate": generic_rate,
+            "curie_linked_gold_endpoint_rate": verified_curie_rate,
+            "verified_curie_match_rate": verified_curie_rate,
+            "entailment_checked_rate": entailment_checked_rate,
+            "fallback_case_count": fallback_cases,
+            "invalid_agent_case_count": invalid_agent_cases,
+            "negative_control_leakage_count": negative_control_leakage_cases,
+            "raw_unknown_relation_type_count": raw_unknown_candidate_types,
+            "raw_unknown_relation_type_surface_count": raw_unknown_inventory_types,
+            "wrong_verified_curie_link_count": wrong_verified_curie_links,
+        },
+    }
+    path.write_text(json.dumps(payload) + "\n")
+    return path
+
+
+def test_readiness_gate_passes_when_repeated_strict_runs_clear_thresholds(
+    tmp_path: Path,
+) -> None:
+    report_paths = (
+        _write_report(tmp_path, "run1", precision=0.86, verified_curie_rate=0.96),
+        _write_report(tmp_path, "run2", precision=0.88, verified_curie_rate=0.97),
+        _write_report(tmp_path, "run3", precision=0.9, verified_curie_rate=0.98),
+    )
+
+    report = build_readiness_report(report_paths=report_paths, min_runs=3)
+    markdown = render_readiness_markdown(report)
+
+    assert report["trusted_graph_ready"] is True
+    assert report["run_count"] == 3
+    assert report["blocking_reasons"] == []
+    assert report["worst_metrics"]["completed_agent_precision_against_gold"] == 0.86
+    assert report["worst_metrics"]["curie_linked_gold_endpoint_rate"] == 0.96
+    assert report["hard_failure_counts"]["fallback_case_count"] == 0
+    assert "Trusted graph readiness: **READY**" in markdown
+
+
+def test_readiness_gate_blocks_unstable_or_unsafe_strict_runs(tmp_path: Path) -> None:
+    report_paths = (
+        _write_report(
+            tmp_path,
+            "run1",
+            precision=0.79,
+            verified_curie_rate=0.74,
+            fallback_cases=1,
+        ),
+        _write_report(
+            tmp_path,
+            "run2",
+            precision=0.84,
+            verified_curie_rate=0.76,
+            raw_unknown_inventory_types=1,
+        ),
+    )
+
+    report = build_readiness_report(report_paths=report_paths, min_runs=3)
+    markdown = render_readiness_markdown(report)
+
+    assert report["trusted_graph_ready"] is False
+    assert report["run_count"] == 2
+    assert report["hard_failure_counts"]["fallback_case_count"] == 1
+    assert report["hard_failure_counts"]["raw_unknown_relation_type_surface_count"] == 1
+    assert any("At least 3 strict live-agent runs" in reason for reason in report["blocking_reasons"])
+    assert any("Fallback" in reason for reason in report["blocking_reasons"])
+    assert any("precision" in reason for reason in report["blocking_reasons"])
+    assert any("CURIE" in reason for reason in report["blocking_reasons"])
+    assert "Trusted graph readiness: **NOT READY**" in markdown
+
+
+def test_readiness_gate_blocks_missing_or_invalid_required_metrics(
+    tmp_path: Path,
+) -> None:
+    valid_report = _write_report(tmp_path, "valid")
+    missing_report = _write_report(tmp_path, "missing")
+    invalid_report = _write_report(tmp_path, "invalid")
+    missing_payload = json.loads(missing_report.read_text())
+    del missing_payload["summary"]["fallback_case_count"]
+    missing_report.write_text(json.dumps(missing_payload) + "\n")
+    invalid_payload = json.loads(invalid_report.read_text())
+    invalid_payload["summary"]["generic_relation_rate"] = "0.00"
+    invalid_report.write_text(json.dumps(invalid_payload) + "\n")
+
+    report = build_readiness_report(
+        report_paths=(valid_report, missing_report, invalid_report),
+        min_runs=3,
+    )
+
+    assert report["trusted_graph_ready"] is False
+    assert any(
+        "missing required metric fallback_case_count" in reason
+        for reason in report["blocking_reasons"]
+    )
+    assert any(
+        "invalid required metric generic_relation_rate" in reason
+        for reason in report["blocking_reasons"]
+    )
+
+
+def test_readiness_gate_blocks_red_source_audit_verdicts(tmp_path: Path) -> None:
+    report_paths = (
+        _write_report(tmp_path, "run1"),
+        _write_report(
+            tmp_path,
+            "run2",
+            verdict="RED",
+            blocking_reasons=["New single-run blocker."],
+        ),
+        _write_report(tmp_path, "run3"),
+    )
+
+    report = build_readiness_report(report_paths=report_paths, min_runs=3)
+
+    assert report["trusted_graph_ready"] is False
+    assert report["red_source_report_count"] == 1
+    assert any(
+        "source audit reports were RED" in reason
+        for reason in report["blocking_reasons"]
+    )


### PR DESCRIPTION
## Summary
- add repeatability/readiness gate for strict live-agent relation feasibility reports
- require repeated runs before trusted-graph readiness claims
- fail closed on fallback, invalid agent cases, negative leakage, raw unknown surfaces, wrong verified CURIEs, malformed required metrics, and RED source audits
- wire readiness tests into relation-feasibility-quality-gate
- add PR16 evidence snapshot from three strict live-agent runs and readiness-gate output

## Validation
- reproduced failing import regression before implementation
- readiness unit tests passed (4 tests)
- relation-feasibility-quality-gate passed (48 tests)
- make artana-evidence-api-lint passed
- make artana-evidence-api-type-check passed
- three strict live-agent audits completed: fallback=0, invalid=0, negative leakage=0
- readiness gate result: NOT READY; blockers are RED source audits, worst-run precision, high-value recall, and CURIE-linked endpoint recovery
- adversarial subagent review found fail-open malformed-input and RED-source issues; both fixed with negative regressions
- --fail-on-not-ready returned exit status 1 for current NOT READY gate
- make service-checks passed; coverage 86.86%

## Live-Agent Snapshot
Report: docs/validation/reports/2026-07-05-pr16-repeatability-readiness-summary.md

This PR intentionally does not mark the system trusted-graph ready. It adds the repeatability gate that prevents auto-promotion until repeated live-agent evidence clears the quality thresholds.