### PR TITLE
PR21: tighten verified grounding readiness

### DIFF
--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -16,6 +16,10 @@ Next trusted-readiness PR plans:
   `docs/validation/trusted-graph-finding-remediation-plan.md`
 - Root-cause blocker plan for the latest PR19 trusted-readiness blockers:
   `docs/validation/trusted-graph-readiness-blocker-resolution-plan.md`
+- Robust finding-by-finding PR21+ execution plan:
+  `docs/validation/trusted-graph-readiness-robust-findings-plan.md`
+- Current post-PR21 finding closure plan:
+  `docs/validation/trusted-graph-readiness-post-pr21-findings-plan.md`
 
 The tracker is updated after each PR with metrics, report links, tests, and
 review evidence. A phase is not done because code merged. A phase is done when
@@ -133,6 +137,7 @@ Status values:
 | 7 | PR-17 | `alvaro/evidence-pr17-readiness-failure-attribution` | Local checkpoint committed | Explain every PR16 readiness blocker before changing extraction or promotion policy. | Repeated misses, false positives, CURIE gaps, proposal capture, and model labels are reportable. | Failure-analysis module, CLI, focused RED/GREEN tests, PR16 three-run baseline analysis, service-checks pass, and merge-visible PR17 evidence snapshot. |
 | 8 | PR-19 | `alvaro/evidence-pr19-high-value-relation-recovery` | Implemented locally; strict gate RED | Make high-value drug-resistance relations canonical instead of proposal noise. | High-value recall >= 0.8500 with raw unknown relation surfaces 0. | `CONFERS_RESISTANCE_TO` API taxonomy, graph dictionary seed, graph constraints, safe typo proposal repair, verifier cues, benchmark shape update, focused RED/GREEN tests, relation-feasibility gate, and strict live run. Live run reaches precision 0.9048 and high-value recall 0.9500, but trusted graph readiness remains blocked by verified CURIE endpoint rate 0.8108. |
 | 9 | PR-20 | `alvaro/evidence-pr20-qualifier-precision-adjudication` | Implemented locally; adversarial review fixes applied; strict gate RED | Preserve biomedical qualifiers and remove context false positives from trusted evidence. | Completed-agent precision >= 0.8000 and high-value recall >= 0.8500 without broad subject substitutions. | Dropped-modifier tests, expanded modifier adversarial tests, clause-local and comma-and modifier regressions, context-shadowing and review-only trust tests, low-value review accounting, relation-feasibility gate, strict live run4 with completed-agent precision 0.9500 and high-value recall 0.9500. Trusted high-value recall is now stricter at 0.5500; trusted graph readiness remains blocked by verified CURIE endpoint rate 0.8108. |
+| 10 | PR-21 | `alvaro/evidence-pr21-verified-grounding-closure` | Implemented locally; adversarial blockers fixed; strict gate RED | Improve verified grounding and review-only abstention without trusting raw model hints. | Trusted high-value recall >= 0.8500 and wrong verified CURIE links remain 0. | Grounding dictionary split, verified process labels, review-only broad/composite labels, verified-linker spoof regression, safe relation-alias scoring, missed-gold CURIE attribution, focused tests, relation-feasibility gate, strict live run3 with precision 1.0000, high-value recall 1.0000, trusted high-value recall 0.8500, verified endpoint rate 0.8810, false positives 0, fallback 0. Overall readiness remains RED. |
 
 ## PR Evidence Packet
 
@@ -193,6 +198,29 @@ Run only the service checks relevant to the changed boundary, then run the
 aggregate gate before merge when the PR is ready.
 
 ## Evidence Log
+
+### 2026-07-05 - PR-21 Verified Grounding And Review-Only Abstention
+
+PR: PR-21 verified grounding and review-only abstention
+
+Branch: `alvaro/evidence-pr21-verified-grounding-closure`
+
+Goal: Improve verified endpoint recovery and trusted high-value recall while
+keeping broad/composite endpoint labels review-only.
+
+Evidence:
+
+- `docs/validation/reports/2026-07-05-pr21-verified-grounding-summary.md`
+- `reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_report.md`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_failure_analysis_report.json`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_failure_analysis_report.md`
+
+Result: strict live-agent path remains RED, but the grounding slice materially
+improves the trusted path: completed-agent precision `1.0000`, high-value recall
+`1.0000`, trusted high-value recall `0.8500`, verified endpoint rate `0.8810`,
+wrong verified links `0`, fallback cases `0`, invalid-agent cases `0`, and
+false positives `0`.
 
 ### 2026-07-05 - PR-17 Readiness Failure Attribution
 

--- a/docs/validation/reports/2026-07-05-pr21-verified-grounding-summary.md
+++ b/docs/validation/reports/2026-07-05-pr21-verified-grounding-summary.md
@@ -1,0 +1,111 @@
+# PR21 Verified Grounding And Review-Only Abstention Summary
+
+Date: 2026-07-05
+
+Branch: `alvaro/evidence-pr21-verified-grounding-closure`
+
+Status: implemented locally, adversarial review blockers addressed, strict gate RED
+
+## Goal
+
+Improve verified endpoint recovery and trusted high-value recall without trusting
+raw model CURIE hints or broad ontology shortcuts.
+
+## What Changed
+
+- Moved local verified entity curation into
+  `document_extraction_support/entity_grounding/`.
+- Added verified grounding for safe process/pathway labels:
+  `MAPK signaling`, `homologous recombination DNA repair`, and
+  `cardiac septal development`.
+- Kept broad or composite labels review-only:
+  `ERK phosphorylation`, `aggressive tumor growth`, and
+  `response to pembrolizumab`.
+- Re-verified caller-provided `verified_linker` input so it cannot bypass the
+  local dictionary or review-only policy.
+- Added relation-safe alias matching that requires a verified CURIE match; it
+  does not reuse identity aliases such as `BRCA1 loss -> BRCA1`.
+- Added failure-attribution rows for CURIE endpoints lost because a gold
+  relation was missed.
+
+## Validation
+
+Focused tests:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  services/artana_evidence_api/tests/unit/test_entity_curie_linking.py \
+  services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py \
+  tests/unit/test_relation_feasibility_audit.py \
+  tests/unit/test_relation_feasibility_failure_analysis.py \
+  -q
+```
+
+Latest result: 75 passed.
+
+Relation feasibility gate:
+
+```bash
+make relation-feasibility-quality-gate
+```
+
+Latest result: 56 passed.
+
+Strict live-agent run:
+
+```bash
+bash -lc 'set -a; source .env.postgres; set +a; \
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run3'
+```
+
+Report artifacts:
+
+- `reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_report.md`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_failure_analysis_report.json`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_failure_analysis_report.md`
+
+## Live Metrics
+
+| Metric | PR20 run4 | PR21 run3 |
+|---|---:|---:|
+| Verdict | RED | RED |
+| Completed-agent precision | 0.9500 | 1.0000 |
+| Completed-agent recall | 0.7600 | 0.8000 |
+| Completed-agent valuable rate | 0.9500 | 1.0000 |
+| High-value recall | 0.9500 | 1.0000 |
+| Trusted high-value recall | 0.5500 | 0.8500 |
+| Generic relation rate | 0.0500 | 0.0000 |
+| Candidate CURIE present rate | 0.9000 | 0.9250 |
+| Verified CURIE-linked endpoint rate | 0.8108 | 0.8810 |
+| Wrong verified CURIE links | 0 | 0 |
+| Fallback cases | 0 | 0 |
+| Invalid strict-agent cases | 0 | 0 |
+| Negative-control leakage cases | 0 | 0 |
+| CURIE gaps in failure attribution | 8 | 3 |
+| False positives | 1 | 0 |
+
+## Adversarial Review
+
+External adversarial review found five issues. Addressed blockers:
+
+- Caller-supplied `verified_linker` could bypass local verification. Fixed by
+  rechecking every `verified_linker` input against dictionary/review-only policy
+  and downgrading unknown labels to untrusted hints.
+- `ERK phosphorylation` was over-broadly linked to `GO:0018108`. Fixed by
+  making it review-only.
+- Review-only endpoints appeared as `flags=none`. Fixed by adding
+  `review_only_subject_grounding` and `review_only_object_grounding` flags.
+- CURIE failure attribution underexplained denominator loss. Fixed by adding a
+  `CURIE Endpoints Lost To Missed Gold` table.
+
+## Remaining Risk
+
+PR21 is not trusted-graph ready by itself. The strict gate remains RED because
+verified CURIE-linked endpoint rate is `0.8810`, below the `0.9500` target.
+The remaining gap is now mostly low-value/review-lane work plus review-only
+endpoint policy, not raw model-hint verification.

--- a/docs/validation/trusted-graph-readiness-post-pr21-findings-plan.md
+++ b/docs/validation/trusted-graph-readiness-post-pr21-findings-plan.md
@@ -1,0 +1,863 @@
+# Post-PR21 Trusted Graph Readiness Findings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close every current post-PR21 finding that prevents Artana Evidence live-agent output from being safely promoted into the trusted graph.
+
+**Architecture:** Keep the live agent as a candidate generator and make trust a code-enforced contract. Evidence API owns extraction, grounding, review-lane classification, support verification, and audit metrics. Graph DB owns final promotion enforcement, relation governance, provenance, and fail-closed policy. Validation scripts own repeated-run proof and must keep fallback, low-value review evidence, and trusted auto-promotion as separate scorecard lanes.
+
+**Tech Stack:** Python, FastAPI service modules, Pydantic contracts, pytest, ruff, strict live-agent relation feasibility audits, failure attribution reports, readiness gates, verified entity dictionaries, graph trusted-evidence floors, Postgres-backed service checks, and adversarial review loops.
+
+---
+
+## Current Evidence Snapshot
+
+This plan starts from the latest strict live-agent PR21 evidence in this worktree.
+
+Source artifacts:
+
+- `reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_report.md`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_failure_analysis_report.json`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_failure_analysis_report.md`
+- `docs/validation/reports/2026-07-05-pr21-verified-grounding-summary.md`
+
+Latest state:
+
+| Gate | PR21 run3 value | Target | Status |
+|---|---:|---:|---|
+| Verdict | RED | READY | Blocking |
+| Strict live-agent cases completed | 30/30 | 30/30 | Passing |
+| Fallback cases | 0 | 0 | Passing |
+| Invalid strict-agent cases | 0 | 0 | Passing |
+| Negative-control leakage cases | 0 | 0 | Passing |
+| Raw unknown relation types | 0 | 0 | Passing |
+| Raw unknown relation inventory surfaces | 0 | 0 | Passing |
+| Wrong verified CURIE links | 0 | 0 | Passing |
+| Completed-agent precision | 1.0000 | >= 0.8000 | Passing |
+| Completed-agent recall | 0.8000 | >= 0.6000 | Passing |
+| High-value recall | 1.0000 | >= 0.8500 | Passing |
+| Trusted high-value recall | 0.8500 | >= 0.8500 | Passing, no margin |
+| Generic relation rate | 0.0000 | <= 0.0500 | Passing |
+| Candidate CURIE present rate | 0.9250 | observe | Informational |
+| Verified CURIE-linked gold endpoint rate | 0.8810 | >= 0.9500 | Blocking |
+| Low-value review recall | 0.0000 | separate review target | Blocking |
+
+Failure attribution from PR21 run3:
+
+| Area | Current evidence |
+|---|---|
+| Missed gold relations | 5, all low-value hedged or broad review-lane cases |
+| False positives | 0 |
+| CURIE endpoints lost to missed gold | 5, all from low-value missed relations |
+| Remaining CURIE gaps | `aggressive tumor growth`, `ERK phosphorylation`, `response to pembrolizumab` |
+| Review-only endpoint flags | Present for broad or composite endpoint labels |
+
+Interpretation:
+
+- The live-agent path now works and is precise on this fixture.
+- The system is not trusted-graph ready because the readiness gate is still RED.
+- The remaining RED state is not a model-runtime failure. It is a trust-contract design problem: low-value review evidence, composite endpoint policy, repeatability, model selection proof, graph promotion enforcement, and benchmark breadth.
+
+## Non-Negotiable Trust Contract
+
+Trusted graph readiness must never be achieved by relaxing the scorecard. It is true only when all of these are true:
+
+- Strict live-agent runs complete with `fallback_case_count == 0`.
+- Invalid agent cases, negative-control leakage, raw unknown relation types, raw unknown relation surfaces, and wrong verified CURIE links remain `0`.
+- Trusted high-value claims require completed-agent provenance, verified subject and object grounding, approved relation type, grounded support sentence, entailment support, and no fallback trace.
+- Low-value hedged evidence can be useful, but it must enter a review-only lane and must not satisfy trusted auto-promotion.
+- Composite or event-like endpoints must either have a curated safe grounding policy or explicit review-only abstention. Broad ontology parents do not count as safe grounding.
+- Graph DB must reject unsafe trusted AI evidence even if Evidence API or a report artifact incorrectly marks it trusted.
+- Readiness must be proven on repeated strict live-agent runs using worst-run metrics, not only a single favorable run.
+
+## Implementation Loop For Every PR
+
+Each PR lane must follow this loop:
+
+1. Pick exactly one finding or tightly coupled finding group from the ledger.
+2. Write the failing regression test first.
+3. Run the focused test and capture the expected failure.
+4. Implement the smallest first-principles fix in the owning service boundary.
+5. Run the focused test until green.
+6. Run the relevant service lint, type, boundary, and contract checks when service contracts change.
+7. Run `make relation-feasibility-quality-gate`.
+8. Run one strict live-agent audit with `--extractor agent`.
+9. Run failure attribution on the new strict report.
+10. Request adversarial review against the diff, scorecard, and failure attribution.
+11. Fix every valid adversarial finding.
+12. Run `git diff --check` and `make service-checks`.
+13. Update `docs/validation/evidence-excellence-progress-tracker.md`.
+14. Add a dated evidence summary under `docs/validation/reports/`.
+15. Commit only after tests, live evidence, adversarial review, and docs agree.
+
+Strict live-agent audit command, using PR22 as the concrete example:
+
+```bash
+bash -lc 'set -a; source .env.postgres; set +a; \
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-05-pr22-low-value-review-lane-run1'
+```
+
+Failure attribution command, using the same PR22 example:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/summarize_relation_readiness_failures.py \
+  --report current=reports/relation_feasibility/2026-07-05-pr22-low-value-review-lane-run1/relation_feasibility_report.json \
+  --output-dir reports/relation_feasibility_failure_analysis/2026-07-05-pr22-low-value-review-lane-run1
+```
+
+Final repeated-run readiness command:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_readiness_gate.py \
+  --report reports/relation_feasibility/2026-07-05-final-readiness-run1/relation_feasibility_report.json \
+  --report reports/relation_feasibility/2026-07-05-final-readiness-run2/relation_feasibility_report.json \
+  --report reports/relation_feasibility/2026-07-05-final-readiness-run3/relation_feasibility_report.json \
+  --fail-on-not-ready \
+  --output-dir reports/relation_feasibility_readiness/2026-07-05-final-readiness
+```
+
+## Finding Ledger
+
+| ID | Finding | First-principles root cause | Owner lane | Robust closure evidence |
+|---|---|---|---|---|
+| F-01 | Verified CURIE-linked gold endpoint rate is `0.8810`, below `0.9500`. | The current all-gold endpoint metric mixes trusted-eligible claims with low-value review claims. Five denominator endpoints are lost because five low-value relations are not captured at all. | PR22 and PR24 | Add trusted-eligible endpoint metrics plus low-value review endpoint metrics. Readiness stays RED until trusted-eligible endpoints pass and low-value review capture is measured separately. |
+| F-02 | Low-value review recall is `0.0000`. | The trusted path correctly avoids promoting hedged claims, but there is no live-agent review-only capture lane for useful weak evidence. | PR22 | Hedged claims produce review-only candidates with hedge metadata, support sentence, endpoints, and no trusted leakage. |
+| F-03 | `aggressive tumor growth`, `ERK phosphorylation`, and `response to pembrolizumab` remain CURIE gaps. | These are broad, event-like, or composite endpoint labels. A single broad ontology parent would improve the metric but reduce graph trust. | PR23 | Each label has a typed grounding decision: curated safe grounding or explicit review-only abstention with reason codes visible in reports. |
+| F-04 | Trusted high-value recall is exactly `0.8500`, with no safety margin. | PR21 reaches the current threshold, but review-only endpoint labels and live-agent variance can move the metric below target in another run. | PR23 and PR24 | Three strict runs keep worst-run trusted high-value recall `>= 0.8500`, or unstable high-value claims are held for review. |
+| F-05 | Repeatability is not proven after PR21. | The latest improvement is demonstrated by one strict run after adversarial fixes. Live-agent outputs can vary. | PR24 | At least three strict runs pass on worst-run metrics, and failure attribution identifies repeated versus one-off failures. |
+| F-06 | Stronger-model benefit is unknown. | There is no controlled A/B harness that compares the current configured model with a stronger candidate under identical fixture, prompt, thresholds, cost, latency, and failure attribution. | PR24 | Model comparison report contains at least three runs per model and adopts a stronger model only if worst-run trust metrics improve without new safety failures. |
+| F-07 | Runtime graph promotion is not yet proven end to end for the current trust floor. | Audit readiness and graph persistence are separate boundaries. A green audit must not be the only protection. | PR25 | Graph DB rejects trusted AI relation writes missing verified endpoints, approved relation type, grounded support, entailment, provenance, no-fallback trace, or allowed review status. |
+| F-08 | Benchmark confidence is limited by fixture breadth. | The current fixture is useful for regression but is still too small and curated to prove production biomedical value. | PR26 | A v3 blinded fixture expands cases across oncology, rare disease, variants, pathways, drug response, negative controls, long documents, and adversarial near-misses. |
+| F-09 | Evidence docs can drift from JSON reports. | Manual summaries can preserve stale metrics after live-agent reports change. | PR27 | Summary docs are generated or checked from report JSON and include artifact hashes, branch, commit, fixture version, model label, and exact commands. |
+| F-10 | PR21 merge hygiene is not finished until final local validation is clean. | The branch has useful changes, but final `make service-checks`, generated coverage cleanup, and staged scope still need confirmation before merge. | PR21 closeout | Service checks pass, generated `coverage.xml` churn is removed unless intentionally committed, and only intended files are staged. |
+
+## PR21 Closeout: Verified Grounding Hygiene
+
+Suggested branch: `alvaro/evidence-pr21-verified-grounding-closure`
+
+**Findings addressed:** F-03 partially, F-04 partially, F-10 fully.
+
+**Files:**
+
+- Modify: `services/artana_evidence_api/document_extraction_support/entity_curie_linking.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/entity_grounding/contracts.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/entity_grounding/verified_dictionary.py`
+- Modify: `scripts/validation/relation_feasibility/relation_matching.py`
+- Modify: `scripts/validation/relation_feasibility/scoring.py`
+- Modify: `scripts/validation/relation_feasibility/failure_analysis.py`
+- Modify: `services/artana_evidence_api/tests/unit/test_entity_curie_linking.py`
+- Modify: `services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py`
+- Modify: `tests/unit/test_relation_feasibility_audit.py`
+- Modify: `tests/unit/test_relation_feasibility_failure_analysis.py`
+- Modify: `docs/validation/reports/2026-07-05-pr21-verified-grounding-summary.md`
+
+- [ ] **Step 1: Re-run focused PR21 tests**
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    services/artana_evidence_api/tests/unit/test_entity_curie_linking.py \
+    services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py \
+    tests/unit/test_relation_feasibility_audit.py \
+    tests/unit/test_relation_feasibility_failure_analysis.py \
+    -q
+  ```
+
+  Expected: all focused tests pass.
+
+- [ ] **Step 2: Re-run architecture and quality gates**
+
+  ```bash
+  make architecture-size-check
+  make architecture-structure-check
+  make relation-feasibility-quality-gate
+  git diff --check
+  ```
+
+  Expected: all commands pass.
+
+- [ ] **Step 3: Re-run `make service-checks`**
+
+  ```bash
+  make service-checks
+  ```
+
+  Expected: repository service checks pass. If this updates `coverage.xml`, remove the generated diff unless coverage output is intentionally tracked in the PR.
+
+- [ ] **Step 4: Confirm strict PR21 evidence still matches the summary**
+
+  ```bash
+  rg -n "Verdict|Trusted high-value recall|Verified CURIE-linked gold endpoint rate|Low-value review recall" \
+    reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_report.md
+  ```
+
+  Expected values: verdict RED, trusted high-value recall `0.8500`, verified CURIE-linked gold endpoint rate `0.8810`, low-value review recall `0.0000`.
+
+**Merge gate:** PR21 is mergeable when local validation is clean and the PR description honestly says the branch improved precision and trusted high-value recall but did not make the system trusted-graph ready.
+
+## PR22: Low-Value Review Lane And Metric Split
+
+Suggested branch: `alvaro/evidence-pr22-low-value-review-lane`
+
+**Findings closed:** F-01, F-02.
+
+**Files:**
+
+- Create: `services/artana_evidence_api/document_extraction_support/review_only_candidate_policy.py`
+- Modify: `services/artana_evidence_api/document_extraction_prompting.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/llm_fulltext_extraction.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py`
+- Create: `services/artana_evidence_api/tests/unit/test_review_only_candidate_policy.py`
+- Modify: `services/artana_evidence_api/tests/unit/test_document_extraction_modules.py`
+- Modify: `scripts/validation/relation_feasibility/scoring.py`
+- Modify: `scripts/validation/relation_feasibility/reporting.py`
+- Modify: `scripts/validation/relation_feasibility/readiness.py`
+- Modify: `scripts/validation/relation_feasibility/trusted_metric_rules.py`
+- Modify: `tests/unit/test_relation_feasibility_audit.py`
+- Modify: `tests/unit/test_relation_feasibility_readiness_gate.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr22-low-value-review-lane-summary.md`
+
+- [ ] **Step 1: Write failing tests for the five missed low-value cases**
+
+  Add cases for:
+
+  - `weak_akt_trend_survival`
+  - `weak_hrd_possible_biomarker`
+  - `weak_il6_may_regulate_inflammation`
+  - `weak_med13_may_link_chd`
+  - `weak_met_correlated_resistance`
+
+  Expected behavior:
+
+  - hedged candidates are emitted with `review_status == "review_only"`
+  - hedge reason codes include `hedged_language`, `trend_only`, `possible_biomarker`, `may_regulate`, or `correlated_only`
+  - review-only candidates can improve `low_value_review_recall`
+  - review-only candidates cannot improve `trusted_high_value_recall`
+  - review-only candidates cannot be graph-promotion eligible
+
+  Run:
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    services/artana_evidence_api/tests/unit/test_review_only_candidate_policy.py \
+    tests/unit/test_relation_feasibility_audit.py::test_low_value_review_metrics_require_review_only_candidate \
+    -q
+  ```
+
+  Expected before implementation: new policy tests fail because the review-only policy module does not exist.
+
+- [ ] **Step 2: Implement review-only policy**
+
+  Implement `review_only_candidate_policy.py` with a focused interface:
+
+  ```python
+  @dataclass(frozen=True)
+  class ReviewOnlyDecision:
+      review_only: bool
+      reason_codes: tuple[str, ...]
+      trusted_promotion_allowed: bool
+
+
+  def classify_review_only_candidate(
+      *,
+      relation_type: str,
+      support_sentence: str,
+      value_level: str | None,
+  ) -> ReviewOnlyDecision:
+      ...
+  ```
+
+  Required decisions:
+
+  | Evidence language | Decision |
+  |---|---|
+  | `trend toward` | review-only, `trend_only`, no trusted promotion |
+  | `possible biomarker` | review-only, `possible_biomarker`, no trusted promotion |
+  | `may regulate` | review-only, `may_regulate`, no trusted promotion |
+  | `correlated with` | review-only, `correlated_only`, no trusted promotion |
+  | direct causal, resistance, sensitivity, activation, inhibition, or biomarker support without hedge | not review-only by this policy |
+
+- [ ] **Step 3: Split readiness metrics**
+
+  Keep `curie_linked_gold_endpoint_rate` visible, then add:
+
+  - `trusted_eligible_curie_linked_gold_endpoint_rate`
+  - `trusted_eligible_gold_curie_endpoint_count`
+  - `trusted_eligible_curie_linked_gold_endpoint_count`
+  - `low_value_review_curie_endpoint_capture_rate`
+  - `weak_claim_trusted_leakage_count`
+
+  Readiness rules:
+
+  - trusted readiness uses `trusted_eligible_curie_linked_gold_endpoint_rate >= 0.9500`
+  - low-value review lane uses `low_value_review_recall >= 0.8000` as a product-quality target
+  - `weak_claim_trusted_leakage_count` must be `0`
+  - all-gold `curie_linked_gold_endpoint_rate` remains reported as diagnostic context
+
+- [ ] **Step 4: Run validation**
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    services/artana_evidence_api/tests/unit/test_review_only_candidate_policy.py \
+    services/artana_evidence_api/tests/unit/test_document_extraction_modules.py \
+    tests/unit/test_relation_feasibility_audit.py \
+    tests/unit/test_relation_feasibility_readiness_gate.py \
+    -q
+
+  make relation-feasibility-quality-gate
+  ```
+
+- [ ] **Step 5: Run live-agent evidence and adversarial review**
+
+  Run the strict audit and failure attribution commands from the implementation loop using output names containing `pr22-low-value-review-lane-run1`.
+
+  Adversarial review must attack:
+
+  - weak claims leaking into trusted promotion
+  - metric split hiding true misses
+  - false review-only credit without support sentence alignment
+  - low-value review candidates missing endpoint metadata
+
+**Merge gate:** PR22 is mergeable when low-value review recall improves, weak-claim trusted leakage remains `0`, and trusted readiness uses trusted-eligible endpoint recovery without deleting the all-gold diagnostic metric.
+
+## PR23: Composite Endpoint Grounding And Abstention Policy
+
+Suggested branch: `alvaro/evidence-pr23-composite-endpoint-policy`
+
+**Findings closed:** F-03 and part of F-04.
+
+**Files:**
+
+- Create: `services/artana_evidence_api/document_extraction_support/entity_grounding/composite_endpoint_policy.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/entity_grounding/contracts.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/entity_grounding/verified_dictionary.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/entity_curie_linking.py`
+- Create: `services/artana_evidence_api/tests/unit/test_composite_endpoint_policy.py`
+- Modify: `services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py`
+- Modify: `services/artana_evidence_api/tests/unit/test_entity_curie_linking.py`
+- Modify: `scripts/validation/relation_feasibility/scoring.py`
+- Modify: `scripts/validation/relation_feasibility/failure_analysis.py`
+- Modify: `tests/unit/test_relation_feasibility_audit.py`
+- Modify: `tests/unit/test_relation_feasibility_failure_analysis.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr23-composite-endpoint-policy-summary.md`
+
+- [ ] **Step 1: Write failing tests for the three remaining review-only endpoints**
+
+  Required endpoint decisions:
+
+  | Label | Required policy |
+  |---|---|
+  | `aggressive tumor growth` | review-only phenotype or outcome endpoint; no broad auto-promotion |
+  | `ERK phosphorylation` | review-only molecular event unless a curated event-level grounding is added |
+  | `response to pembrolizumab` | review-only therapy-response outcome unless a curated response concept is added |
+
+  Run:
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    services/artana_evidence_api/tests/unit/test_composite_endpoint_policy.py \
+    services/artana_evidence_api/tests/unit/test_entity_curie_linking.py \
+    tests/unit/test_relation_feasibility_audit.py::test_review_only_grounding_labels_are_flagged_without_gold_curie \
+    -q
+  ```
+
+  Expected before implementation: the new composite endpoint policy tests fail because the policy module does not exist.
+
+- [ ] **Step 2: Implement typed composite decisions**
+
+  Implement `composite_endpoint_policy.py` with this behavior:
+
+  - returns `grounding_kind == "review_only_composite_endpoint"` for the three labels above
+  - records `endpoint_shape` as `phenotype_outcome`, `molecular_event`, or `therapy_response`
+  - records `promotion_block_reason == "composite_endpoint_requires_curator_review"`
+  - refuses broad fallback IDs such as a parent pathway when the label is a narrower event
+  - exposes reason codes to scoring and failure attribution
+
+- [ ] **Step 3: Update report flags**
+
+  Report flags must distinguish:
+
+  - `review_only_object_grounding`
+  - `composite_endpoint_requires_review`
+  - `broad_ontology_parent_rejected`
+  - `missing_safe_grounding`
+
+  Failure attribution must show whether the remaining gap is a real missing safe ID or an intentional abstention.
+
+- [ ] **Step 4: Run validation**
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    services/artana_evidence_api/tests/unit/test_composite_endpoint_policy.py \
+    services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py \
+    services/artana_evidence_api/tests/unit/test_entity_curie_linking.py \
+    tests/unit/test_relation_feasibility_audit.py \
+    tests/unit/test_relation_feasibility_failure_analysis.py \
+    -q
+
+  make relation-feasibility-quality-gate
+  ```
+
+- [ ] **Step 5: Run live-agent evidence and adversarial review**
+
+  Run the strict audit and failure attribution commands from the implementation loop using output names containing `pr23-composite-endpoint-policy-run1`.
+
+  Adversarial review must attack:
+
+  - broad parent ontology links being accepted as safe
+  - review-only labels being counted as trusted
+  - high-value recall becoming artificially green through abstention
+  - report flags hiding useful review candidates
+
+**Merge gate:** PR23 is mergeable when composite endpoints have explicit typed policy, no broad wrong CURIEs are introduced, and high-value candidates with review-only endpoints are useful to reviewers but cannot auto-promote.
+
+## PR24: Repeatability And Stronger-Model A/B
+
+Suggested branch: `alvaro/evidence-pr24-repeatability-model-ab`
+
+**Findings closed:** F-04, F-05, F-06.
+
+**Files:**
+
+- Modify: `scripts/run_relation_feasibility_audit.py`
+- Modify: `scripts/run_relation_feasibility_readiness_gate.py`
+- Modify: `scripts/summarize_relation_readiness_failures.py`
+- Modify: `scripts/validation/relation_feasibility/readiness.py`
+- Modify: `scripts/validation/relation_feasibility/failure_analysis.py`
+- Create: `scripts/validation/relation_feasibility/model_comparison.py`
+- Create: `tests/unit/test_relation_feasibility_model_comparison.py`
+- Modify: `tests/unit/test_relation_feasibility_readiness_gate.py`
+- Modify: `tests/unit/test_relation_feasibility_failure_analysis.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr24-repeatability-model-ab-summary.md`
+
+- [ ] **Step 1: Write failing tests for worst-run gating**
+
+  Tests must prove:
+
+  - three runs are required for readiness
+  - average metrics cannot hide a bad run
+  - one run below trusted high-value recall target keeps readiness not ready
+  - one run with fallback, invalid agent output, negative leakage, wrong verified CURIE, or weak-claim trusted leakage keeps readiness not ready
+
+  Run:
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    tests/unit/test_relation_feasibility_readiness_gate.py \
+    -q
+  ```
+
+- [ ] **Step 2: Write failing tests for model comparison**
+
+  `model_comparison.py` must report:
+
+  - model label
+  - run count
+  - worst-run and mean precision
+  - worst-run and mean high-value recall
+  - worst-run and mean trusted high-value recall
+  - worst-run and mean trusted-eligible endpoint rate
+  - fallback count
+  - invalid-agent count
+  - wrong verified CURIE count
+  - weak-claim trusted leakage count
+  - cost when present
+  - latency when present
+  - repeated failure clusters
+
+  Run:
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    tests/unit/test_relation_feasibility_model_comparison.py \
+    -q
+  ```
+
+- [ ] **Step 3: Run three strict audits for the current model**
+
+  ```bash
+  bash -lc 'set -a; source .env.postgres; set +a; \
+    PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+    --extractor agent \
+    --model-label current \
+    --output-dir reports/relation_feasibility/2026-07-05-pr24-current-run1'
+  ```
+
+  Repeat with `run2` and `run3`.
+
+- [ ] **Step 4: Run three strict audits for the stronger candidate model**
+
+  ```bash
+  bash -lc 'set -a; source .env.postgres; set +a; \
+    export ARTANA_AI_EVIDENCE_EXTRACTION_MODEL="$ARTANA_STRONGER_MODEL_CANDIDATE"; \
+    PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+    --extractor agent \
+    --model-label candidate \
+    --output-dir reports/relation_feasibility/2026-07-05-pr24-candidate-run1'
+  ```
+
+  Repeat with `run2` and `run3`.
+
+  Required precondition: `ARTANA_STRONGER_MODEL_CANDIDATE` must be set in the shell or `.env.postgres`. The run must fail preflight if this variable is empty.
+
+- [ ] **Step 5: Compare and decide**
+
+  Stronger model adoption is allowed only when all are true:
+
+  - candidate worst-run trusted high-value recall is higher or equal
+  - candidate worst-run trusted-eligible endpoint rate is higher or equal
+  - candidate fallback, invalid-agent, negative leakage, wrong verified CURIE, and weak trusted leakage counts are all `0`
+  - candidate cost and latency are recorded
+  - adversarial review finds no cherry-picked comparison
+
+**Merge gate:** PR24 is mergeable when repeatability is measured with worst-run gates and model choice is evidence-backed. A stronger model can help, but it cannot replace grounding, review policy, and graph enforcement.
+
+## PR25: Graph Promotion Hard Gate
+
+Suggested branch: `alvaro/evidence-pr25-graph-promotion-hard-gate`
+
+**Findings closed:** F-07.
+
+**Files:**
+
+- Modify: `services/artana_evidence_db/validation/trusted_evidence_floor.py`
+- Modify: `services/artana_evidence_db/validation/claim_ai_evidence_validation.py`
+- Modify: `services/artana_evidence_db/relation_claim_service.py`
+- Modify: `services/artana_evidence_db/claim_evidence_service.py`
+- Modify: `services/artana_evidence_db/tests/unit/test_claim_ai_evidence_validation.py`
+- Modify: `services/artana_evidence_db/tests/unit/test_relation_auto_promotion.py`
+- Create: `services/artana_evidence_db/tests/unit/test_trusted_relation_promotion_policy.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr25-graph-promotion-hard-gate-summary.md`
+
+- [ ] **Step 1: Write failing promotion rejection tests**
+
+  Graph DB must reject trusted AI evidence with:
+
+  - missing subject CURIE
+  - missing object CURIE
+  - model-only subject or object CURIE source
+  - review-only endpoint status
+  - unapproved relation type
+  - missing evidence sentence
+  - support status other than entailed
+  - fallback extraction trace
+  - missing provenance
+  - weak-claim trusted leakage metadata
+
+  Run:
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    services/artana_evidence_db/tests/unit/test_claim_ai_evidence_validation.py \
+    services/artana_evidence_db/tests/unit/test_relation_auto_promotion.py \
+    services/artana_evidence_db/tests/unit/test_trusted_relation_promotion_policy.py \
+    -q
+  ```
+
+  Expected before implementation: the new policy tests fail if a bypass path exists or if the test module does not exist.
+
+- [ ] **Step 2: Consolidate promotion policy**
+
+  Keep `trusted_evidence_floor.py` as the single hard-floor decision point for trusted AI evidence and return reason codes that match audit terminology:
+
+  - `missing_verified_subject`
+  - `missing_verified_object`
+  - `model_hint_only_identifier`
+  - `review_only_endpoint`
+  - `unapproved_relation_type`
+  - `missing_evidence_sentence`
+  - `support_not_entailed`
+  - `fallback_trace_present`
+  - `missing_provenance`
+  - `weak_claim_trusted_leakage`
+
+- [ ] **Step 3: Run graph service gates**
+
+  ```bash
+  make graph-service-lint
+  make graph-service-type-check
+  make graph-service-boundary-check
+  make graph-service-contract-check
+  make graph-service-test
+  make graph-service-checks
+  ```
+
+- [ ] **Step 4: Run adversarial bypass review**
+
+  Adversarial review must attack:
+
+  - metadata spoofing
+  - direct service call bypasses
+  - relation evidence write paths that skip `trusted_evidence_floor.py`
+  - update paths that change a review-only relation into trusted without revalidation
+
+**Merge gate:** PR25 is mergeable when Graph DB fails closed even if upstream metadata lies.
+
+## PR26: Blinded Benchmark Expansion
+
+Suggested branch: `alvaro/evidence-pr26-blinded-benchmark-expansion`
+
+**Findings closed:** F-08.
+
+**Files:**
+
+- Create: `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json`
+- Modify: `scripts/validation/relation_feasibility/io.py`
+- Modify: `scripts/run_relation_feasibility_audit.py`
+- Create: `tests/unit/test_relation_feasibility_fixture_v3.py`
+- Modify: `tests/unit/test_relation_feasibility_audit.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr26-blinded-benchmark-expansion-summary.md`
+
+- [ ] **Step 1: Write fixture validation tests**
+
+  Tests must fail when v3 contains:
+
+  - duplicate `case_id`
+  - missing support sentence
+  - missing rationale
+  - invalid relation type
+  - unsupported value level
+  - trusted-eligible relation without endpoint policy
+  - negative control with a gold relation
+  - long-document case without relation position metadata
+
+  Run:
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    tests/unit/test_relation_feasibility_fixture_v3.py \
+    -q
+  ```
+
+- [ ] **Step 2: Add at least 60 v3 cases**
+
+  Required distribution:
+
+  | Category | Minimum cases |
+  |---|---:|
+  | Oncology driver or resistance | 10 |
+  | Rare disease or phenotype | 8 |
+  | Variant-specific claims | 8 |
+  | Pathway/process relations | 8 |
+  | Drug response or biomarker | 8 |
+  | Low-value hedged review-only claims | 8 |
+  | Negative controls | 6 |
+  | Long-document tail relations | 4 |
+
+- [ ] **Step 3: Run v2 regression and v3 exploratory audits**
+
+  ```bash
+  make relation-feasibility-quality-gate
+
+  bash -lc 'set -a; source .env.postgres; set +a; \
+    PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+    --extractor agent \
+    --fixture-version v3 \
+    --output-dir reports/relation_feasibility/2026-07-05-pr26-v3-run1'
+  ```
+
+- [ ] **Step 4: Run adversarial benchmark review**
+
+  Adversarial review must attack:
+
+  - leakage from existing examples
+  - cases that are too easy
+  - ambiguous gold labels
+  - invalid negative controls
+  - ontology shortcuts that would make wrong links look correct
+
+**Merge gate:** PR26 is mergeable when v3 expands confidence while keeping v2 as the stable regression gate.
+
+## PR27: Generated Evidence Reports And Drift Guard
+
+Suggested branch: `alvaro/evidence-pr27-generated-evidence-reports`
+
+**Findings closed:** F-09.
+
+**Files:**
+
+- Create: `scripts/generate_relation_evidence_summary.py`
+- Modify: `scripts/validation/relation_feasibility/reporting.py`
+- Modify: `scripts/validation/relation_feasibility/readiness.py`
+- Create: `tests/unit/test_generate_relation_evidence_summary.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr27-generated-evidence-summary.md`
+
+- [ ] **Step 1: Write failing summary-generation tests**
+
+  Tests must prove:
+
+  - metrics are read from JSON, not typed manually
+  - artifact paths are included
+  - SHA-256 hashes are included
+  - branch and commit are included when available
+  - fixture version and model label are included
+  - exact commands are included
+  - generation fails when required metrics are missing
+
+  Run:
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    tests/unit/test_generate_relation_evidence_summary.py \
+    -q
+  ```
+
+- [ ] **Step 2: Generate PR summaries from artifacts**
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 scripts/generate_relation_evidence_summary.py \
+    --report reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_report.json \
+    --failure-report reports/relation_feasibility_failure_analysis/2026-07-05-pr21-verified-grounding-closure-run3/relation_feasibility_failure_analysis_report.json \
+    --output docs/validation/reports/2026-07-05-pr21-verified-grounding-summary.md
+  ```
+
+- [ ] **Step 3: Add doc drift check**
+
+  The check must fail when a generated summary metric differs from the JSON report it cites.
+
+- [ ] **Step 4: Run validation**
+
+  ```bash
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+    .venv/bin/python3 -m pytest \
+    tests/unit/test_generate_relation_evidence_summary.py \
+    -q
+
+  make relation-feasibility-quality-gate
+  make service-checks
+  ```
+
+**Merge gate:** PR27 is mergeable when report summaries can be regenerated from JSON and stale metric drift is caught automatically.
+
+## Final Readiness Drill
+
+Suggested branch: `alvaro/evidence-final-trusted-graph-readiness`
+
+Depends on: PR21, PR22, PR23, PR24, PR25, PR26, PR27.
+
+- [ ] **Step 1: Rebase final readiness branch on the merged stack**
+
+  ```bash
+  git fetch origin
+  git rebase origin/main
+  ```
+
+- [ ] **Step 2: Run repository gates**
+
+  ```bash
+  make service-checks
+  git diff --check
+  ```
+
+- [ ] **Step 3: Run three strict final audits**
+
+  Use output directories:
+
+  - `reports/relation_feasibility/2026-07-05-final-readiness-run1`
+  - `reports/relation_feasibility/2026-07-05-final-readiness-run2`
+  - `reports/relation_feasibility/2026-07-05-final-readiness-run3`
+
+- [ ] **Step 4: Run failure attribution for all three final audits**
+
+  ```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/summarize_relation_readiness_failures.py \
+    --report run1=reports/relation_feasibility/2026-07-05-final-readiness-run1/relation_feasibility_report.json \
+    --report run2=reports/relation_feasibility/2026-07-05-final-readiness-run2/relation_feasibility_report.json \
+    --report run3=reports/relation_feasibility/2026-07-05-final-readiness-run3/relation_feasibility_report.json \
+    --output-dir reports/relation_feasibility_failure_analysis/2026-07-05-final-readiness
+```
+
+- [ ] **Step 5: Run repeated readiness gate**
+
+  ```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_readiness_gate.py \
+    --report reports/relation_feasibility/2026-07-05-final-readiness-run1/relation_feasibility_report.json \
+    --report reports/relation_feasibility/2026-07-05-final-readiness-run2/relation_feasibility_report.json \
+    --report reports/relation_feasibility/2026-07-05-final-readiness-run3/relation_feasibility_report.json \
+    --fail-on-not-ready \
+    --output-dir reports/relation_feasibility_readiness/2026-07-05-final-readiness
+```
+
+- [ ] **Step 6: Run adversarial final review**
+
+  Review scope:
+
+  - full diff
+  - three strict audit reports
+  - failure attribution
+  - model comparison
+  - graph promotion tests
+  - generated docs
+  - tracker status
+
+- [ ] **Step 7: Generate final evidence summary**
+
+  Use `scripts/generate_relation_evidence_summary.py` after PR27.
+
+**Final trusted-graph readiness gate:** The system is ready only when repeated strict live-agent reports are READY and Graph DB independently rejects unsafe trusted-promotion attempts.
+
+## Parallelization Plan
+
+```text
+PR21 closeout
+  -> PR22 low-value review lane
+  -> PR23 composite endpoint policy
+  -> PR25 graph promotion hard gate
+  -> PR27 generated evidence reports
+
+PR22 + PR23
+  -> PR24 repeatability and stronger-model A/B
+
+PR26 benchmark expansion
+  -> PR24 repeatability and stronger-model A/B
+  -> final readiness drill
+
+PR24 + PR25 + PR26 + PR27
+  -> final readiness drill
+```
+
+Parallel lanes after PR21 closeout:
+
+- PR22 and PR23 can run in parallel if they avoid editing the same scoring functions at the same time or one branch rebases on the other.
+- PR25 can run independently in Graph DB.
+- PR26 can run independently if it does not change v2 readiness behavior.
+- PR27 can run independently after summary JSON fields are stable.
+- PR24 should wait for PR22, PR23, and PR26 before making repeatability and model adoption claims.
+
+## Progress Checklist
+
+- [ ] PR21 closeout confirms grounding fixes, service checks, and honest RED status.
+- [ ] PR22 adds low-value review capture and splits trusted readiness from review-lane diagnostics.
+- [ ] PR23 adds typed composite endpoint policy without broad wrong CURIEs.
+- [ ] PR24 proves repeatability and stronger-model policy through controlled A/B runs.
+- [ ] PR25 enforces trusted evidence floors at Graph DB promotion.
+- [ ] PR26 expands the benchmark with blinded v3 coverage.
+- [ ] PR27 prevents evidence-summary drift from JSON artifacts.
+- [ ] Final readiness drill passes three strict live-agent runs and graph hard-gate validation.

--- a/docs/validation/trusted-graph-readiness-robust-findings-plan.md
+++ b/docs/validation/trusted-graph-readiness-robust-findings-plan.md
@@ -1,0 +1,527 @@
+# Trusted Graph Readiness Robust Findings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Robustly close every known finding that blocks Artana Evidence live-agent output from safe trusted-graph promotion.
+
+**Architecture:** Treat the live agent as a hypothesis generator, not as the trust authority. Evidence API owns extraction, grounding, support verification, value adjudication, and audit telemetry. Graph DB owns final promotion enforcement, relation dictionary governance, provenance, and fail-closed trust policy. Validation scripts own reproducible scorecards and must never count deterministic fallback as trusted evidence.
+
+**Tech Stack:** Python, FastAPI service modules, Pydantic models, pytest, ruff, relation feasibility audits, failure attribution reports, strict live-agent runs, local verified dictionaries, ontology-backed grounding fixtures, graph service promotion tests, Postgres service checks, and repeated-run readiness gates.
+
+---
+
+## Source Evidence
+
+This plan starts from the latest PR20 strict live-agent run:
+
+- `reports/relation_feasibility/2026-07-05-pr20-qualifier-precision-run4/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-05-pr20-qualifier-precision-run4/relation_feasibility_report.md`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr20-run4/relation_feasibility_failure_analysis_report.md`
+- `docs/validation/reports/2026-07-05-pr20-qualifier-precision-summary.md`
+
+Current state:
+
+| Gate | Current value | Merge-ready target | Status |
+|---|---:|---:|---|
+| Strict live-agent cases completed | 30/30 | 30/30 | Passing |
+| Fallback cases | 0 | 0 | Passing |
+| Invalid strict-agent cases | 0 | 0 | Passing |
+| Negative-control leakage | 0 | 0 | Passing |
+| Raw unknown relation surfaces | 0 | 0 | Passing |
+| Wrong verified CURIE links | 0 | 0 | Passing |
+| Completed-agent precision | 0.9500 | >= 0.8000 | Passing |
+| Completed-agent recall | 0.7600 | >= 0.6000 | Passing |
+| Completed-agent valuable rate | 0.9500 | >= 0.7000 | Passing |
+| High-value recall | 0.9500 | >= 0.8500 | Passing |
+| Trusted high-value recall | 0.5500 | >= 0.8500 | Blocking |
+| Generic relation rate | 0.0500 | <= 0.0500 hard max, prefer < 0.0500 | At ceiling |
+| Verified CURIE-linked gold endpoint rate | 0.8108 | >= 0.9500 | Blocking |
+| Repeatability | one latest strict run | at least three strict runs | Blocking |
+| Graph promotion enforcement | not proven end to end | fail closed | Blocking |
+
+The important conclusion is that the system is no longer blocked by basic agent execution. It is blocked by proof quality: verified endpoint grounding, trusted high-value recall, run variance, graph promotion enforcement, and benchmark breadth.
+
+## Non-Negotiable Readiness Contract
+
+Trusted graph readiness is true only when all of these are true across repeated strict live-agent runs:
+
+- `fallback_case_count == 0`
+- `invalid_agent_case_count == 0`
+- `negative_control_leakage_count == 0`
+- `raw_unknown_relation_type_count == 0`
+- `raw_unknown_relation_type_surface_count == 0`
+- `wrong_verified_curie_link_count == 0`
+- worst-run `completed_agent_precision_against_gold >= 0.8000`
+- worst-run `completed_agent_recall_against_gold >= 0.6000`
+- worst-run `high_value_recall >= 0.8500`
+- worst-run `trusted_high_value_recall >= 0.8500`
+- worst-run `completed_agent_valuable_rate >= 0.7000`
+- worst-run `generic_relation_rate <= 0.0500`
+- worst-run `curie_linked_gold_endpoint_rate >= 0.9500`
+- graph promotion rejects any AI relation missing verified endpoints, approved relation type, entailing evidence support, grounded support sentence, provenance, no-fallback trace, and review status compatible with trusted promotion
+
+These thresholds may be raised after the system becomes stable. They must not be lowered to create a green report.
+
+## Agile Execution Loop
+
+Every PR lane must follow the same loop:
+
+1. Select one finding or one tightly coupled finding group from the ledger.
+2. Write the failing test first.
+3. Run the focused test and capture the expected failure.
+4. Implement the smallest first-principles fix at the owning service boundary.
+5. Run the focused test until green.
+6. Run the relevant boundary checks for the changed service.
+7. Run `make relation-feasibility-quality-gate`.
+8. Run one strict live-agent audit with `--extractor agent`.
+9. Run failure attribution on the new report.
+10. Request adversarial review against the diff, scorecard, and failure attribution.
+11. Fix every valid adversarial finding.
+12. Run `git diff --check` and `make service-checks`.
+13. Update `docs/validation/evidence-excellence-progress-tracker.md`.
+14. Add a dated evidence summary under `docs/validation/reports/`.
+15. Commit only after tests, live evidence, adversarial review, and docs agree.
+
+Strict live-agent audit template:
+
+```bash
+bash -lc 'set -a; source .env.postgres; set +a; \
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run1'
+```
+
+Failure attribution template:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/summarize_relation_readiness_failures.py \
+  --report current=reports/relation_feasibility/2026-07-05-pr21-verified-grounding-closure-run1/relation_feasibility_report.json \
+  --output-dir reports/relation_feasibility_failure_analysis/2026-07-05-pr21-verified-grounding-closure-run1
+```
+
+Final repeated-run readiness template:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_readiness_gate.py \
+  --report reports/relation_feasibility/2026-07-05-final-readiness-run1 \
+  --report reports/relation_feasibility/2026-07-05-final-readiness-run2 \
+  --report reports/relation_feasibility/2026-07-05-final-readiness-run3 \
+  --fail-on-not-ready \
+  --output-dir reports/relation_feasibility_readiness/2026-07-05-final-readiness
+```
+
+## Finding Ledger
+
+| ID | Finding | First-principles root cause | Owning PR | Robust closure evidence |
+|---|---|---|---|---|
+| F-01 | Verified CURIE-linked endpoint rate is `0.8108`, below `0.9500`. | The linker correctly refuses raw model hints, but the verified grounding layer does not cover recurring pathway, process, event, phenotype, and response labels. | PR21, PR23, PR24 | PR21 must improve verified endpoint recovery without wrong links; full closure requires worst-run verified CURIE-linked endpoint rate `>= 0.9500` and wrong verified CURIE links `0`. |
+| F-02 | Trusted high-value recall is `0.5500` while high-value recall is `0.9500`. | Many high-value relations are found, but they cannot become trusted because one or both endpoints lack verified identifiers. | PR21 | Trusted high-value recall is `>= 0.8500`, and every trusted match has completed-agent provenance plus verified subject and object IDs. |
+| F-03 | `MAPK signaling`, `homologous recombination DNA repair`, and `cardiac septal development` appear only as unverified model hints. | Model-proposed CURIEs are intentionally untrusted until confirmed by curated records or allowed ontology grounding. | PR21 | These labels link through verified curation and raw hints remain untrusted until confirmed. |
+| F-04 | `aggressive tumor growth`, `ERK phosphorylation`, and `response to pembrolizumab` still have missing CURIE policy. | Composite and event-like endpoint labels need typed grounding rules, not generic text matching. | PR21 | Each label has a documented review-only abstention that blocks trusted promotion. |
+| F-05 | The `BRCA1 loss SENSITIZES_TO cisplatin` high-value claim is run-variant. | The live agent can select a weaker surrounding association instead of the valuable drug-sensitivity claim. | PR22 and PR24 | The claim is recovered repeatably or withheld from trusted promotion unless consensus confirms it. |
+| F-06 | `BRCA1 loss ASSOCIATED_WITH DNA repair defects` can survive as an entailed false positive. | Entailment alone is insufficient; the system also needs value-aware claim adjudication against more specific sibling claims. | PR22 | Locally true but lower-value sibling relations become review-only or are pruned when a higher-value supported relation is present. |
+| F-07 | Generic relation rate is at the hard ceiling, `0.0500`. | A single broad relation can still pass quality filters under live-agent variance. | PR22 | Worst-run generic relation rate stays below or at `0.0500`, with operational target below `0.0500`, and high-value recall does not regress. |
+| F-08 | Low-value hedged gold rows have `0.0000` low-value review recall. | Trusted extraction intentionally filters weak claims, but the product still needs a separate review-only capture lane for useful weak evidence. | PR23 | Low-value review recall is measured and improves without allowing weak claims into trusted promotion. |
+| F-09 | Repeatability is not proven. | The current scorecard is based on single latest strict runs, and live-agent output varies between runs. | PR24 | Three strict runs pass readiness on worst-run metrics, or non-repeatable relations are held for review. |
+| F-10 | Stronger-model benefit is unknown. | There is no controlled A/B harness comparing current and candidate models with identical fixtures, thresholds, cost, and failure attribution. | PR24 | A/B report includes at least three runs per model, worst-run metrics, mean metrics, cost, latency, and model-specific failure clusters. |
+| F-11 | Runtime graph promotion is not proven to enforce the audit trust floor. | Audit readiness and graph promotion are separate boundaries; a green report must not be the only protection. | PR25 | Graph DB rejects any trusted AI relation missing verified endpoints, approved relation type, entailing support, provenance, or no-fallback trace. |
+| F-12 | Benchmark confidence is still limited. | The current fixture is a strong regression suite but not a broad blinded biomedical corpus. | PR26 | A larger fixture adds oncology, rare disease, variants, pathways, drug response, negative controls, long documents, and adversarial near-misses. |
+| F-13 | Evidence docs can drift from generated report JSON. | Several summaries are manually copied from live reports. | PR27 | Summary docs are generated or checked from report JSON and include artifact hashes. |
+
+## PR21: Verified Grounding And Review-Only Abstention
+
+Suggested branch: `alvaro/evidence-pr21-verified-grounding-closure`
+
+**Findings addressed:** F-01, F-02, F-03, F-04. PR21 is expected to materially
+improve these findings, not by itself prove final trusted-graph readiness.
+
+**Files:**
+
+- Create: `services/artana_evidence_api/document_extraction_support/entity_grounding/verified_dictionary.py`
+- Create: `services/artana_evidence_api/document_extraction_support/entity_grounding/contracts.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/entity_curie_linking.py`
+- Modify: `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v2.json`
+- Create: `scripts/validation/relation_feasibility/relation_matching.py`
+- Modify: `scripts/validation/relation_feasibility/failure_analysis.py`
+- Modify: `scripts/validation/relation_feasibility/scoring.py`
+- Modify: `services/artana_evidence_api/tests/unit/test_entity_curie_linking.py`
+- Create: `services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py`
+- Modify: `tests/unit/test_relation_feasibility_audit.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr21-verified-grounding-summary.md`
+
+**Steps:**
+
+- [ ] Write failing tests for verified labels from the PR20 gap report: `MAPK signaling`, `homologous recombination DNA repair`, `cardiac septal development`, and `ERK phosphorylation`.
+- [ ] Write failing tests for review-only abstention labels: `aggressive tumor growth`, `response to pembrolizumab`, and any broad response or phenotype label that cannot be safely represented by one approved CURIE.
+- [ ] Split verified records out of `entity_curie_linking.py` into `verified_entity_dictionary.py` so the linker stays small and single-purpose.
+- [ ] Add typed grounding contracts that distinguish `verified`, `model_hint_only`, `review_only`, `ambiguous`, `unsupported_namespace`, and `missing`.
+- [ ] Update `entity_curie_linking.py` so raw model CURIE hints never produce `trusted_identifier == True` without verified dictionary or approved ontology confirmation.
+- [ ] Update the gold fixture only for endpoints with safe approved identifiers. Keep unsafe composite labels without trusted gold CURIEs and record the abstention reason.
+- [ ] Strengthen scoring tests so trusted high-value recall counts only completed-agent candidates with verified subject and object matches.
+- [ ] Run focused grounding tests.
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  services/artana_evidence_api/tests/unit/test_entity_curie_linking.py \
+  services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py \
+  tests/unit/test_relation_feasibility_audit.py \
+  -q
+```
+
+- [ ] Run `make relation-feasibility-quality-gate`.
+- [ ] Run the PR21 strict live-agent audit and failure attribution.
+- [ ] Run adversarial review focused on false verified links, over-broad ontology links, and silent model-hint trust.
+- [ ] Run `make service-checks`.
+
+**Merge gate:** PR21 is mergeable when verified endpoint rate and trusted high-value recall improve materially, wrong verified links remain `0`, unsafe labels abstain explicitly, and no fallback path is counted as trusted evidence.
+
+## PR22: Value-Aware Precision And Generic Relation Suppression
+
+Suggested branch: `alvaro/evidence-pr22-value-aware-precision`
+
+**Findings closed:** F-05, F-06, F-07
+
+**Files:**
+
+- Modify: `services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/relation_specificity_pruning.py`
+- Create: `services/artana_evidence_api/document_extraction_support/relation_value_adjudication.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/evidence_support_verifier.py`
+- Modify: `services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py`
+- Create: `services/artana_evidence_api/tests/unit/test_relation_value_adjudication.py`
+- Modify: `tests/unit/test_relation_feasibility_audit.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr22-value-aware-precision-summary.md`
+
+**Steps:**
+
+- [ ] Write a regression test where `BRCA1 loss SENSITIZES_TO cisplatin` is supported and `BRCA1 loss ASSOCIATED_WITH DNA repair defects` is also entailed; expected result is that the sensitivity claim stays trusted-eligible and the generic association becomes review-only.
+- [ ] Add tests for context siblings where a broad `ASSOCIATED_WITH` claim competes with a specific `SENSITIZES_TO`, `RESISTANT_TO`, `TARGETS`, `BIOMARKER_FOR`, `ACTIVATES`, `INHIBITS`, or `REGULATES` claim in the same evidence window.
+- [ ] Implement `relation_value_adjudication.py` as a focused module that ranks candidate claims by relation specificity, endpoint specificity, support sentence alignment, and value level.
+- [ ] Make quality filtering use adjudication output without embedding ranking rules directly into the filter.
+- [ ] Ensure generic relations can remain review candidates when clinically useful but cannot count toward trusted high-value recall when a more specific sibling exists.
+- [ ] Run focused quality and adjudication tests.
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py \
+  services/artana_evidence_api/tests/unit/test_relation_value_adjudication.py \
+  tests/unit/test_relation_feasibility_audit.py \
+  -q
+```
+
+- [ ] Run `make relation-feasibility-quality-gate`.
+- [ ] Run strict live-agent audit and failure attribution.
+- [ ] Run adversarial review focused on hidden recall loss and over-pruning valid separate claims.
+- [ ] Run `make service-checks`.
+
+**Merge gate:** PR22 is mergeable when generic relation rate stays within the hard max, high-value recall does not regress below target, and locally true low-value siblings cannot be auto-promoted as trusted graph evidence.
+
+## PR23: Low-Value Review-Only Evidence Lane
+
+Suggested branch: `alvaro/evidence-pr23-low-value-review-lane`
+
+**Findings closed:** F-08
+
+**Files:**
+
+- Modify: `services/artana_evidence_api/document_extraction_prompting.py`
+- Modify: `services/artana_evidence_api/document_extraction_support/llm_fulltext_extraction.py`
+- Create: `services/artana_evidence_api/document_extraction_support/review_only_candidate_policy.py`
+- Modify: `services/artana_evidence_api/tests/unit/test_document_extraction_modules.py`
+- Create: `services/artana_evidence_api/tests/unit/test_review_only_candidate_policy.py`
+- Modify: `scripts/validation/relation_feasibility/scoring.py`
+- Modify: `scripts/validation/relation_feasibility/reporting.py`
+- Modify: `tests/unit/test_relation_feasibility_audit.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr23-low-value-review-summary.md`
+
+**Steps:**
+
+- [ ] Write tests for hedged examples from the fixture: `may regulate`, `trend toward`, `possible biomarker`, and `correlated with`.
+- [ ] Require these candidates to be represented as review-only with explicit hedge metadata instead of trusted relation evidence.
+- [ ] Add scorecard rows for low-value review recall and weak-claim trust leakage.
+- [ ] Ensure review-only candidates cannot satisfy trusted high-value recall or graph auto-promotion gates.
+- [ ] Run focused review-lane tests.
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  services/artana_evidence_api/tests/unit/test_review_only_candidate_policy.py \
+  services/artana_evidence_api/tests/unit/test_document_extraction_modules.py \
+  tests/unit/test_relation_feasibility_audit.py \
+  -q
+```
+
+- [ ] Run `make relation-feasibility-quality-gate`.
+- [ ] Run strict live-agent audit and failure attribution.
+- [ ] Run adversarial review focused on weak evidence leaking into trusted promotion.
+- [ ] Run `make service-checks`.
+
+**Merge gate:** PR23 is mergeable when weak but potentially useful evidence is visible to reviewers while trusted promotion remains unchanged and strict.
+
+## PR24: Repeatability, Consensus, And Stronger-Model A/B
+
+Suggested branch: `alvaro/evidence-pr24-repeatability-model-ab`
+
+**Findings closed:** F-05, F-09, F-10
+
+**Files:**
+
+- Modify: `scripts/run_relation_feasibility_audit.py`
+- Modify: `scripts/summarize_relation_readiness_failures.py`
+- Modify: `scripts/validation/relation_feasibility/failure_analysis.py`
+- Modify: `scripts/validation/relation_feasibility/readiness.py`
+- Create: `scripts/validation/relation_feasibility/model_comparison.py`
+- Create: `tests/unit/test_relation_feasibility_model_comparison.py`
+- Modify: `tests/unit/test_relation_feasibility_readiness_gate.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr24-repeatability-model-ab-summary.md`
+
+**Steps:**
+
+- [ ] Add a model label and run label to each audit report so multiple runs can be compared without manual bookkeeping.
+- [ ] Write tests proving the readiness gate evaluates worst-run metrics, not only averages.
+- [ ] Write tests proving a non-repeatable high-value claim cannot be marked promotion-ready unless consensus policy accepts it.
+- [ ] Add a model comparison report that includes precision, recall, high-value recall, trusted high-value recall, verified endpoint rate, generic rate, fallback count, invalid-agent count, cost if available, latency if available, and failure clusters.
+- [ ] Run three strict audits for the current model.
+- [ ] Run three strict audits for the candidate stronger model approved by the runtime configuration.
+- [ ] Compare models using identical fixture version, thresholds, and report format.
+- [ ] Do not switch production default model unless the stronger model improves worst-run trusted readiness without introducing wrong verified links, fallback, invalid completions, or unacceptable cost/latency.
+
+Current-model template:
+
+```bash
+bash -lc 'set -a; source .env.postgres; set +a; \
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --model-label current \
+  --output-dir reports/relation_feasibility/2026-07-05-pr24-current-run1'
+```
+
+Candidate-model template:
+
+```bash
+bash -lc 'set -a; source .env.postgres; set +a; \
+  export ARTANA_AI_EVIDENCE_EXTRACTION_MODEL="$ARTANA_STRONGER_MODEL_CANDIDATE"; \
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --model-label candidate \
+  --output-dir reports/relation_feasibility/2026-07-05-pr24-candidate-run1'
+```
+
+- [ ] Run focused comparison tests.
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  tests/unit/test_relation_feasibility_model_comparison.py \
+  tests/unit/test_relation_feasibility_readiness_gate.py \
+  -q
+```
+
+- [ ] Run `make relation-feasibility-quality-gate`.
+- [ ] Run adversarial review focused on cherry-picked model wins, average-only claims, and hidden cost/latency tradeoffs.
+- [ ] Run `make service-checks`.
+
+**Merge gate:** PR24 is mergeable when the system has a repeatable readiness report and a defensible model policy. A stronger model can be adopted only as an evidence-backed configuration decision, not as a substitute for verification.
+
+## PR25: Graph Promotion Hard Gate
+
+Suggested branch: `alvaro/evidence-pr25-graph-promotion-hard-gate`
+
+**Findings closed:** F-11
+
+**Files:**
+
+- Modify: `services/artana_evidence_db/graph_validation_service.py`
+- Modify: `services/artana_evidence_db/relation_evidence_service.py`
+- Modify: `services/artana_evidence_db/graph_repository.py`
+- Modify: `services/artana_evidence_db/models.py`
+- Modify: `services/artana_evidence_db/tests/unit/test_graph_validation_service.py`
+- Create: `services/artana_evidence_db/tests/unit/test_trusted_relation_promotion_policy.py`
+- Modify: `services/artana_evidence_db/tests/integration/test_relation_evidence_api.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr25-graph-promotion-hard-gate-summary.md`
+
+**Steps:**
+
+- [ ] Write tests proving graph promotion rejects AI relations with missing subject CURIE, missing object CURIE, model-only CURIE source, unapproved relation type, missing evidence sentence, non-entailing support, fallback trace, missing provenance, or review-only status.
+- [ ] Add a single promotion-policy function that returns a decision envelope with reason codes instead of scattering checks across service methods.
+- [ ] Ensure audit reason codes and graph rejection reason codes use the same vocabulary where possible.
+- [ ] Preserve governance audit records for rejected promotions.
+- [ ] Run graph focused tests.
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  services/artana_evidence_db/tests/unit/test_graph_validation_service.py \
+  services/artana_evidence_db/tests/unit/test_trusted_relation_promotion_policy.py \
+  services/artana_evidence_db/tests/integration/test_relation_evidence_api.py \
+  -q
+```
+
+- [ ] Run `make graph-service-checks`.
+- [ ] Run `make service-checks`.
+- [ ] Run adversarial review focused on bypass paths and metadata spoofing.
+
+**Merge gate:** PR25 is mergeable when Graph DB fails closed even if Evidence API or an audit artifact incorrectly labels an unsafe AI relation as trusted.
+
+## PR26: Blinded Benchmark Expansion
+
+Suggested branch: `alvaro/evidence-pr26-blinded-benchmark-expansion`
+
+**Findings closed:** F-12
+
+**Files:**
+
+- Modify: `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v2.json`
+- Create: `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json`
+- Modify: `scripts/validation/relation_feasibility/fixtures.py`
+- Modify: `scripts/run_relation_feasibility_audit.py`
+- Create: `tests/unit/test_relation_feasibility_fixture_v3.py`
+- Modify: `tests/unit/test_relation_feasibility_audit.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr26-blinded-benchmark-summary.md`
+
+**Steps:**
+
+- [ ] Add at least 60 total cases in v3 across oncology, rare disease, variants, pathways, drug response, phenotype links, long documents, negative controls, and adversarial near-misses.
+- [ ] Require each gold relation to specify value level, support sentence, rationale, endpoint specificity expectation, relation specificity expectation, and trusted-promotion eligibility.
+- [ ] Add fixture validation tests that fail on duplicate case IDs, missing support sentences, missing rationales, invalid relation types, unsupported value levels, and unsafe trusted labels without endpoint policy.
+- [ ] Add negative controls that look semantically close but should produce no trusted relation.
+- [ ] Add long-document cases where the valuable relation appears outside the first chunk.
+- [ ] Run fixture validation tests.
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  tests/unit/test_relation_feasibility_fixture_v3.py \
+  tests/unit/test_relation_feasibility_audit.py \
+  -q
+```
+
+- [ ] Run `make relation-feasibility-quality-gate`.
+- [ ] Run one strict live-agent audit against v3.
+- [ ] Run failure attribution against v3.
+- [ ] Run adversarial review focused on benchmark leakage, overly easy cases, and gold-label ambiguity.
+- [ ] Run `make service-checks`.
+
+**Merge gate:** PR26 is mergeable when v3 makes the readiness claim harder to game and the report clearly distinguishes v2 regression results from v3 broader-confidence results.
+
+## PR27: Generated Evidence Reports And Drift Guard
+
+Suggested branch: `alvaro/evidence-pr27-generated-evidence-reports`
+
+**Findings closed:** F-13
+
+**Files:**
+
+- Create: `scripts/generate_relation_evidence_summary.py`
+- Modify: `scripts/validation/relation_feasibility/reporting.py`
+- Modify: `scripts/validation/relation_feasibility/readiness.py`
+- Create: `tests/unit/test_generate_relation_evidence_summary.py`
+- Modify: `docs/validation/evidence-excellence-progress-tracker.md`
+- Create: `docs/validation/reports/2026-07-05-pr27-generated-evidence-summary.md`
+
+**Steps:**
+
+- [ ] Write tests proving generated summaries read metrics from JSON instead of manual Markdown copies.
+- [ ] Include artifact paths, SHA-256 hashes, branch, commit, fixture version, model label, and exact command in generated summaries.
+- [ ] Fail generation when required metrics are missing.
+- [ ] Add a doc check that compares selected summary metrics with report JSON.
+- [ ] Run summary tests.
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  tests/unit/test_generate_relation_evidence_summary.py \
+  -q
+```
+
+- [ ] Run `make relation-feasibility-quality-gate`.
+- [ ] Run `make service-checks`.
+- [ ] Run adversarial review focused on stale docs, copied metrics, and unverifiable evidence.
+
+**Merge gate:** PR27 is mergeable when generated evidence reports can be trusted as a faithful view of the JSON artifacts.
+
+## Final Readiness Drill
+
+Suggested branch: `alvaro/evidence-final-trusted-graph-readiness`
+
+**Depends on:** PR21, PR22, PR23, PR24, PR25, PR26, PR27
+
+**Steps:**
+
+- [ ] Rebase the final readiness branch on the merged stack.
+- [ ] Run `make service-checks`.
+- [ ] Run three strict live-agent audits on the final fixture version.
+- [ ] Run failure attribution on each run.
+- [ ] Run the repeated-run readiness gate with `--fail-on-not-ready`.
+- [ ] Trigger adversarial review against the full stack, final reports, graph promotion tests, and generated evidence docs.
+- [ ] Fix valid adversarial findings in the smallest owning PR or a final narrow patch.
+- [ ] Update `docs/validation/evidence-excellence-progress-tracker.md` with final status.
+- [ ] Generate final evidence summary from JSON artifacts.
+
+**Final merge gate:** The system is trusted-graph ready only when repeated strict live-agent runs pass the readiness gate and Graph DB rejects unsafe trusted-promotion attempts independently of the audit report.
+
+## Parallelization Plan
+
+```text
+PR21 verified grounding
+  -> PR24 repeatability and model A/B
+      -> final readiness drill
+
+PR22 value-aware precision
+  -> PR24 repeatability and model A/B
+      -> final readiness drill
+
+PR23 low-value review lane
+  -> PR24 repeatability and model A/B
+      -> final readiness drill
+
+PR25 graph promotion hard gate
+  -> final readiness drill
+
+PR26 blinded benchmark expansion
+  -> PR24 repeatability and model A/B
+  -> final readiness drill
+
+PR27 generated evidence reports
+  -> final readiness drill
+```
+
+PR21, PR22, PR23, PR25, PR26, and PR27 can start in parallel if each branch is isolated. PR24 should consume PR21, PR22, PR23, and PR26 outputs before making model or consensus claims. The final readiness branch should merge only after PR24 and PR25 both pass.
+
+## Stronger Model Decision Policy
+
+A stronger model may improve extraction recall, relation specificity, and wording stability. It cannot by itself make the system trusted-graph ready, because trusted readiness depends on verified grounding, support entailment, graph promotion policy, and repeatability.
+
+Use this decision table:
+
+| Candidate result | Decision |
+|---|---|
+| Better recall but more wrong verified links | Reject for trusted promotion. |
+| Better averages but worse worst-run metrics | Keep for review experiments only. |
+| Better trusted high-value recall with fallback 0, invalid 0, wrong verified links 0, and acceptable cost/latency | Adopt behind configuration after PR24. |
+| No material quality gain | Keep current model and invest in grounding, adjudication, and corpus quality. |
+| Higher cost/latency with marginal quality gain | Keep as optional escalation for hard cases, not default extraction. |
+
+## Progress Checklist
+
+- [ ] PR21 closes verified grounding and trusted high-value recall gaps.
+- [ ] PR22 closes generic/context false-positive precision gaps.
+- [ ] PR23 captures low-value evidence as review-only without trusted leakage.
+- [ ] PR24 proves repeatability and model policy through controlled A/B runs.
+- [ ] PR25 enforces the same trust floor at Graph DB promotion.
+- [ ] PR26 expands benchmark confidence with blinded v3 cases.
+- [ ] PR27 prevents evidence-doc drift from JSON artifacts.
+- [ ] Final readiness drill passes repeated strict live-agent gate and graph hard-gate validation.

--- a/scripts/validation/relation_feasibility/failure_analysis.py
+++ b/scripts/validation/relation_feasibility/failure_analysis.py
@@ -38,6 +38,15 @@ class _MissedGoldKey:
 
 
 @dataclass(frozen=True, slots=True)
+class _MissedGoldCurieEndpointKey:
+    case_id: str
+    endpoint_role: str
+    label: str
+    gold_curie: str
+    value_level: str
+
+
+@dataclass(frozen=True, slots=True)
 class _FalsePositiveKey:
     case_id: str
     subject: str
@@ -100,6 +109,7 @@ def build_failure_analysis_report(
     """Build a read-only failure attribution report from feasibility reports."""
 
     missed_gold: dict[_MissedGoldKey, _Accumulator] = {}
+    missed_gold_curie_endpoints: dict[_MissedGoldCurieEndpointKey, _Accumulator] = {}
     false_positives: dict[_FalsePositiveKey, _Accumulator] = {}
     curie_gaps: dict[_CurieGapKey, _Accumulator] = {}
     governed_proposals: dict[_GovernedProposalKey, _Accumulator] = {}
@@ -134,6 +144,7 @@ def build_failure_analysis_report(
             case_id = _case_id(case_result)
             _collect_missed_gold(
                 missed_gold,
+                missed_gold_curie_endpoints,
                 case_result=case_result,
                 case_id=case_id,
                 run_label=label,
@@ -153,6 +164,9 @@ def build_failure_analysis_report(
         "run_count": len(inputs),
         "input_reports": input_reports,
         "repeated_missed_gold_relations": _missed_gold_rows(missed_gold),
+        "missed_gold_curie_endpoints": _missed_gold_curie_endpoint_rows(
+            missed_gold_curie_endpoints,
+        ),
         "repeated_false_positive_candidates": _false_positive_rows(false_positives),
         "curie_gaps": _curie_gap_rows(curie_gaps),
         "proposal_capture": {
@@ -185,6 +199,20 @@ def render_failure_analysis_markdown(report: JSONObject) -> str:
         _table_lines(
             report.get("repeated_missed_gold_relations"),
             ("occurrence_count", "value_level", "case_id", "subject", "relation_type", "object"),
+        ),
+    )
+    lines.extend(["", "## CURIE Endpoints Lost To Missed Gold", ""])
+    lines.extend(
+        _table_lines(
+            report.get("missed_gold_curie_endpoints"),
+            (
+                "occurrence_count",
+                "value_level",
+                "case_id",
+                "endpoint_role",
+                "label",
+                "gold_curie",
+            ),
         ),
     )
     lines.extend(["", "## Repeated False Positives", ""])
@@ -249,6 +277,7 @@ def write_failure_analysis_report(*, report: JSONObject, output_dir: Path) -> JS
 
 def _collect_missed_gold(
     missed_gold: dict[_MissedGoldKey, _Accumulator],
+    missed_gold_curie_endpoints: dict[_MissedGoldCurieEndpointKey, _Accumulator],
     *,
     case_result: JSONObject,
     case_id: str,
@@ -263,6 +292,41 @@ def _collect_missed_gold(
             value_level=_string_value(missed_relation.get("value_level")),
         )
         _add_occurrence(missed_gold, key, run_label)
+        _collect_missed_gold_curie_endpoint(
+            missed_gold_curie_endpoints,
+            missed_relation=missed_relation,
+            case_id=case_id,
+            run_label=run_label,
+            role="subject",
+        )
+        _collect_missed_gold_curie_endpoint(
+            missed_gold_curie_endpoints,
+            missed_relation=missed_relation,
+            case_id=case_id,
+            run_label=run_label,
+            role="object",
+        )
+
+
+def _collect_missed_gold_curie_endpoint(
+    missed_gold_curie_endpoints: dict[_MissedGoldCurieEndpointKey, _Accumulator],
+    *,
+    missed_relation: JSONObject,
+    case_id: str,
+    run_label: str,
+    role: str,
+) -> None:
+    gold_curie = _optional_string(missed_relation.get(f"{role}_curie"))
+    if gold_curie is None:
+        return
+    key = _MissedGoldCurieEndpointKey(
+        case_id=case_id,
+        endpoint_role=role,
+        label=_string_value(missed_relation.get(role)),
+        gold_curie=gold_curie,
+        value_level=_string_value(missed_relation.get("value_level")),
+    )
+    _add_occurrence(missed_gold_curie_endpoints, key, run_label)
 
 
 def _collect_assessments(
@@ -409,6 +473,25 @@ def _false_positive_rows(
                 "proposed_relation_type": key.proposed_relation_type,
                 "object": key.object,
                 "support_verification": key.support_verification,
+                "occurrence_count": accumulator.count,
+                "run_labels": sorted(accumulator.run_labels),
+            },
+        )
+    return _sort_rows(rows)
+
+
+def _missed_gold_curie_endpoint_rows(
+    missed_gold_curie_endpoints: dict[_MissedGoldCurieEndpointKey, _Accumulator],
+) -> list[JSONObject]:
+    rows: list[JSONObject] = []
+    for key, accumulator in missed_gold_curie_endpoints.items():
+        rows.append(
+            {
+                "case_id": key.case_id,
+                "endpoint_role": key.endpoint_role,
+                "label": key.label,
+                "gold_curie": key.gold_curie,
+                "value_level": key.value_level,
                 "occurrence_count": accumulator.count,
                 "run_labels": sorted(accumulator.run_labels),
             },

--- a/scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v2.json
+++ b/scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v2.json
@@ -17,7 +17,7 @@
           "value_level": "high",
           "rationale": "Direct gene-to-process activation claim.",
           "subject_curie": "HGNC:22474",
-          "object_curie": null,
+          "object_curie": "GO:0003279",
           "requires_entailment": true
         }
       ]
@@ -55,7 +55,7 @@
           "value_level": "high",
           "rationale": "Specific gene-to-process regulatory relation.",
           "subject_curie": "HGNC:1100",
-          "object_curie": null,
+          "object_curie": "GO:0000724",
           "requires_entailment": true
         }
       ]
@@ -169,7 +169,7 @@
           "value_level": "high",
           "rationale": "Specific variant-to-pathway activation.",
           "subject_curie": "ClinVar:BRAF_V600E",
-          "object_curie": null,
+          "object_curie": "GO:0000165",
           "requires_entailment": true
         }
       ]
@@ -356,7 +356,7 @@
           "value_level": "high",
           "rationale": "Variant aliases should not fragment the entity identity.",
           "subject_curie": "ClinVar:RET_ARG1174TER",
-          "object_curie": null,
+          "object_curie": "GO:0000165",
           "requires_entailment": true
         }
       ]
@@ -470,7 +470,7 @@
           "value_level": "high",
           "rationale": "Tail relation should remain measurable as long-document coverage expands.",
           "subject_curie": "ClinVar:BRAF_V600E",
-          "object_curie": null,
+          "object_curie": "GO:0000165",
           "requires_entailment": true
         }
       ]

--- a/scripts/validation/relation_feasibility/relation_matching.py
+++ b/scripts/validation/relation_feasibility/relation_matching.py
@@ -1,0 +1,135 @@
+"""Relation-key and endpoint matching helpers for feasibility scoring."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from artana_evidence_api.document_extraction_support.entity_grounding.verified_dictionary import (
+    relation_match_label_for_label,
+)
+
+if TYPE_CHECKING:
+    from scripts.validation.relation_feasibility.models import (
+        ExtractedRelation,
+        GoldRelation,
+    )
+
+_RELATION_SYNONYMS = {
+    "LINKED_TO": "ASSOCIATED_WITH",
+    "LINKS_TO": "ASSOCIATED_WITH",
+    "CORRELATED_WITH": "ASSOCIATED_WITH",
+    "INTERACTS_WITH": "PHYSICALLY_INTERACTS_WITH",
+    "BINDS_TO": "PHYSICALLY_INTERACTS_WITH",
+    "UPREGULATES": "ACTIVATES",
+    "DOWNREGULATES": "INHIBITS",
+}
+
+
+def normalized_relation_key(
+    relation: ExtractedRelation | GoldRelation,
+) -> tuple[str, str, str]:
+    """Return the normalized triple key used for support matching."""
+
+    return (
+        normalize_entity(relation.subject),
+        normalize_relation_type(relation.relation_type),
+        normalize_entity(relation.object),
+    )
+
+
+def relation_matches_gold(
+    *,
+    candidate: ExtractedRelation,
+    gold_relation: GoldRelation,
+) -> bool:
+    """Return whether a candidate can be assessed against a gold relation."""
+
+    if normalize_relation_type(candidate.relation_type) != normalize_relation_type(
+        gold_relation.relation_type,
+    ):
+        return False
+    return _endpoint_matches_gold(
+        candidate_label=candidate.subject,
+        candidate_curie=candidate.subject_curie,
+        candidate_curie_source=candidate.subject_curie_source,
+        gold_label=gold_relation.subject,
+        gold_curie=gold_relation.subject_curie,
+    ) and _endpoint_matches_gold(
+        candidate_label=candidate.object,
+        candidate_curie=candidate.object_curie,
+        candidate_curie_source=candidate.object_curie_source,
+        gold_label=gold_relation.object,
+        gold_curie=gold_relation.object_curie,
+    )
+
+
+def normalize_entity(value: str) -> str:
+    """Normalize an entity label for exact relation matching."""
+
+    return re.sub(r"[^a-z0-9]+", " ", value.casefold()).strip()
+
+
+def normalize_relation_type(value: str) -> str:
+    """Normalize a relation type and known relation synonyms."""
+
+    token = re.sub(r"[^A-Z0-9]+", "_", value.strip().upper()).strip("_")
+    return _RELATION_SYNONYMS.get(token, token)
+
+
+def curie_matches(
+    *,
+    candidate_curie: str | None,
+    gold_curie: str | None,
+) -> bool:
+    """Return whether two CURIE values are equal after prefix normalization."""
+
+    return (
+        gold_curie is not None
+        and candidate_curie is not None
+        and _normalize_curie(candidate_curie) == _normalize_curie(gold_curie)
+    )
+
+
+def _endpoint_matches_gold(
+    *,
+    candidate_label: str,
+    candidate_curie: str | None,
+    candidate_curie_source: str,
+    gold_label: str,
+    gold_curie: str | None,
+) -> bool:
+    if normalize_entity(candidate_label) == normalize_entity(gold_label):
+        return True
+
+    candidate_relation_label = _relation_match_label(candidate_label)
+    gold_relation_label = _relation_match_label(gold_label)
+    return (
+        candidate_curie_source == "verified_linker"
+        and curie_matches(candidate_curie=candidate_curie, gold_curie=gold_curie)
+        and candidate_relation_label == gold_relation_label
+        and candidate_relation_label is not None
+    )
+
+
+def _relation_match_label(label: str) -> str | None:
+    canonical_label = relation_match_label_for_label(label)
+    if canonical_label is None:
+        return None
+    return normalize_entity(canonical_label)
+
+
+def _normalize_curie(value: str) -> str:
+    prefix, separator, local = value.strip().partition(":")
+    if separator == "":
+        return value.strip().upper()
+    return f"{prefix.upper()}:{local}"
+
+
+__all__ = [
+    "curie_matches",
+    "normalize_entity",
+    "normalize_relation_type",
+    "normalized_relation_key",
+    "relation_matches_gold",
+]

--- a/scripts/validation/relation_feasibility/scoring.py
+++ b/scripts/validation/relation_feasibility/scoring.py
@@ -16,6 +16,9 @@ from artana_evidence_api.document_extraction_support.evidence_support_verifier i
     TripleSupport,
     verify_triple_support,
 )
+from artana_evidence_api.document_extraction_support.entity_grounding.verified_dictionary import (
+    review_only_record_for_label,
+)
 
 from scripts.validation.relation_feasibility.models import (
     BenchmarkCase,
@@ -26,6 +29,19 @@ from scripts.validation.relation_feasibility.models import (
     GoldRelation,
     RelationTypeSurface,
     Verdict,
+)
+from scripts.validation.relation_feasibility.relation_matching import (
+    curie_matches as _curie_matches,
+)
+from scripts.validation.relation_feasibility.relation_matching import (
+    normalize_entity as _normalize_entity,
+)
+from scripts.validation.relation_feasibility.relation_matching import (
+    normalize_relation_type as _normalize_relation_type,
+)
+from scripts.validation.relation_feasibility.relation_matching import (
+    normalized_relation_key,
+    relation_matches_gold,
 )
 from scripts.validation.relation_feasibility.trusted_metric_rules import (
     HIGH_VALUE_LEVELS,
@@ -59,15 +75,6 @@ _GENERIC_ENTITY_LABELS = frozenset(
         "traits",
     },
 )
-_RELATION_SYNONYMS = {
-    "LINKED_TO": "ASSOCIATED_WITH",
-    "LINKS_TO": "ASSOCIATED_WITH",
-    "CORRELATED_WITH": "ASSOCIATED_WITH",
-    "INTERACTS_WITH": "PHYSICALLY_INTERACTS_WITH",
-    "BINDS_TO": "PHYSICALLY_INTERACTS_WITH",
-    "UPREGULATES": "ACTIVATES",
-    "DOWNREGULATES": "INHIBITS",
-}
 _MAX_SPECIFIC_ENTITY_TOKENS = 6
 _RED_MIN_PRECISION = 0.5
 _RED_MIN_VALUABLE_RATE = 0.35
@@ -102,6 +109,8 @@ class _QualityContext:
     has_verified_object_curie: bool
     subject_curie_matches_gold: bool
     object_curie_matches_gold: bool
+    subject_review_only_grounding: bool
+    object_review_only_grounding: bool
     matched_gold: GoldRelation | None
 
 
@@ -625,16 +634,6 @@ def build_summary(inputs: SummaryInputs) -> FeasibilitySummary:
     )
 
 
-def normalized_relation_key(relation: ExtractedRelation | GoldRelation) -> tuple[str, str, str]:
-    """Return the normalized triple key used for support matching."""
-
-    return (
-        _normalize_entity(relation.subject),
-        _normalize_relation_type(relation.relation_type),
-        _normalize_entity(relation.object),
-    )
-
-
 def _missed_gold_indices(
     *,
     gold_relations: tuple[GoldRelation, ...],
@@ -723,6 +722,12 @@ def _assess_candidate(
         ),
         gold_curie=matched_gold.object_curie if matched_gold is not None else None,
     )
+    subject_review_only_grounding = (
+        review_only_record_for_label(candidate.subject) is not None
+    )
+    object_review_only_grounding = (
+        review_only_record_for_label(candidate.object) is not None
+    )
     value_supported = (
         matched_gold is not None and matched_gold.value_level in {"high", "medium"}
     )
@@ -749,6 +754,8 @@ def _assess_candidate(
             has_verified_object_curie=has_verified_object_curie,
             subject_curie_matches_gold=subject_curie_matches_gold,
             object_curie_matches_gold=object_curie_matches_gold,
+            subject_review_only_grounding=subject_review_only_grounding,
+            object_review_only_grounding=object_review_only_grounding,
             matched_gold=matched_gold,
         ),
     )
@@ -821,9 +828,8 @@ def _matched_gold_index(
 ) -> int | None:
     if _is_governed_relation_proposal(candidate):
         return None
-    candidate_key = normalized_relation_key(candidate)
     for index, gold_relation in enumerate(gold_relations):
-        if candidate_key == normalized_relation_key(gold_relation):
+        if relation_matches_gold(candidate=candidate, gold_relation=gold_relation):
             return index
     return None
 
@@ -856,6 +862,10 @@ def _quality_flags(context: _QualityContext) -> tuple[str, ...]:
         flags.append("requires_relation_review")
     if context.proposal_supported:
         flags.append("proposal_matches_gold")
+    if context.subject_review_only_grounding:
+        flags.append("review_only_subject_grounding")
+    if context.object_review_only_grounding:
+        flags.append("review_only_object_grounding")
     if not context.subject_specific:
         flags.append("generic_subject")
     if not context.object_specific:
@@ -930,15 +940,6 @@ def _curie_endpoint_flag(
     return ""
 
 
-def _normalize_entity(value: str) -> str:
-    return re.sub(r"[^a-z0-9]+", " ", value.casefold()).strip()
-
-
-def _normalize_relation_type(value: str) -> str:
-    token = re.sub(r"[^A-Z0-9]+", "_", value.strip().upper()).strip("_")
-    return _RELATION_SYNONYMS.get(token, token)
-
-
 def _is_specific_entity_label(label: str) -> bool:
     normalized = _normalize_entity(label)
     if not normalized:
@@ -976,18 +977,6 @@ def _is_governed_relation_proposal(candidate: ExtractedRelation) -> bool:
         candidate.relation_governance_status == "requires_relation_review"
         or _normalize_relation_type(candidate.relation_type)
         == LLM_PROPOSE_NEW_RELATION_TYPE
-    )
-
-
-def _curie_matches(
-    *,
-    candidate_curie: str | None,
-    gold_curie: str | None,
-) -> bool:
-    return (
-        gold_curie is not None
-        and candidate_curie is not None
-        and _normalize_curie(candidate_curie) == _normalize_curie(gold_curie)
     )
 
 
@@ -1087,13 +1076,6 @@ def _model_curie_is_wrong(
             gold_curie=gold_curie,
         )
     )
-
-
-def _normalize_curie(value: str) -> str:
-    prefix, separator, local = value.strip().partition(":")
-    if separator == "":
-        return value.strip().upper()
-    return f"{prefix.upper()}:{local}"
 
 
 def _has_grounded_sentence(*, source_text: str, sentence: str) -> bool:

--- a/services/artana_evidence_api/document_extraction_support/entity_curie_linking.py
+++ b/services/artana_evidence_api/document_extraction_support/entity_curie_linking.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Literal
 
+from artana_evidence_api.document_extraction_support.entity_grounding.contracts import (
+    CurieSource,
+    ModelHintStatus,
+    ReviewOnlyEntityRecord,
+    VerifiedEntityRecord,
+)
+from artana_evidence_api.document_extraction_support.entity_grounding.verified_dictionary import (
+    review_only_record_for_label,
+    verified_record_for_label,
+)
 from artana_evidence_api.types.common import JSONObject
-
-CurieSource = Literal["none", "model", "verified_linker"]
-ModelHintStatus = Literal["matched", "replaced", "invalid"]
 
 _CURIE_RE = re.compile(r"^(?P<prefix>[A-Za-z][A-Za-z0-9_.-]{1,31}):(?P<local>[A-Za-z0-9][A-Za-z0-9_.:-]{0,127})$")
 _GENE_TOKEN_RE = re.compile(r"^[A-Z][A-Z0-9-]{1,11}$")
@@ -27,13 +33,6 @@ _CURIE_PREFIXES: dict[str, tuple[str, str, str]] = {
     "OMIM": ("OMIM", "omim_id", "DISEASE"),
     "UMLS": ("UMLS", "umls_id", "BIOMEDICAL_CONCEPT"),
 }
-
-
-@dataclass(frozen=True, slots=True)
-class _VerifiedEntityRecord:
-    label: str
-    curie: str
-    aliases: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,29 +92,21 @@ def normalize_entity_curie(
 ) -> EntityCurieLink:
     """Normalize a model-supplied CURIE or return a typed abstention."""
 
-    if source == "model":
-        record = _verified_record_for_label(label)
+    if source in {"model", "verified_linker"}:
+        record = verified_record_for_label(label)
         if record is not None:
-            if raw_curie is not None and raw_curie.strip() != "":
-                normalized_hint = _normalize_supported_curie_value(raw_curie)
-                if normalized_hint is None:
-                    return _link_from_verified_record(
-                        record,
-                        model_hint_curie=raw_curie.strip(),
-                        model_hint_status="invalid",
-                    )
-                if _curies_equal(normalized_hint, record.curie):
-                    return _link_from_verified_record(
-                        record,
-                        model_hint_curie=normalized_hint,
-                        model_hint_status="matched",
-                    )
-                return _link_from_verified_record(
-                    record,
-                    model_hint_curie=normalized_hint,
-                    model_hint_status="replaced",
-                )
-            return _link_from_verified_record(record)
+            return _link_from_verified_record_with_hint(
+                record,
+                raw_curie=raw_curie,
+            )
+
+    if source in {"model", "verified_linker", "none"}:
+        review_record = review_only_record_for_label(label)
+        if review_record is not None:
+            return _review_only_link_from_record(review_record, raw_curie=raw_curie)
+
+    if source == "verified_linker":
+        return _normalize_raw_curie(raw_curie, label=label, source="model")
 
     return _normalize_raw_curie(raw_curie, label=label, source=source)
 
@@ -200,146 +191,8 @@ def entity_candidate_payload_from_curie(
     }
 
 
-def _entity_label_key(label: str) -> str:
-    return re.sub(r"\s+", " ", label.strip()).casefold()
-
-
-_VERIFIED_ENTITY_RECORDS: tuple[_VerifiedEntityRecord, ...] = (
-    _VerifiedEntityRecord(
-        label="AKT1",
-        curie="HGNC:391",
-        aliases=("AKT activation",),
-    ),
-    _VerifiedEntityRecord(
-        label="BRAF V600E",
-        curie="ClinVar:BRAF_V600E",
-    ),
-    _VerifiedEntityRecord(
-        label="BRCA-mutated ovarian cancer",
-        curie="MONDO:0008170",
-    ),
-    _VerifiedEntityRecord(
-        label="BRCA1",
-        curie="HGNC:1100",
-        aliases=("BRCA1 loss",),
-    ),
-    _VerifiedEntityRecord(
-        label="Bevacizumab",
-        curie="DrugBank:DB00112",
-    ),
-    _VerifiedEntityRecord(
-        label="Cisplatin",
-        curie="DrugBank:DB00515",
-    ),
-    _VerifiedEntityRecord(
-        label="EGFR T790M",
-        curie="ClinVar:EGFR_T790M",
-    ),
-    _VerifiedEntityRecord(
-        label="HER2",
-        curie="HGNC:3430",
-        aliases=("HER2 amplification",),
-    ),
-    _VerifiedEntityRecord(
-        label="IL6",
-        curie="HGNC:6018",
-    ),
-    _VerifiedEntityRecord(
-        label="JAK2",
-        curie="HGNC:6192",
-        aliases=("JAK2 signaling",),
-    ),
-    _VerifiedEntityRecord(
-        label="KRAS G12C",
-        curie="ClinVar:KRAS_G12C",
-    ),
-    _VerifiedEntityRecord(
-        label="MED13",
-        curie="HGNC:22474",
-    ),
-    _VerifiedEntityRecord(
-        label="MET",
-        curie="HGNC:7029",
-        aliases=("MET amplification",),
-    ),
-    _VerifiedEntityRecord(
-        label="Olaparib",
-        curie="DrugBank:DB09074",
-    ),
-    _VerifiedEntityRecord(
-        label="Osimertinib",
-        curie="DrugBank:DB09330",
-    ),
-    _VerifiedEntityRecord(
-        label="PD-L1",
-        curie="HGNC:17635",
-        aliases=("PD-L1 expression",),
-    ),
-    _VerifiedEntityRecord(
-        label="RET p.Arg1174*",
-        curie="ClinVar:RET_ARG1174TER",
-    ),
-    _VerifiedEntityRecord(
-        label="Ruxolitinib",
-        curie="DrugBank:DB08877",
-    ),
-    _VerifiedEntityRecord(
-        label="Sotorasib",
-        curie="DrugBank:DB15569",
-    ),
-    _VerifiedEntityRecord(
-        label="TP53",
-        curie="HGNC:11998",
-        aliases=("TP53 loss",),
-    ),
-    _VerifiedEntityRecord(
-        label="Trametinib",
-        curie="DrugBank:DB08911",
-    ),
-    _VerifiedEntityRecord(
-        label="VEGF-A",
-        curie="HGNC:12680",
-    ),
-    _VerifiedEntityRecord(
-        label="congenital heart disease",
-        curie="MONDO:0005267",
-    ),
-    _VerifiedEntityRecord(
-        label="developmental delay",
-        curie="HP:0001263",
-    ),
-    _VerifiedEntityRecord(
-        label="early-onset breast cancer",
-        curie="MONDO:0007254",
-    ),
-    _VerifiedEntityRecord(
-        label="erlotinib",
-        curie="DrugBank:DB00530",
-    ),
-    _VerifiedEntityRecord(
-        label="gefitinib",
-        curie="DrugBank:DB00317",
-        aliases=("resistance to gefitinib",),
-    ),
-    _VerifiedEntityRecord(
-        label="triple-negative breast cancer",
-        curie="MONDO:0007254",
-    ),
-)
-
-_VERIFIED_ENTITY_RECORDS_BY_LABEL: dict[str, _VerifiedEntityRecord] = {
-    _entity_label_key(label): record
-    for record in _VERIFIED_ENTITY_RECORDS
-    for label in (record.label, *record.aliases)
-}
-
-
-def _verified_record_for_label(label: str) -> _VerifiedEntityRecord | None:
-    return _VERIFIED_ENTITY_RECORDS_BY_LABEL.get(_entity_label_key(label))
-
-
 def _link_from_verified_record(
-    record: _VerifiedEntityRecord,
+    record: VerifiedEntityRecord,
     *,
     model_hint_curie: str | None = None,
     model_hint_status: ModelHintStatus | None = None,
@@ -359,6 +212,51 @@ def _link_from_verified_record(
         entity_type=link.entity_type,
         source=link.source,
         reason=link.reason,
+        model_hint_curie=model_hint_curie,
+        model_hint_status=model_hint_status,
+    )
+
+
+def _link_from_verified_record_with_hint(
+    record: VerifiedEntityRecord,
+    *,
+    raw_curie: str | None,
+) -> EntityCurieLink:
+    if raw_curie is None or raw_curie.strip() == "":
+        return _link_from_verified_record(record)
+    normalized_hint = _normalize_supported_curie_value(raw_curie)
+    if normalized_hint is None:
+        return _link_from_verified_record(
+            record,
+            model_hint_curie=raw_curie.strip(),
+            model_hint_status="invalid",
+        )
+    model_hint_status: ModelHintStatus = (
+        "matched" if _curies_equal(normalized_hint, record.curie) else "replaced"
+    )
+    return _link_from_verified_record(
+        record,
+        model_hint_curie=normalized_hint,
+        model_hint_status=model_hint_status,
+    )
+
+
+def _review_only_link_from_record(
+    record: ReviewOnlyEntityRecord,
+    *,
+    raw_curie: str | None,
+) -> EntityCurieLink:
+    model_hint_curie: str | None = None
+    model_hint_status: ModelHintStatus | None = None
+    if raw_curie is not None and raw_curie.strip() != "":
+        normalized_hint = _normalize_supported_curie_value(raw_curie)
+        model_hint_curie = normalized_hint or raw_curie.strip()
+        if normalized_hint is None:
+            model_hint_status = "invalid"
+    return EntityCurieLink(
+        status="abstained",
+        source="none",
+        reason=record.reason,
         model_hint_curie=model_hint_curie,
         model_hint_status=model_hint_status,
     )

--- a/services/artana_evidence_api/document_extraction_support/entity_grounding/__init__.py
+++ b/services/artana_evidence_api/document_extraction_support/entity_grounding/__init__.py
@@ -1,0 +1,1 @@
+"""Entity grounding helpers for document relation extraction."""

--- a/services/artana_evidence_api/document_extraction_support/entity_grounding/contracts.py
+++ b/services/artana_evidence_api/document_extraction_support/entity_grounding/contracts.py
@@ -1,0 +1,71 @@
+"""Typed contracts for extracted-entity grounding decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+CurieSource = Literal["none", "model", "verified_linker"]
+ModelHintStatus = Literal["matched", "replaced", "invalid"]
+GroundingDecisionKind = Literal[
+    "verified",
+    "model_hint_only",
+    "review_only",
+    "ambiguous",
+    "unsupported_namespace",
+    "missing",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class EntityGroundingCandidate:
+    """Input label and optional hint being evaluated for trust."""
+
+    label: str
+    raw_curie: str | None
+    source: CurieSource
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedEntityRecord:
+    """A locally curated entity label that may produce a trusted identifier."""
+
+    label: str
+    curie: str
+    aliases: tuple[str, ...] = ()
+    relation_match_aliases: tuple[str, ...] = ()
+    curation_status: str = "approved_for_relation_feasibility_v2"
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewOnlyEntityRecord:
+    """A known label that must stay review-only until a safe concept exists."""
+
+    label: str
+    reason: str = "grounding_requires_review"
+    aliases: tuple[str, ...] = ()
+    curation_status: str = "review_only_for_relation_feasibility_v2"
+
+
+class EntityGrounder(Protocol):
+    """Lookup interface for grounding implementations."""
+
+    def verified_record_for_label(self, label: str) -> VerifiedEntityRecord | None:
+        """Return a trusted record for the label when local curation allows it."""
+
+    def review_only_record_for_label(
+        self,
+        label: str,
+    ) -> ReviewOnlyEntityRecord | None:
+        """Return a review-only record for labels that must not auto-promote."""
+
+
+__all__ = [
+    "CurieSource",
+    "EntityGrounder",
+    "EntityGroundingCandidate",
+    "GroundingDecisionKind",
+    "ModelHintStatus",
+    "ReviewOnlyEntityRecord",
+    "VerifiedEntityRecord",
+]

--- a/services/artana_evidence_api/document_extraction_support/entity_grounding/verified_dictionary.py
+++ b/services/artana_evidence_api/document_extraction_support/entity_grounding/verified_dictionary.py
@@ -1,0 +1,221 @@
+"""Local verified entity dictionary for relation extraction grounding."""
+
+from __future__ import annotations
+
+import re
+
+from artana_evidence_api.document_extraction_support.entity_grounding.contracts import (
+    ReviewOnlyEntityRecord,
+    VerifiedEntityRecord,
+)
+
+
+def entity_label_key(label: str) -> str:
+    """Return the dictionary key used for labels and aliases."""
+
+    return re.sub(r"\s+", " ", label.strip()).casefold()
+
+
+VERIFIED_ENTITY_RECORDS: tuple[VerifiedEntityRecord, ...] = (
+    VerifiedEntityRecord(
+        label="AKT1",
+        curie="HGNC:391",
+        aliases=("AKT activation",),
+    ),
+    VerifiedEntityRecord(
+        label="BRAF V600E",
+        curie="ClinVar:BRAF_V600E",
+    ),
+    VerifiedEntityRecord(
+        label="BRCA-mutated ovarian cancer",
+        curie="MONDO:0008170",
+    ),
+    VerifiedEntityRecord(
+        label="BRCA1",
+        curie="HGNC:1100",
+        aliases=("BRCA1 loss",),
+    ),
+    VerifiedEntityRecord(
+        label="Bevacizumab",
+        curie="DrugBank:DB00112",
+    ),
+    VerifiedEntityRecord(
+        label="cardiac septal development",
+        curie="GO:0003279",
+        aliases=("cardiac septum development", "heart septum development"),
+        relation_match_aliases=(
+            "cardiac septum development",
+            "heart septum development",
+        ),
+    ),
+    VerifiedEntityRecord(
+        label="Cisplatin",
+        curie="DrugBank:DB00515",
+    ),
+    VerifiedEntityRecord(
+        label="EGFR T790M",
+        curie="ClinVar:EGFR_T790M",
+    ),
+    VerifiedEntityRecord(
+        label="HER2",
+        curie="HGNC:3430",
+        aliases=("HER2 amplification",),
+    ),
+    VerifiedEntityRecord(
+        label="homologous recombination DNA repair",
+        curie="GO:0000724",
+        aliases=("homologous recombination repair",),
+        relation_match_aliases=(
+            "homologous recombination",
+            "homologous recombination repair",
+        ),
+    ),
+    VerifiedEntityRecord(
+        label="IL6",
+        curie="HGNC:6018",
+    ),
+    VerifiedEntityRecord(
+        label="JAK2",
+        curie="HGNC:6192",
+        aliases=("JAK2 signaling",),
+    ),
+    VerifiedEntityRecord(
+        label="KRAS G12C",
+        curie="ClinVar:KRAS_G12C",
+    ),
+    VerifiedEntityRecord(
+        label="MAPK signaling",
+        curie="GO:0000165",
+        aliases=("MAPK cascade", "MAPK pathway", "MAPK signaling pathway"),
+        relation_match_aliases=(
+            "MAPK cascade",
+            "MAPK pathway",
+            "MAPK signaling pathway",
+        ),
+    ),
+    VerifiedEntityRecord(
+        label="MED13",
+        curie="HGNC:22474",
+    ),
+    VerifiedEntityRecord(
+        label="MET",
+        curie="HGNC:7029",
+        aliases=("MET amplification",),
+    ),
+    VerifiedEntityRecord(
+        label="Olaparib",
+        curie="DrugBank:DB09074",
+    ),
+    VerifiedEntityRecord(
+        label="Osimertinib",
+        curie="DrugBank:DB09330",
+    ),
+    VerifiedEntityRecord(
+        label="PD-L1",
+        curie="HGNC:17635",
+        aliases=("PD-L1 expression",),
+    ),
+    VerifiedEntityRecord(
+        label="RET p.Arg1174*",
+        curie="ClinVar:RET_ARG1174TER",
+    ),
+    VerifiedEntityRecord(
+        label="Ruxolitinib",
+        curie="DrugBank:DB08877",
+    ),
+    VerifiedEntityRecord(
+        label="Sotorasib",
+        curie="DrugBank:DB15569",
+    ),
+    VerifiedEntityRecord(
+        label="TP53",
+        curie="HGNC:11998",
+        aliases=("TP53 loss",),
+    ),
+    VerifiedEntityRecord(
+        label="Trametinib",
+        curie="DrugBank:DB08911",
+    ),
+    VerifiedEntityRecord(
+        label="VEGF-A",
+        curie="HGNC:12680",
+    ),
+    VerifiedEntityRecord(
+        label="congenital heart disease",
+        curie="MONDO:0005267",
+    ),
+    VerifiedEntityRecord(
+        label="developmental delay",
+        curie="HP:0001263",
+    ),
+    VerifiedEntityRecord(
+        label="early-onset breast cancer",
+        curie="MONDO:0007254",
+    ),
+    VerifiedEntityRecord(
+        label="erlotinib",
+        curie="DrugBank:DB00530",
+    ),
+    VerifiedEntityRecord(
+        label="gefitinib",
+        curie="DrugBank:DB00317",
+        aliases=("resistance to gefitinib",),
+    ),
+    VerifiedEntityRecord(
+        label="triple-negative breast cancer",
+        curie="MONDO:0007254",
+    ),
+)
+
+REVIEW_ONLY_ENTITY_RECORDS: tuple[ReviewOnlyEntityRecord, ...] = (
+    ReviewOnlyEntityRecord(label="aggressive tumor growth"),
+    ReviewOnlyEntityRecord(
+        label="ERK phosphorylation",
+        aliases=("ERK tyrosine phosphorylation",),
+    ),
+    ReviewOnlyEntityRecord(label="response to pembrolizumab"),
+)
+
+_VERIFIED_ENTITY_RECORDS_BY_LABEL: dict[str, VerifiedEntityRecord] = {
+    entity_label_key(label): record
+    for record in VERIFIED_ENTITY_RECORDS
+    for label in (record.label, *record.aliases)
+}
+_REVIEW_ONLY_ENTITY_RECORDS_BY_LABEL: dict[str, ReviewOnlyEntityRecord] = {
+    entity_label_key(label): record
+    for record in REVIEW_ONLY_ENTITY_RECORDS
+    for label in (record.label, *record.aliases)
+}
+_RELATION_MATCH_LABELS_BY_LABEL: dict[str, str] = {
+    entity_label_key(label): record.label
+    for record in VERIFIED_ENTITY_RECORDS
+    for label in (record.label, *record.relation_match_aliases)
+}
+
+
+def verified_record_for_label(label: str) -> VerifiedEntityRecord | None:
+    """Return a curated trusted record for a label or alias."""
+
+    return _VERIFIED_ENTITY_RECORDS_BY_LABEL.get(entity_label_key(label))
+
+
+def review_only_record_for_label(label: str) -> ReviewOnlyEntityRecord | None:
+    """Return a review-only record for labels unsafe to auto-ground."""
+
+    return _REVIEW_ONLY_ENTITY_RECORDS_BY_LABEL.get(entity_label_key(label))
+
+
+def relation_match_label_for_label(label: str) -> str | None:
+    """Return the canonical label for relation-safe aliases only."""
+
+    return _RELATION_MATCH_LABELS_BY_LABEL.get(entity_label_key(label))
+
+
+__all__ = [
+    "REVIEW_ONLY_ENTITY_RECORDS",
+    "VERIFIED_ENTITY_RECORDS",
+    "entity_label_key",
+    "relation_match_label_for_label",
+    "review_only_record_for_label",
+    "verified_record_for_label",
+]

--- a/services/artana_evidence_api/tests/unit/test_entity_curie_linking.py
+++ b/services/artana_evidence_api/tests/unit/test_entity_curie_linking.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from artana_evidence_api.document_extraction_support.entity_curie_linking import (
     normalize_entity_curie,
 )
@@ -63,3 +64,121 @@ def test_clinvar_variant_curie_can_be_verified() -> None:
     assert link.source == "verified_linker"
     assert link.entity_type == "VARIANT"
     assert link.identifiers == {"clinvar_id": "ClinVar:EGFR_T790M"}
+
+
+@pytest.mark.parametrize(
+    ("raw_curie", "label", "expected_curie"),
+    [
+        ("GO:0000165", "MAPK signaling", "GO:0000165"),
+        (
+            "GO:0000724",
+            "homologous recombination DNA repair",
+            "GO:0000724",
+        ),
+        ("GO:0003279", "cardiac septal development", "GO:0003279"),
+    ],
+)
+def test_biological_process_model_hints_require_verified_grounding(
+    raw_curie: str,
+    label: str,
+    expected_curie: str,
+) -> None:
+    link = normalize_entity_curie(
+        raw_curie,
+        label=label,
+        source="model",
+    )
+
+    metadata = link.to_metadata()
+    assert link.status == "linked"
+    assert link.curie == expected_curie
+    assert link.source == "verified_linker"
+    assert link.entity_type == "BIOLOGICAL_PROCESS"
+    assert link.identifiers == {"go_id": expected_curie}
+    assert metadata["trusted_identifier"] is True
+    assert metadata["model_hint_curie"] == expected_curie
+    assert metadata["model_hint_status"] == "matched"
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "aggressive tumor growth",
+        "response to pembrolizumab",
+    ],
+)
+def test_composite_or_broad_labels_abstain_for_review_without_model_hint(
+    label: str,
+) -> None:
+    link = normalize_entity_curie(
+        None,
+        label=label,
+        source="model",
+    )
+
+    metadata = link.to_metadata()
+    assert link.status == "abstained"
+    assert link.source == "none"
+    assert link.reason == "grounding_requires_review"
+    assert metadata["trusted_identifier"] is False
+
+
+def test_composite_response_does_not_trust_drug_anchor_model_hint() -> None:
+    link = normalize_entity_curie(
+        "DrugBank:DB09037",
+        label="response to pembrolizumab",
+        source="model",
+    )
+
+    metadata = link.to_metadata()
+    assert link.status == "abstained"
+    assert link.curie is None
+    assert link.source == "none"
+    assert link.reason == "grounding_requires_review"
+    assert metadata["trusted_identifier"] is False
+    assert metadata["model_hint_curie"] == "DRUGBANK:DB09037"
+
+
+def test_verified_linker_source_does_not_bypass_review_only_grounding() -> None:
+    link = normalize_entity_curie(
+        "DrugBank:DB09037",
+        label="response to pembrolizumab",
+        source="verified_linker",
+    )
+
+    metadata = link.to_metadata()
+    assert link.status == "abstained"
+    assert link.curie is None
+    assert link.source == "none"
+    assert link.reason == "grounding_requires_review"
+    assert metadata["trusted_identifier"] is False
+    assert metadata["model_hint_curie"] == "DRUGBANK:DB09037"
+
+
+def test_unknown_verified_linker_source_is_downgraded_to_untrusted_hint() -> None:
+    link = normalize_entity_curie(
+        "GO:1234567",
+        label="unreviewed pathway label",
+        source="verified_linker",
+    )
+
+    metadata = link.to_metadata()
+    assert link.status == "linked"
+    assert link.curie == "GO:1234567"
+    assert link.source == "model"
+    assert metadata["trusted_identifier"] is False
+
+
+def test_broad_erk_phosphorylation_grounding_requires_review() -> None:
+    link = normalize_entity_curie(
+        "GO:0018108",
+        label="ERK phosphorylation",
+        source="model",
+    )
+
+    metadata = link.to_metadata()
+    assert link.status == "abstained"
+    assert link.source == "none"
+    assert link.reason == "grounding_requires_review"
+    assert metadata["trusted_identifier"] is False
+    assert metadata["model_hint_curie"] == "GO:0018108"

--- a/services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py
+++ b/services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py
@@ -1,0 +1,49 @@
+"""Unit coverage for the local verified entity grounding dictionary."""
+
+from __future__ import annotations
+
+from artana_evidence_api.document_extraction_support.entity_grounding.verified_dictionary import (
+    relation_match_label_for_label,
+    review_only_record_for_label,
+    verified_record_for_label,
+)
+
+
+def test_verified_dictionary_resolves_process_aliases() -> None:
+    record = verified_record_for_label("MAPK pathway")
+
+    assert record is not None
+    assert record.label == "MAPK signaling"
+    assert record.curie == "GO:0000165"
+
+
+def test_verified_dictionary_resolves_cardiac_septum_alias() -> None:
+    record = verified_record_for_label("cardiac septum development")
+
+    assert record is not None
+    assert record.label == "cardiac septal development"
+    assert record.curie == "GO:0003279"
+
+
+def test_review_only_dictionary_blocks_composite_response_grounding() -> None:
+    record = review_only_record_for_label("response to pembrolizumab")
+
+    assert record is not None
+    assert record.reason == "grounding_requires_review"
+    assert verified_record_for_label("response to pembrolizumab") is None
+
+
+def test_review_only_dictionary_blocks_overbroad_process_grounding() -> None:
+    record = review_only_record_for_label("ERK tyrosine phosphorylation")
+
+    assert record is not None
+    assert record.label == "ERK phosphorylation"
+    assert verified_record_for_label("ERK phosphorylation") is None
+
+
+def test_relation_match_aliases_do_not_reuse_identity_aliases() -> None:
+    assert (
+        relation_match_label_for_label("homologous recombination")
+        == "homologous recombination DNA repair"
+    )
+    assert relation_match_label_for_label("BRCA1 loss") is None

--- a/tests/unit/test_relation_feasibility_audit.py
+++ b/tests/unit/test_relation_feasibility_audit.py
@@ -362,6 +362,113 @@ def test_model_curie_hints_do_not_count_as_verified_gold_endpoint_links() -> Non
     assert report.summary.trusted_high_value_recall == 0.0
 
 
+def test_verified_curie_match_can_support_curated_endpoint_alias() -> None:
+    cases = (
+        _case(
+            case_id="curated_endpoint_alias",
+            text="BRCA1 regulates homologous recombination DNA repair.",
+            gold=(
+                GoldRelation(
+                    subject="BRCA1",
+                    relation_type="REGULATES",
+                    object="homologous recombination DNA repair",
+                    support_sentence=(
+                        "BRCA1 regulates homologous recombination DNA repair."
+                    ),
+                    value_level="high",
+                    rationale="Specific gene-to-process regulatory relation.",
+                    subject_curie="HGNC:1100",
+                    object_curie="GO:0000724",
+                ),
+            ),
+        ),
+    )
+
+    def extractor(_: str) -> RelationExtractionResult:
+        return RelationExtractionResult(
+            relations=(
+                ExtractedRelation(
+                    subject="BRCA1",
+                    subject_curie="HGNC:1100",
+                    subject_curie_source="verified_linker",
+                    relation_type="REGULATES",
+                    object="homologous recombination",
+                    object_curie="GO:0000724",
+                    object_curie_source="verified_linker",
+                    sentence="BRCA1 regulates homologous recombination DNA repair.",
+                ),
+            ),
+            trace=ExtractionTrace(
+                extractor_mode="agent",
+                llm_candidate_status="completed",
+            ),
+        )
+
+    report = run_feasibility_audit(cases=cases, extractor=extractor)
+    assessment = report.case_results[0].candidate_assessments[0]
+
+    assert assessment.is_supported_by_gold is True
+    assert assessment.object_curie_matches_gold is True
+    assert "unsupported_by_gold" not in assessment.quality_flags
+    assert report.summary.high_value_recall == 1.0
+    assert report.summary.trusted_high_value_recall == 1.0
+    assert report.summary.curie_linked_gold_endpoint_rate == 1.0
+
+
+def test_review_only_grounding_labels_are_flagged_without_gold_curie() -> None:
+    cases = (
+        _case(
+            case_id="review_only_grounding",
+            text="PD-L1 expression is a biomarker for response to pembrolizumab.",
+            gold=(
+                GoldRelation(
+                    subject="PD-L1 expression",
+                    relation_type="BIOMARKER_FOR",
+                    object="response to pembrolizumab",
+                    support_sentence=(
+                        "PD-L1 expression is a biomarker for response to "
+                        "pembrolizumab."
+                    ),
+                    value_level="high",
+                    rationale="Specific biomarker-to-response relation.",
+                    subject_curie="HGNC:17635",
+                    object_curie=None,
+                ),
+            ),
+        ),
+    )
+
+    def extractor(_: str) -> RelationExtractionResult:
+        return RelationExtractionResult(
+            relations=(
+                ExtractedRelation(
+                    subject="PD-L1 expression",
+                    subject_curie="HGNC:17635",
+                    subject_curie_source="verified_linker",
+                    relation_type="BIOMARKER_FOR",
+                    object="response to pembrolizumab",
+                    sentence=(
+                        "PD-L1 expression is a biomarker for response to "
+                        "pembrolizumab."
+                    ),
+                ),
+            ),
+            trace=ExtractionTrace(
+                extractor_mode="agent",
+                llm_candidate_status="completed",
+            ),
+        )
+
+    report = run_feasibility_audit(cases=cases, extractor=extractor)
+    assessment = report.case_results[0].candidate_assessments[0]
+
+    assert assessment.is_supported_by_gold is True
+    assert assessment.is_valuable is True
+    assert "review_only_object_grounding" in assessment.quality_flags
+    assert report.summary.high_value_recall == 1.0
+    assert report.summary.trusted_high_value_recall == 0.0
+
+
 def test_trusted_high_value_recall_requires_completed_agent_and_verified_curies() -> None:
     cases = (
         _case(
@@ -1353,6 +1460,49 @@ def test_v2_fixture_has_required_categories_and_richer_labels() -> None:
     assert any(relation.subject_curie for relation in gold_relations)
     assert any(relation.object_curie for relation in gold_relations)
     assert any(not relation.requires_entailment for relation in gold_relations)
+
+
+def test_v2_fixture_pins_pr21_verified_grounding_policy() -> None:
+    cases = load_benchmark_cases(
+        Path("scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v2.json"),
+    )
+
+    gold_by_case = {
+        case.case_id: case.gold_relations[0]
+        for case in cases
+        if case.case_id
+        in {
+            "strong_med13_activates_septal_development",
+            "strong_brca1_regulates_dna_repair",
+            "strong_mek_inhibits_erk",
+            "strong_pdl1_biomarker_immunotherapy",
+            "strong_braf_v600e_activates_mapk",
+            "complex_ret_variant_alias",
+            "complex_her2_amplification_growth",
+            "long_document_tail_relation_braf",
+        }
+    }
+
+    assert (
+        gold_by_case["strong_med13_activates_septal_development"].object_curie
+        == "GO:0003279"
+    )
+    assert (
+        gold_by_case["strong_brca1_regulates_dna_repair"].object_curie
+        == "GO:0000724"
+    )
+    assert gold_by_case["strong_mek_inhibits_erk"].object_curie is None
+    assert (
+        gold_by_case["strong_braf_v600e_activates_mapk"].object_curie
+        == "GO:0000165"
+    )
+    assert gold_by_case["complex_ret_variant_alias"].object_curie == "GO:0000165"
+    assert (
+        gold_by_case["long_document_tail_relation_braf"].object_curie
+        == "GO:0000165"
+    )
+    assert gold_by_case["strong_pdl1_biomarker_immunotherapy"].object_curie is None
+    assert gold_by_case["complex_her2_amplification_growth"].object_curie is None
 
 
 def test_v2_fixture_uses_canonical_drug_resistance_relation_shape() -> None:

--- a/tests/unit/test_relation_feasibility_failure_analysis.py
+++ b/tests/unit/test_relation_feasibility_failure_analysis.py
@@ -113,6 +113,45 @@ def test_failure_analysis_classifies_model_hint_curie_as_unverified(
     ]
 
 
+def test_failure_analysis_reports_curie_endpoints_lost_to_missed_gold(
+    tmp_path: Path,
+) -> None:
+    missed_relation = {
+        "subject": "MED13",
+        "relation_type": "ASSOCIATED_WITH",
+        "object": "congenital heart disease",
+        "value_level": "low",
+        "subject_curie": "HGNC:22474",
+        "object_curie": "MONDO:0005267",
+    }
+    report_path = _write_report(tmp_path, "run1", missed=[missed_relation])
+
+    report = build_failure_analysis_report(
+        (FailureAnalysisInput(path=report_path, label="run1"),),
+    )
+
+    assert report["missed_gold_curie_endpoints"] == [
+        {
+            "case_id": "case_a",
+            "endpoint_role": "subject",
+            "label": "MED13",
+            "gold_curie": "HGNC:22474",
+            "value_level": "low",
+            "occurrence_count": 1,
+            "run_labels": ["run1"],
+        },
+        {
+            "case_id": "case_a",
+            "endpoint_role": "object",
+            "label": "congenital heart disease",
+            "gold_curie": "MONDO:0005267",
+            "value_level": "low",
+            "occurrence_count": 1,
+            "run_labels": ["run1"],
+        },
+    ]
+
+
 def test_failure_analysis_keeps_governed_proposal_capture_separate_from_trust(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Splits verified entity grounding into focused contracts and dictionary modules.
- Verifies safe process labels while keeping broad/composite endpoints review-only.
- Hardens scoring and failure attribution so model hints and review-only endpoints cannot masquerade as trusted graph evidence.

## Test Plan
- PYTHONPATH="$(pwd)/services:$(pwd)" .venv/bin/python3 -m pytest services/artana_evidence_api/tests/unit/test_entity_curie_linking.py services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py tests/unit/test_relation_feasibility_audit.py tests/unit/test_relation_feasibility_failure_analysis.py -q
- uv run --python python3.13 --with ruff ruff check scripts/validation/relation_feasibility/relation_matching.py scripts/validation/relation_feasibility/failure_analysis.py services/artana_evidence_api/document_extraction_support/entity_curie_linking.py services/artana_evidence_api/document_extraction_support/entity_grounding/contracts.py services/artana_evidence_api/document_extraction_support/entity_grounding/verified_dictionary.py services/artana_evidence_api/tests/unit/test_entity_curie_linking.py services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py tests/unit/test_relation_feasibility_audit.py tests/unit/test_relation_feasibility_failure_analysis.py
- make architecture-size-check
- make architecture-structure-check
- make relation-feasibility-quality-gate
- git diff --check
- uv run pre-commit run --all-files
- make service-checks

## Live Evidence
- PR21 run3 remains RED but improves precision to 1.0000, high-value recall to 1.0000, trusted high-value recall to 0.8500, verified endpoint rate to 0.8810, false positives to 0, and fallback to 0.

## Notes
- Draft stacked on PR20.
- This branch materially improves grounding but does not claim trusted-graph readiness.