### PR TITLE
PR23: recover weak review evidence with agent pass

### DIFF
--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -141,6 +141,7 @@ Status values:
 | 9 | PR-20 | `alvaro/evidence-pr20-qualifier-precision-adjudication` | Implemented locally; adversarial review fixes applied; strict gate RED | Preserve biomedical qualifiers and remove context false positives from trusted evidence. | Completed-agent precision >= 0.8000 and high-value recall >= 0.8500 without broad subject substitutions. | Dropped-modifier tests, expanded modifier adversarial tests, clause-local and comma-and modifier regressions, context-shadowing and review-only trust tests, low-value review accounting, relation-feasibility gate, strict live run4 with completed-agent precision 0.9500 and high-value recall 0.9500. Trusted high-value recall is now stricter at 0.5500; trusted graph readiness remains blocked by verified CURIE endpoint rate 0.8108. |
 | 10 | PR-21 | `alvaro/evidence-pr21-verified-grounding-closure` | Implemented locally; adversarial blockers fixed; strict gate RED | Improve verified grounding and review-only abstention without trusting raw model hints. | Trusted high-value recall >= 0.8500 and wrong verified CURIE links remain 0. | Grounding dictionary split, verified process labels, review-only broad/composite labels, verified-linker spoof regression, safe relation-alias scoring, missed-gold CURIE attribution, focused tests, relation-feasibility gate, strict live run3 with precision 1.0000, high-value recall 1.0000, trusted high-value recall 0.8500, verified endpoint rate 0.8810, false positives 0, fallback 0. Overall readiness remains RED. |
 | 11 | PR-22 | `alvaro/evidence-pr22-low-value-review-lane` | Implemented locally; strict single-run GREEN; repeatability pending | Split trusted-eligible endpoint recovery from low-value review evidence. | Trusted-eligible CURIE-linked endpoint rate >= 0.9500 and weak-claim trusted leakage remains 0. | Review-only candidate policy, review status propagation, `review_only_candidate` trust floor, promotion metadata protection, trusted/review endpoint metric split, single-run verdict contract fix, scoring/readiness helper refactor, focused tests, direct touched-file ruff, relation-feasibility gate, strict live run4 with verdict GREEN, precision 1.0000, high-value recall 1.0000, trusted endpoint rate 1.0000, weak leakage 0, fallback 0. Low-value review recall remains 0.4000 and final readiness still needs repeated runs. |
+| 12 | PR-23 | `alvaro/evidence-pr23-low-value-review-recall` | Draft PR #106 open; GitHub CI clean | Recover weak-but-useful low-value review evidence through the live agent path without deterministic fallback. | Low-value review recall >= 0.8000 and weak-claim trusted leakage remains 0. | Weak-review agent pass, weak-pass prompt/schema versioning, code-forced review-only metadata, policy-backed weak-pass keep filter, candidate-argument scoped weak-cue policy, raw weak-pass relation-type/proposal drop, review-only pruning preservation, fallback-gated review metrics, sensitization prompt repair, focused RED/GREEN tests, relation-feasibility gate, strict live run7 with verdict GREEN, precision 1.0000, low-value review recall 1.0000, high-value recall 1.0000, trusted endpoint rate 1.0000, false positives 0, missed gold 0, weak leakage 0, fallback 0, invalid agent 0, `make service-checks` with coverage 87.03%, and PR #106 GitHub checks passing. Repeatability remains pending. |
 
 ## PR Evidence Packet
 
@@ -201,6 +202,68 @@ Run only the service checks relevant to the changed boundary, then run the
 aggregate gate before merge when the PR is ready.
 
 ## Evidence Log
+
+### 2026-07-05 - PR-23 Low-Value Review Recall
+
+PR: PR-23 low-value review recall
+
+Branch: `alvaro/evidence-pr23-low-value-review-recall`
+
+Draft PR: https://github.com/med13foundation/artana-evidence-platform/pull/106
+
+Goal: Recover weak but useful low-value evidence with the live agent path while
+forcing weak evidence to remain review-only and excluding deterministic fallback
+from success.
+
+Evidence:
+
+- `docs/validation/reports/2026-07-05-pr23-low-value-review-recall-summary.md`
+- `reports/relation_feasibility/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_report.md`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_failure_analysis_report.json`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_failure_analysis_report.md`
+
+Final strict live-agent metrics:
+
+| Metric | Value |
+|---|---:|
+| Verdict | GREEN |
+| Completed-agent precision | 1.0000 |
+| Completed-agent recall | 1.0000 |
+| High-value recall | 1.0000 |
+| Trusted high-value recall | 0.8500 |
+| Low-value review recall | 1.0000 |
+| Low-value review CURIE endpoint capture rate | 1.0000 |
+| Trusted-eligible CURIE-linked endpoint rate | 1.0000 |
+| Verified CURIE match rate | 1.0000 |
+| Weak-claim trusted leakage count | 0 |
+| Fallback cases | 0 |
+| Invalid strict-agent cases | 0 |
+| Negative-control leakage cases | 0 |
+| Raw unknown relation-type surfaces | 0 |
+| Wrong verified CURIE links | 0 |
+
+Validation:
+
+- Focused RED/GREEN weak-pass tests passed.
+- Affected extraction, prompt, quality-filter, and review-policy tests passed.
+- `make relation-feasibility-quality-gate` passed.
+- Strict live-agent run7 passed with all five low-value review cases captured
+  as `review_only`.
+- Adversarial review findings from run6 were addressed before run7: mixed
+  strong/weak sentence poisoning, weak-pass structured proposal leakage, and
+  fallback-creditable low-value review metrics now have regressions.
+- `make service-checks` passed with coverage 87.03% against the 86% gate.
+- PR #106 GitHub checks passed and `mergeStateStatus` was `CLEAN` while the PR
+  remained draft.
+
+Known remaining risk:
+
+- Precision returned to 1.0000 after adversarial mixed-sentence scoping and weak-pass proposal rejection fixes.
+- Generic review-lane noise remains visible and should be tightened in a
+  follow-up without losing weak-review recall.
+- Repeatability still needs multi-run proof before final trusted-readiness
+  claims.
 
 ### 2026-07-05 - PR-22 Low-Value Review Lane And Trusted Verdict Split
 

--- a/docs/validation/reports/2026-07-05-pr23-low-value-review-recall-summary.md
+++ b/docs/validation/reports/2026-07-05-pr23-low-value-review-recall-summary.md
@@ -1,0 +1,197 @@
+# PR-23 Low-Value Review Recall
+
+Date: 2026-07-05
+
+Branch: `alvaro/evidence-pr23-low-value-review-recall`
+
+Base branch: `alvaro/evidence-pr22-low-value-review-lane`
+
+Pull request: https://github.com/med13foundation/artana-evidence-platform/pull/106
+
+Commit: PR head commit after packaging
+
+## Goal
+
+PR-23 improves live-agent recall for weak but useful low-value evidence without
+letting weak claims become trusted graph evidence. It keeps the deterministic
+fallback out of the success path.
+
+## What Changed
+
+- Added `review_status` and `review_reason_codes` to the LLM extraction schema
+  so the agent can mark weak claims as review-only.
+- Added prompt guidance and examples for hedged, trend-only, may-link,
+  possible-biomarker, and correlation-only review evidence.
+- Added a second live-agent extraction pass for weak review-only relations.
+- Forced every weak-pass candidate into `review_only` by code.
+- Dropped weak-pass candidates unless the code-owned review policy detects real
+  weak evidence cues in the support sentence.
+- Dropped raw unknown relation types from the weak pass before relation-type
+  governance resolution.
+- Preserved review-only weak generic candidates through specificity pruning
+  while normal weak generic candidates remain suppressible.
+- Added a primary-prompt rule for `SENSITIZES_TO` constructions such as
+  `BRCA1 loss sensitizes triple-negative breast cancer to cisplatin`.
+- Bumped the primary extraction prompt version to
+  `document_extraction.llm_extraction.v4` and added a weak-review prompt version
+  `document_extraction.weak_review_extraction.v1`.
+
+## Validation Commands
+
+Focused regressions:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_uses_agent_review_only_pass \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_drops_invalid_weak_pass_type \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_does_not_downgrade_strong_claims \
+  -q
+```
+
+Affected tests:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py \
+  services/artana_evidence_api/tests/unit/test_document_extraction_modules.py \
+  services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py \
+  services/artana_evidence_api/tests/unit/test_review_only_candidate_policy.py \
+  -q
+```
+
+Quality gate:
+
+```bash
+make relation-feasibility-quality-gate
+```
+
+Strict live-agent audit:
+
+```bash
+bash -lc 'set -a; source .env.postgres; set +a; \
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-05-pr23-low-value-review-recall-run7'
+```
+
+Failure attribution:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/summarize_relation_readiness_failures.py \
+  --report current=reports/relation_feasibility/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_report.json \
+  --output-dir reports/relation_feasibility_failure_analysis/2026-07-05-pr23-low-value-review-recall-run7
+```
+
+Full service gate:
+
+```bash
+make service-checks
+```
+
+## Live-Agent Result
+
+Source artifact:
+
+- `reports/relation_feasibility/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_report.md`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_failure_analysis_report.json`
+- `reports/relation_feasibility_failure_analysis/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_failure_analysis_report.md`
+
+| Metric | PR22 run4 | PR23 run7 | Status |
+|---|---:|---:|---|
+| Verdict | GREEN | GREEN | Passing |
+| Completed-agent precision | 1.0000 | 1.0000 | Passing |
+| Completed-agent recall | 0.8800 | 1.0000 | Improved |
+| High-value recall | 1.0000 | 1.0000 | Preserved |
+| Trusted high-value recall | 0.8500 | 0.8500 | Preserved |
+| Low-value review recall | 0.4000 | 1.0000 | Fixed |
+| Low-value review CURIE endpoint capture rate | 0.2000 | 1.0000 | Fixed |
+| Trusted-eligible CURIE-linked endpoint rate | 1.0000 | 1.0000 | Preserved |
+| Verified CURIE match rate | 0.9048 | 1.0000 | Improved |
+| Weak-claim trusted leakage count | 0 | 0 | Passing |
+| Fallback cases | 0 | 0 | Passing |
+| Invalid strict-agent cases | 0 | 0 | Passing |
+| Negative-control leakage cases | 0 | 0 | Passing |
+| Wrong verified CURIE links | 0 | 0 | Passing |
+| Raw unknown candidate relation types | 0 | 0 | Passing |
+| Raw unknown inventory relation types | 0 | 0 | Passing |
+
+## Live Loop Notes
+
+- Run1 and run2 stayed safe but missed the three PR23 weak targets; prompt-only
+  guidance was not enough.
+- Run3 exposed an invalid weak-pass relation type (`CASES`), proving the weak
+  pass needed tolerant parsing plus code-owned raw-type rejection.
+- Run4 recovered all weak cases but over-downgraded strong candidates because
+  weak-pass outputs were too broad.
+- Run5 restored precision but still missed the specific `SENSITIZES_TO` case.
+- Run6 passed after adding policy-backed weak-pass filtering and a primary
+  prompt rule for `X sensitizes disease/cells to drug`, then adversarial review
+  found three remaining closeout gaps: mixed-sentence weak cue poisoning,
+  structured weak-pass proposal leakage, and fallback-creditable review metrics.
+- Run7 passed after adding candidate-argument scoped weak-cue policy, weak-pass
+  proposal rejection, and agent-completion requirements for low-value review
+  metric credit.
+
+## Final Weak-Case Evidence
+
+The final live run captured all five low-value review cases as review-only:
+
+- `weak_med13_may_link_chd`: `MED13 ASSOCIATED_WITH congenital heart disease`
+  with `hedged_language`, `may_link`, `weak_review_agent_pass`.
+- `weak_met_correlated_resistance`: `MET amplification ASSOCIATED_WITH
+  resistance` with `hedged_language`, `correlated_only`,
+  `weak_review_agent_pass`.
+- `weak_hrd_possible_biomarker`: `HRD score BIOMARKER_FOR platinum sensitivity`
+  with `hedged_language`, `may_link`, `possible_biomarker`,
+  `weak_review_agent_pass`.
+- `weak_il6_may_regulate_inflammation`: `IL6 REGULATES inflammatory signaling`
+  with `hedged_language`, `may_regulate`, `may_link`,
+  `weak_review_agent_pass`.
+- `weak_akt_trend_survival`: `AKT activation ASSOCIATED_WITH reduced survival`
+  with `hedged_language`, `trend_only`, `correlated_only`,
+  `weak_review_agent_pass`.
+
+## Remaining Failure Attribution
+
+Final failure attribution reports no missed gold relations.
+
+Final failure attribution reports no false positives.
+
+Remaining CURIE gaps are review-lane or broad endpoint labels:
+
+- `aggressive tumor growth`
+- `ERK phosphorylation`
+- `response to pembrolizumab`
+- `reduced survival`
+- `HRD score`
+- `platinum sensitivity`
+- `inflammatory signaling` with an unverified model hint (`GO:0002526`)
+- `resistance`
+
+## Artifact Hashes
+
+| Artifact | SHA-256 |
+|---|---|
+| relation feasibility JSON | `e08c95ce73c49ea1911c877f20216250781a4745222b82265df3468ce3c4d5ed` |
+| relation feasibility Markdown | `2766c06deea7fc78bc514ec934cd5b9a69889243c4cfedd81fe3a64029a5f30f` |
+| failure analysis JSON | `380c3b0e25668e93447977e840558cf89f434e26a8fb0b84ca7361ee285760a5` |
+| failure analysis Markdown | `3b02408976683117dce478c858f2e945b5d49ec711c3008afd74e767f2e0d6ad` |
+
+## Interpretation
+
+PR-23 fixes the live-agent low-value review recall gap without using
+deterministic fallback as success. The system now has a separate weak-review
+agent pass, but the code remains the trust boundary: weak-pass outputs are
+forced to review-only, raw weak-pass relation types are dropped, and weak-pass
+candidates must satisfy the code-owned review policy before they can be kept.
+The closeout service gate passed with coverage 87.03% against the 86% gate.
+
+This does not finish trusted-graph readiness. It improves one blocker while
+leaving review-lane generic noise, repeated-run proof, endpoint grounding for
+broad labels, and graph-side independent promotion enforcement for the remaining
+PRs.

--- a/scripts/validation/relation_feasibility/endpoint_metrics.py
+++ b/scripts/validation/relation_feasibility/endpoint_metrics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from scripts.validation.relation_feasibility.trusted_metric_rules import (
     HIGH_VALUE_LEVELS,
@@ -34,6 +34,7 @@ def build_endpoint_metric_summary(
     *,
     case_assessments: tuple[tuple[CandidateAssessment, ...], ...],
     case_gold_relations: tuple[tuple[GoldRelation, ...], ...],
+    case_agent_completed_flags: tuple[bool, ...],
 ) -> EndpointMetricSummary:
     """Build endpoint metrics that separate trusted and review-only evidence."""
 
@@ -44,9 +45,9 @@ def build_endpoint_metric_summary(
     trusted_linked_endpoints = _linked_endpoint_keys(
         case_assessments=case_assessments,
         case_gold_relations=case_gold_relations,
+        case_agent_completed_flags=case_agent_completed_flags,
         value_levels=HIGH_VALUE_LEVELS,
-        require_trusted_eligible=True,
-        require_review_only=False,
+        lane="trusted",
     )
     low_value_gold_endpoints = _gold_endpoint_keys(
         case_gold_relations=case_gold_relations,
@@ -55,9 +56,9 @@ def build_endpoint_metric_summary(
     low_value_review_linked_endpoints = _linked_endpoint_keys(
         case_assessments=case_assessments,
         case_gold_relations=case_gold_relations,
+        case_agent_completed_flags=case_agent_completed_flags,
         value_levels=LOW_VALUE_LEVELS,
-        require_trusted_eligible=False,
-        require_review_only=True,
+        lane="review",
     )
     return EndpointMetricSummary(
         trusted_eligible_gold_curie_endpoint_count=len(trusted_gold_endpoints),
@@ -104,23 +105,27 @@ def _linked_endpoint_keys(
     *,
     case_assessments: tuple[tuple[CandidateAssessment, ...], ...],
     case_gold_relations: tuple[tuple[GoldRelation, ...], ...],
+    case_agent_completed_flags: tuple[bool, ...],
     value_levels: frozenset[str],
-    require_trusted_eligible: bool,
-    require_review_only: bool,
+    lane: Literal["trusted", "review"],
 ) -> set[tuple[int, int, str]]:
     endpoint_keys: set[tuple[int, int, str]] = set()
-    for case_index, assessments in enumerate(case_assessments):
+    for case_index, (assessments, agent_completed) in enumerate(
+        zip(case_assessments, case_agent_completed_flags, strict=True),
+    ):
+        if not agent_completed:
+            continue
         for assessment in assessments:
             gold_index = _review_or_match_gold_index(
                 assessment=assessment,
-                require_review_only=require_review_only,
+                require_review_only=lane == "review",
             )
             if gold_index is None:
                 continue
             gold_relation = case_gold_relations[case_index][gold_index]
             if gold_relation.value_level not in value_levels:
                 continue
-            if require_trusted_eligible and not assessment.is_trusted_evidence_eligible:
+            if lane == "trusted" and not assessment.is_trusted_evidence_eligible:
                 continue
             if assessment.subject_curie_matches_gold:
                 endpoint_keys.add((case_index, gold_index, "subject"))

--- a/scripts/validation/relation_feasibility/summary_scoring.py
+++ b/scripts/validation/relation_feasibility/summary_scoring.py
@@ -199,6 +199,7 @@ def build_summary(inputs: SummaryInputs) -> FeasibilitySummary:
     endpoint_metric_summary = build_endpoint_metric_summary(
         case_assessments=inputs.case_assessments,
         case_gold_relations=inputs.case_gold_relations,
+        case_agent_completed_flags=case_agent_completed_flags,
     )
     negative_control_metrics = _negative_control_metric_counts(
         inputs,
@@ -694,7 +695,7 @@ def _trust_lane_metric_counts(
                 assessment=assessment,
                 gold_relations=gold_relations,
             )
-            if low_value_review_index is not None:
+            if agent_completed and low_value_review_index is not None:
                 low_value_review_candidate_count += 1
                 low_value_review_matches.add((case_index, low_value_review_index))
     return _TrustLaneMetricCounts(

--- a/services/artana_evidence_api/document_extraction.py
+++ b/services/artana_evidence_api/document_extraction.py
@@ -19,7 +19,6 @@ from artana_evidence_api.document_extraction_contracts import (
     DocumentProposalReviewDiagnostics,
     DocumentTextExtraction,
     ExtractedRelationCandidate,
-    LLMExtractionResultLike,
     PdfTextExtractionOutcome,
     ProposalReviewResultLike,
 )
@@ -47,6 +46,7 @@ from artana_evidence_api.document_extraction_entities import (
 from artana_evidence_api.document_extraction_prompting import (
     DOCUMENT_PROPOSAL_REVIEW_SYSTEM_PROMPT,
     build_llm_extraction_output_schema,
+    build_llm_weak_review_extraction_output_schema,
     build_proposal_review_output_schema,
 )
 from artana_evidence_api.document_extraction_relation_taxonomy import (
@@ -66,9 +66,14 @@ from artana_evidence_api.document_extraction_support.full_text_chunking import (
 )
 from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
     LLM_EXTRACTION_PROMPT_VERSION,
+    LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
     build_llm_extraction_prompt,
+    build_llm_weak_review_extraction_prompt,
+    fingerprinted_step_key,
     llm_extraction_document_fingerprint,
-    llm_relations_to_candidates,
+    llm_extraction_step_key,
+    merge_duplicate_relation_candidates,
+    run_llm_relation_extraction_pass,
 )
 from artana_evidence_api.document_extraction_support.relation_candidate_quality_filter import (
     RelationCandidateQualityFilterResult,
@@ -107,6 +112,7 @@ _MAX_AI_ENTITY_PRE_RESOLUTION_LABELS = 4
 _AI_ENTITY_PRE_RESOLUTION_TIMEOUT_SECONDS = 2.0
 _LLM_CANDIDATE_EXTRACTION_TIMEOUT_SECONDS = 5.0
 _LLM_PROPOSAL_REVIEW_TIMEOUT_SECONDS = 5.0
+_WEAK_REVIEW_AGENT_PASS_REASON = "weak_review_agent_pass"
 _RELATION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(
@@ -229,39 +235,6 @@ def sha256_hex(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
-def _fingerprinted_step_key(prefix: str, *parts: str) -> str:
-    """Return a stable per-input step key for replay-sensitive model calls."""
-    payload = "\x1f".join(parts).encode("utf-8")
-    digest = hashlib.sha256(payload).hexdigest()[:16]
-    return f"{prefix}.{digest}"
-
-
-def _llm_extraction_step_key(
-    *,
-    text: str,
-    max_relations: int,
-    model_id: str = "",
-    prompt_version: str = LLM_EXTRACTION_PROMPT_VERSION,
-    chunk_index: int = 0,
-    total_chunks: int = 1,
-    document_fingerprint: str | None = None,
-) -> str:
-    """Return the stable extraction step key for one extraction chunk."""
-    normalized_text = normalize_text_document(text)
-    chunk_fingerprint = hashlib.sha256(normalized_text.encode("utf-8")).hexdigest()
-    effective_document_fingerprint = document_fingerprint or chunk_fingerprint
-    return _fingerprinted_step_key(
-        "research_init.llm_extraction.v2",
-        prompt_version,
-        model_id,
-        str(max_relations),
-        effective_document_fingerprint,
-        str(chunk_index),
-        str(total_chunks),
-        chunk_fingerprint,
-    )
-
-
 def _proposal_review_step_key(
     *,
     document: HarnessDocumentRecord,
@@ -269,7 +242,7 @@ def _proposal_review_step_key(
     goal_context_summary: str,
 ) -> str:
     """Return the stable proposal-review step key for one review payload."""
-    return _fingerprinted_step_key(
+    return fingerprinted_step_key(
         "document_extraction.proposal_review.v1",
         document.sha256,
         document.source_type,
@@ -504,6 +477,9 @@ async def extract_relation_candidates_with_llm(
         )
     document_fingerprint = llm_extraction_document_fingerprint(normalized_text)
     output_schema = build_llm_extraction_output_schema(max_relations)
+    weak_review_output_schema = build_llm_weak_review_extraction_output_schema(
+        max_relations,
+    )
 
     from artana.agent import SingleStepModelClient
     from artana.kernel import ArtanaKernel
@@ -542,49 +518,63 @@ async def extract_relation_candidates_with_llm(
         unknown_relation_types: set[str] = set()
         raw_relation_count = 0
         for chunk in chunks:
-            result = await run_single_step_with_policy(
-                client,
-                run_id=f"research-init-extraction:{uuid4()}",
-                tenant=tenant,
-                model=model_id,
-                prompt=build_llm_extraction_prompt(
-                    chunk=chunk,
-                    total_chunks=len(chunks),
-                    document_fingerprint=document_fingerprint,
-                ),
-                output_schema=output_schema,
-                step_key=_llm_extraction_step_key(
-                    text=chunk.text,
-                    max_relations=max_relations,
-                    model_id=model_id,
-                    chunk_index=chunk.index,
-                    total_chunks=len(chunks),
-                    document_fingerprint=document_fingerprint,
-                ),
-                replay_policy="fork_on_drift",
-            )
-
-            output = result.output
-            parsed = cast(
-                "LLMExtractionResultLike",
+            extraction_passes = (
                 (
-                    output
-                    if isinstance(output, output_schema)
-                    else output_schema.model_validate(output)
+                    LLM_EXTRACTION_PROMPT_VERSION,
+                    build_llm_extraction_prompt(
+                        chunk=chunk,
+                        total_chunks=len(chunks),
+                        document_fingerprint=document_fingerprint,
+                    ),
+                    output_schema,
+                    (),
+                ),
+                (
+                    LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+                    build_llm_weak_review_extraction_prompt(
+                        chunk=chunk,
+                        total_chunks=len(chunks),
+                        document_fingerprint=document_fingerprint,
+                    ),
+                    weak_review_output_schema,
+                    (_WEAK_REVIEW_AGENT_PASS_REASON,),
                 ),
             )
-            raw_relation_count += len(parsed.relations)
-            chunk_candidates, chunk_unknown_relation_types = (
-                llm_relations_to_candidates(parsed)
-            )
-            candidates.extend(chunk_candidates)
-            unknown_relation_types.update(chunk_unknown_relation_types)
+            for prompt_version, prompt, pass_output_schema, force_review_only_reason_codes in (
+                extraction_passes
+            ):
+                chunk_candidates, chunk_unknown_relation_types, chunk_raw_count = (
+                    await run_llm_relation_extraction_pass(
+                        step_runner=run_single_step_with_policy,
+                        client=client,
+                        tenant=tenant,
+                        model_id=model_id,
+                        prompt=prompt,
+                        output_schema=pass_output_schema,
+                        step_key=llm_extraction_step_key(
+                            text=chunk.text,
+                            max_relations=max_relations,
+                            model_id=model_id,
+                            prompt_version=prompt_version,
+                            chunk_index=chunk.index,
+                            total_chunks=len(chunks),
+                            document_fingerprint=document_fingerprint,
+                        ),
+                        force_review_only_reason_codes=(
+                            force_review_only_reason_codes
+                        ),
+                    )
+                )
+                raw_relation_count += chunk_raw_count
+                candidates.extend(chunk_candidates)
+                unknown_relation_types.update(chunk_unknown_relation_types)
 
         candidates = await _resolve_unknown_llm_relation_types(
             candidates=candidates,
             unknown_relation_types=unknown_relation_types,
             space_context=space_context,
         )
+        candidates = merge_duplicate_relation_candidates(candidates)
 
         pruning_result = _prune_relation_candidate_specificity(candidates)
         if pruning_result.pruned_count > 0:
@@ -944,7 +934,6 @@ async def review_document_extraction_drafts_with_diagnostics(  # noqa: PLR0912, 
         goal_context_summary=goal_context,
     )
 
-    from uuid import uuid4
 
     kernel: ArtanaKernel | None = None
     store = None

--- a/services/artana_evidence_api/document_extraction_prompting.py
+++ b/services/artana_evidence_api/document_extraction_prompting.py
@@ -6,6 +6,7 @@ from artana_evidence_api.document_extraction_contracts import (
     FactualSupportScale,
     GoalRelevanceScale,
     PriorityScale,
+    RelationReviewStatus,
 )
 from artana_evidence_api.document_extraction_relation_taxonomy import (
     LLM_EXTRACTION_RELATION_TYPES,
@@ -18,6 +19,30 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 def build_llm_extraction_output_schema(max_relations: int) -> type[BaseModel]:
     """Build the structured output schema for one LLM extraction pass."""
+
+    return _build_llm_extraction_output_schema(
+        max_relations=max_relations,
+        strict_relation_type=True,
+    )
+
+
+def build_llm_weak_review_extraction_output_schema(
+    max_relations: int,
+) -> type[BaseModel]:
+    """Build the schema for weak-review extraction with raw-type guardrails."""
+
+    return _build_llm_extraction_output_schema(
+        max_relations=max_relations,
+        strict_relation_type=False,
+    )
+
+
+def _build_llm_extraction_output_schema(
+    *,
+    max_relations: int,
+    strict_relation_type: bool,
+) -> type[BaseModel]:
+    """Build a relation extraction output schema."""
 
     class LLMRelation(BaseModel):
         model_config = ConfigDict(strict=True)
@@ -86,6 +111,23 @@ def build_llm_extraction_output_schema(max_relations: int) -> type[BaseModel]:
             ),
         )
         sentence: str = Field(..., min_length=1, max_length=1000)
+        review_status: RelationReviewStatus = Field(
+            default="candidate",
+            description=(
+                "Set to review_only only for weak, hedged, trend-only, "
+                "possible biomarker, may-link, or correlation-only claims that "
+                "are useful for human review."
+            ),
+        )
+        review_reason_codes: list[str] = Field(
+            default_factory=list,
+            max_length=8,
+            description=(
+                "Short snake_case reasons when review_status is review_only, "
+                "for example hedged_language, trend_only, may_link, or "
+                "correlated_only."
+            ),
+        )
 
         @field_validator("relation_type")
         @classmethod
@@ -93,6 +135,8 @@ def build_llm_extraction_output_schema(max_relations: int) -> type[BaseModel]:
             normalized = _normalize_relation_type(value)
             canonical = LLM_RELATION_SYNONYMS.get(normalized, normalized)
             if canonical not in LLM_EXTRACTION_RELATION_TYPES:
+                if not strict_relation_type:
+                    return canonical
                 raise ValueError(
                     "relation_type must be a canonical relation type or "
                     f"{LLM_PROPOSE_NEW_RELATION_TYPE}",
@@ -200,6 +244,10 @@ Each triple has:
   biomarker confers resistance to a specific drug.
   Use BIOMARKER_FOR when an expression, score, variant, or signature predicts
   a condition or treatment response.
+  Use SENSITIZES_TO for constructions like "BRCA1 loss sensitizes
+  triple-negative breast cancer to cisplatin": subject BRCA1 loss, object
+  cisplatin. Do not replace this with ASSOCIATED_WITH DNA repair defects when
+  the sentence supports the specific drug-sensitivity relation.
 
 - object: the target entity. Same rules as subject: short canonical name, max 4 words, no sentence fragments.
   Preserve modifiers that define the biomedical entity or clinical subgroup.
@@ -215,8 +263,21 @@ IMPORTANT — do NOT extract:
 - Author names or contributions
 - Study design descriptions that don't state a biological finding
 - Sentences about methods or protocols without a biological conclusion
-- Vague or speculative statements ("may play a role", "further research is needed")
+- Vague non-relational statements ("may play a role", "further research is needed")
 - Relations where subject or object is not a specific named entity
+
+WEAK REVIEW-ONLY RELATIONS:
+Reject vague non-relational role statements. Preserve direct weak claims when
+the sentence still names a concrete subject, relation cue, and object. Emit
+these only as review_only with review_reason_codes; do not treat them as
+trusted evidence and do not invent relations absent from the support sentence.
+Examples to keep for human review:
+- "MED13 may be linked to congenital heart disease" -> ASSOCIATED_WITH,
+  review_only, reasons: hedged_language, may_link
+- "MET amplification was correlated with resistance" -> ASSOCIATED_WITH,
+  review_only, reasons: hedged_language, correlated_only
+- "AKT activation showed a trend toward association with reduced survival" ->
+  ASSOCIATED_WITH, review_only, reasons: hedged_language, trend_only
 
 Focus on:
 - Concrete findings from results and conclusions

--- a/services/artana_evidence_api/document_extraction_support/llm_fulltext_extraction.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_fulltext_extraction.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import hashlib
 import logging
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import replace
+from typing import Protocol, cast
+from uuid import uuid4
 
 from artana_evidence_api.document_extraction_contracts import (
     ExtractedRelationCandidate,
     LLMExtractionResultLike,
     LLMRelationLike,
+    RelationReviewStatus,
 )
 from artana_evidence_api.document_extraction_entities import clean_llm_entity_label
 from artana_evidence_api.document_extraction_prompting import (
@@ -37,17 +42,65 @@ from artana_evidence_api.document_extraction_support.relation_specificity_prunin
 from artana_evidence_api.document_extraction_support.review_policy.review_only_candidate_policy import (
     classify_review_only_candidate,
 )
+from pydantic import BaseModel
 
-LLM_EXTRACTION_PROMPT_VERSION = "document_extraction.llm_extraction.v2"
+LLM_EXTRACTION_PROMPT_VERSION = "document_extraction.llm_extraction.v4"
+LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION = (
+    "document_extraction.weak_review_extraction.v1"
+)
 _MIN_ENTITY_LABEL_LENGTH = 2
 
 logger = logging.getLogger(__name__)
+
+
+class ModelStepResult(Protocol):
+    """Minimal model-step result needed by relation extraction."""
+
+    output: object
+
+
+ModelStepRunner = Callable[..., Awaitable[ModelStepResult]]
 
 
 def llm_extraction_document_fingerprint(normalized_text: str) -> str:
     """Return the full normalized document fingerprint for extraction replay."""
 
     return hashlib.sha256(normalized_text.encode("utf-8")).hexdigest()
+
+
+def fingerprinted_step_key(prefix: str, *parts: str) -> str:
+    """Return a stable per-input step key."""
+
+    payload = "\x1f".join(parts).encode("utf-8")
+    digest = hashlib.sha256(payload).hexdigest()[:16]
+    return f"{prefix}.{digest}"
+
+
+def llm_extraction_step_key(
+    *,
+    text: str,
+    max_relations: int,
+    model_id: str = "",
+    prompt_version: str = LLM_EXTRACTION_PROMPT_VERSION,
+    chunk_index: int = 0,
+    total_chunks: int = 1,
+    document_fingerprint: str | None = None,
+) -> str:
+    """Return the stable extraction step key for one extraction chunk."""
+
+    normalized_text = _normalize_text_document_for_key(text)
+    chunk_fingerprint = hashlib.sha256(normalized_text.encode("utf-8")).hexdigest()
+    effective_document_fingerprint = document_fingerprint or chunk_fingerprint
+    return fingerprinted_step_key(
+        "research_init.llm_extraction.v2",
+        prompt_version,
+        model_id,
+        str(max_relations),
+        effective_document_fingerprint,
+        str(chunk_index),
+        str(total_chunks),
+        chunk_fingerprint,
+    )
 
 
 def build_llm_extraction_prompt(
@@ -76,8 +129,44 @@ def build_llm_extraction_prompt(
     )
 
 
+def build_llm_weak_review_extraction_prompt(
+    *,
+    chunk: RelationExtractionTextChunk,
+    total_chunks: int,
+    document_fingerprint: str,
+) -> str:
+    """Build the second-pass prompt for weak relations that need review only."""
+
+    return (
+        f"{LLM_EXTRACTION_SYSTEM_PROMPT}\n\n"
+        "WEAK REVIEW-ONLY EXTRACTION PASS\n"
+        "This pass is intentionally different from the strongest-relation pass. "
+        "Extract only weak, hedged, trend-only, may-link, possible biomarker, "
+        "or correlation-only relations that are directly stated in this chunk "
+        "and still have a concrete named subject and object. Set review_status "
+        "to review_only for every returned relation and include concise "
+        "review_reason_codes such as hedged_language, trend_only, may_link, "
+        "possible_biomarker, or correlated_only. Return an empty relations "
+        "array when the chunk contains no directly stated weak relation.\n\n"
+        "Reject statements that only say a topic may play a role, needs further "
+        "research, or otherwise lacks a subject-relation-object claim.\n\n"
+        "MODEL CONTRACT\n"
+        f"- prompt_version: {LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION}\n"
+        f"- document_sha256: {document_fingerprint}\n"
+        f"- chunk_index: {chunk.index + 1} of {total_chunks}\n"
+        f"- chunk_char_range: {chunk.start_char}-{chunk.end_char}\n"
+        f"- chunk_sha256: {chunk.sha256}\n\n"
+        "---\nTEXT CHUNK TO ANALYZE:\n---\n"
+        f"{chunk.text}\n"
+        "---\n\n"
+        "Return the weak review-only relations as JSON."
+    )
+
+
 def llm_relations_to_candidates(
     parsed: LLMExtractionResultLike,
+    *,
+    force_review_only_reason_codes: Sequence[str] = (),
 ) -> tuple[list[ExtractedRelationCandidate], set[str]]:
     """Convert structured LLM relations into normalized candidate triples."""
 
@@ -85,7 +174,10 @@ def llm_relations_to_candidates(
     unknown_relation_types: set[str] = set()
 
     for rel in parsed.relations:
-        candidate, unknown_relation_type = _llm_relation_to_candidate(rel)
+        candidate, unknown_relation_type = _llm_relation_to_candidate(
+            rel,
+            force_review_only_reason_codes=force_review_only_reason_codes,
+        )
         if candidate is None:
             continue
         candidates.append(candidate)
@@ -97,6 +189,8 @@ def llm_relations_to_candidates(
 
 def _llm_relation_to_candidate(
     rel: LLMRelationLike,
+    *,
+    force_review_only_reason_codes: Sequence[str] = (),
 ) -> tuple[ExtractedRelationCandidate | None, str | None]:
     relation_type = normalize_relation_type_label(rel.relation_type)
     subject = clean_llm_entity_label(rel.subject)
@@ -130,6 +224,9 @@ def _llm_relation_to_candidate(
     )
 
     if relation_type == LLM_PROPOSE_NEW_RELATION_TYPE:
+        if force_review_only_reason_codes:
+            logger.info("Dropping weak-review relation type proposal before governance")
+            return None, None
         proposed_relation_type = normalize_proposed_relation_type(
             getattr(rel, "proposed_relation_type", None),
         )
@@ -144,6 +241,12 @@ def _llm_relation_to_candidate(
                 rationale,
                 proposed_relation_type=proposed_relation_type.relation_type,
             )
+        review_status, review_reason_codes = _candidate_review_metadata(
+            rel=rel,
+            policy_reason_codes=(),
+            policy_review_only=False,
+            force_review_only_reason_codes=force_review_only_reason_codes,
+        )
         return (
             ExtractedRelationCandidate(
                 subject_label=subject,
@@ -157,6 +260,8 @@ def _llm_relation_to_candidate(
                 proposed_relation_type=proposed_relation_type.relation_type,
                 new_relation_type_rationale=rationale,
                 relation_governance_status="requires_relation_review",
+                review_status=review_status,
+                review_reason_codes=review_reason_codes,
             ),
             None,
         )
@@ -165,9 +270,33 @@ def _llm_relation_to_candidate(
     unknown_relation_type = (
         relation_type if relation_type not in LLM_VALID_RELATION_TYPES else None
     )
+    if unknown_relation_type is not None and force_review_only_reason_codes:
+        logger.info(
+            "Dropping raw weak-review relation type %s before governance resolution",
+            unknown_relation_type,
+        )
+        return None, None
     review_only_decision = classify_review_only_candidate(
         relation_type=relation_type,
         support_sentence=rel.sentence,
+        subject_label=subject,
+        object_label=obj,
+    )
+    if force_review_only_reason_codes and not review_only_decision.review_only:
+        logger.debug(
+            "Dropping weak-review pass candidate without policy weak-evidence cues",
+            extra={
+                "relation_type": relation_type,
+                "subject": subject,
+                "object": obj,
+            },
+        )
+        return None, None
+    review_status, review_reason_codes = _candidate_review_metadata(
+        rel=rel,
+        policy_reason_codes=review_only_decision.reason_codes,
+        policy_review_only=review_only_decision.review_only,
+        force_review_only_reason_codes=force_review_only_reason_codes,
     )
     return (
         ExtractedRelationCandidate(
@@ -179,10 +308,8 @@ def _llm_relation_to_candidate(
             object_curie=object_curie_link.curie,
             subject_curie_source=_candidate_curie_source(subject_curie_link),
             object_curie_source=_candidate_curie_source(object_curie_link),
-            review_status=(
-                "review_only" if review_only_decision.review_only else "candidate"
-            ),
-            review_reason_codes=review_only_decision.reason_codes,
+            review_status=review_status,
+            review_reason_codes=review_reason_codes,
         ),
         unknown_relation_type,
     )
@@ -190,6 +317,50 @@ def _llm_relation_to_candidate(
 
 def _candidate_curie_source(link: EntityCurieLink) -> CurieSource:
     return link.source if link.curie is not None else "none"
+
+
+def _candidate_review_metadata(
+    *,
+    rel: LLMRelationLike,
+    policy_reason_codes: tuple[str, ...],
+    policy_review_only: bool,
+    force_review_only_reason_codes: Sequence[str] = (),
+) -> tuple[RelationReviewStatus, tuple[str, ...]]:
+    model_reason_codes = _model_review_reason_codes(
+        getattr(rel, "review_reason_codes", ()),
+    )
+    forced_reason_codes = _model_review_reason_codes(force_review_only_reason_codes)
+    model_review_only = getattr(rel, "review_status", "candidate") == "review_only"
+    review_reason_codes = tuple(
+        dict.fromkeys((*policy_reason_codes, *model_reason_codes, *forced_reason_codes)),
+    )
+    review_only = (
+        policy_review_only
+        or model_review_only
+        or bool(forced_reason_codes)
+        or bool(review_reason_codes)
+    )
+    return ("review_only" if review_only else "candidate"), review_reason_codes
+
+
+def _model_review_reason_codes(value: object) -> tuple[str, ...]:
+    if isinstance(value, str):
+        normalized = _normalize_review_reason_code(value)
+        return (normalized,) if normalized != "" else ()
+    if not isinstance(value, Sequence):
+        return ()
+    return tuple(
+        dict.fromkeys(
+            normalized
+            for reason_code in value
+            if isinstance(reason_code, str)
+            and (normalized := _normalize_review_reason_code(reason_code)) != ""
+        ),
+    )
+
+
+def _normalize_review_reason_code(value: str) -> str:
+    return value.strip().lower().replace(" ", "_")
 
 
 def _append_relation_proposal_repair_note(
@@ -203,9 +374,111 @@ def _append_relation_proposal_repair_note(
     return f"{rationale.strip()} ({note})"
 
 
+def merge_duplicate_relation_candidates(
+    candidates: list[ExtractedRelationCandidate],
+) -> list[ExtractedRelationCandidate]:
+    """Merge duplicate relation candidates while preserving safer review metadata."""
+
+    merged_by_key: dict[tuple[str, str, str, str], ExtractedRelationCandidate] = {}
+    ordered_keys: list[tuple[str, str, str, str]] = []
+    for candidate in candidates:
+        key = (
+            candidate.subject_label.casefold(),
+            candidate.relation_type,
+            candidate.object_label.casefold(),
+            candidate.sentence.casefold(),
+        )
+        existing = merged_by_key.get(key)
+        if existing is None:
+            merged_by_key[key] = candidate
+            ordered_keys.append(key)
+            continue
+        review_reason_codes = tuple(
+            dict.fromkeys(
+                (*existing.review_reason_codes, *candidate.review_reason_codes),
+            ),
+        )
+        merged_by_key[key] = replace(
+            existing,
+            subject_curie=existing.subject_curie or candidate.subject_curie,
+            object_curie=existing.object_curie or candidate.object_curie,
+            subject_curie_source=(
+                existing.subject_curie_source
+                if existing.subject_curie is not None
+                else candidate.subject_curie_source
+            ),
+            object_curie_source=(
+                existing.object_curie_source
+                if existing.object_curie is not None
+                else candidate.object_curie_source
+            ),
+            review_status=(
+                "review_only"
+                if "review_only"
+                in {existing.review_status, candidate.review_status}
+                or bool(review_reason_codes)
+                else "candidate"
+            ),
+            review_reason_codes=review_reason_codes,
+        )
+    return [merged_by_key[key] for key in ordered_keys]
+
+
+async def run_llm_relation_extraction_pass(
+    *,
+    step_runner: ModelStepRunner,
+    client: object,
+    tenant: object,
+    model_id: str,
+    prompt: str,
+    output_schema: type[BaseModel],
+    step_key: str,
+    force_review_only_reason_codes: tuple[str, ...] = (),
+) -> tuple[list[ExtractedRelationCandidate], set[str], int]:
+    """Run one LLM relation extraction pass and normalize candidates."""
+
+    result = await step_runner(
+        client,
+        run_id=f"research-init-extraction:{uuid4()}",
+        tenant=tenant,
+        model=model_id,
+        prompt=prompt,
+        output_schema=output_schema,
+        step_key=step_key,
+        replay_policy="fork_on_drift",
+    )
+    output = result.output
+    parsed = cast(
+        "LLMExtractionResultLike",
+        (
+            output
+            if isinstance(output, output_schema)
+            else output_schema.model_validate(output)
+        ),
+    )
+    candidates, unknown_relation_types = llm_relations_to_candidates(
+        parsed,
+        force_review_only_reason_codes=force_review_only_reason_codes,
+    )
+    return candidates, unknown_relation_types, len(parsed.relations)
+
+
+def _normalize_text_document_for_key(text: str) -> str:
+    normalized_lines = [
+        line.rstrip() for line in text.replace("\r\n", "\n").split("\n")
+    ]
+    return "\n".join(normalized_lines).strip()
+
+
 __all__ = [
     "LLM_EXTRACTION_PROMPT_VERSION",
+    "LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION",
     "build_llm_extraction_prompt",
+    "build_llm_weak_review_extraction_prompt",
+    "fingerprinted_step_key",
+    "llm_extraction_step_key",
     "llm_extraction_document_fingerprint",
     "llm_relations_to_candidates",
+    "merge_duplicate_relation_candidates",
+    "run_llm_relation_extraction_pass",
 ]

--- a/services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py
+++ b/services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py
@@ -103,7 +103,10 @@ def filter_low_value_relation_candidates(
     for candidate_index, candidate in enumerate(candidates):
         reason = _quality_filter_reason(candidate)
         review_only_candidate = _review_only_candidate(candidate)
-        if reason == "uncertain_relation_claim" and review_only_candidate is not None:
+        if review_only_candidate is not None and reason in {
+            None,
+            "uncertain_relation_claim",
+        }:
             kept_candidates.append(review_only_candidate)
             continue
         if reason is None and _is_context_relation_shadowed(
@@ -135,6 +138,8 @@ def _review_only_candidate(
     decision = classify_review_only_candidate(
         relation_type=candidate.relation_type,
         support_sentence=candidate.sentence,
+        subject_label=candidate.subject_label,
+        object_label=candidate.object_label,
     )
     if not decision.review_only:
         return None
@@ -161,7 +166,13 @@ def _quality_filter_reason(
 def _single_candidate_support_reason(
     candidate: ExtractedRelationCandidate,
 ) -> RelationCandidateQualityFilterReason | None:
-    if _UNCERTAIN_RELATION_CUE_RE.search(candidate.sentence) is not None:
+    review_decision = classify_review_only_candidate(
+        relation_type=candidate.relation_type,
+        support_sentence=candidate.sentence,
+        subject_label=candidate.subject_label,
+        object_label=candidate.object_label,
+    )
+    if review_decision.review_only:
         return "uncertain_relation_claim"
     grounding = ground_relation_sentence(
         source_text=candidate.sentence,

--- a/services/artana_evidence_api/document_extraction_support/relation_specificity_pruning.py
+++ b/services/artana_evidence_api/document_extraction_support/relation_specificity_pruning.py
@@ -151,10 +151,13 @@ def prune_redundant_generic_relation_candidates(
         canonical_relation = canonicalize_extraction_relation_type(
             candidate.relation_type,
         )
-        if is_low_value_generic_relation_candidate(
-            relation_type=candidate.relation_type,
-            lemma="",
-            sentence=candidate.sentence,
+        if (
+            candidate.review_status != "review_only"
+            and is_low_value_generic_relation_candidate(
+                relation_type=candidate.relation_type,
+                lemma="",
+                sentence=candidate.sentence,
+            )
         ):
             weak_generic_candidates.append(
                 WeakGenericRelationCandidate(

--- a/services/artana_evidence_api/document_extraction_support/review_policy/review_only_candidate_policy.py
+++ b/services/artana_evidence_api/document_extraction_support/review_policy/review_only_candidate_policy.py
@@ -21,6 +21,10 @@ _POSSIBLE_BIOMARKER_RE = re.compile(
     re.IGNORECASE,
 )
 _MAY_REGULATE_RE = re.compile(r"\bmay\s+regulat(?:e|es|ed|ing|ion)\b", re.IGNORECASE)
+_MAY_LINK_RE = re.compile(
+    r"\bmay\s+(?:be\s+)?(?:link(?:ed)?|associat(?:ed|e))\s+(?:to|with)\b",
+    re.IGNORECASE,
+)
 _CORRELATED_RE = re.compile(r"\bcorrelat(?:e|es|ed|ing|ion)\s+with\b", re.IGNORECASE)
 _WEAK_LANGUAGE_RE = re.compile(
     r"\b(?:may|might|possible|potential|trend|weakly)\b",
@@ -33,23 +37,33 @@ def classify_review_only_candidate(
     relation_type: str,
     support_sentence: str,
     value_level: str | None = None,
+    subject_label: str | None = None,
+    object_label: str | None = None,
 ) -> ReviewOnlyDecision:
     """Classify weak relation evidence that should be review-only."""
 
     del relation_type
+    cue_text = _candidate_claim_text(
+        support_sentence=support_sentence,
+        subject_label=subject_label,
+        object_label=object_label,
+    )
     reasons: list[str] = []
-    if _TREND_RE.search(support_sentence) is not None:
+    if _TREND_RE.search(cue_text) is not None:
         reasons.append("trend_only")
-    if _POSSIBLE_BIOMARKER_RE.search(support_sentence) is not None:
+    if _POSSIBLE_BIOMARKER_RE.search(cue_text) is not None:
         reasons.append("possible_biomarker")
-    if _MAY_REGULATE_RE.search(support_sentence) is not None:
+    if _MAY_REGULATE_RE.search(cue_text) is not None:
         reasons.append("may_regulate")
-    if _CORRELATED_RE.search(support_sentence) is not None:
+    if _MAY_LINK_RE.search(cue_text) is not None:
+        reasons.append("may_link")
+    if _CORRELATED_RE.search(cue_text) is not None:
         reasons.append("correlated_only")
-    if _WEAK_LANGUAGE_RE.search(support_sentence) is not None or value_level in {
-        "low",
-        "reject",
-    }:
+    if (
+        reasons
+        or _WEAK_LANGUAGE_RE.search(cue_text) is not None
+        or value_level in {"low", "reject"}
+    ):
         reasons.insert(0, "hedged_language")
     reason_codes = tuple(dict.fromkeys(reasons))
     review_only = bool(reason_codes)
@@ -57,6 +71,45 @@ def classify_review_only_candidate(
         review_only=review_only,
         reason_codes=reason_codes,
         trusted_promotion_allowed=not review_only,
+    )
+
+
+def _candidate_claim_text(
+    *,
+    support_sentence: str,
+    subject_label: str | None,
+    object_label: str | None,
+) -> str:
+    if subject_label is None or object_label is None:
+        return support_sentence
+    subject_pattern = _label_pattern(subject_label)
+    object_pattern = _label_pattern(object_label)
+    if subject_pattern == "" or object_pattern == "":
+        return support_sentence
+    clauses = [
+        clause
+        for clause in _split_candidate_clauses(support_sentence)
+        if re.search(subject_pattern, clause, flags=re.IGNORECASE) is not None
+        and re.search(object_pattern, clause, flags=re.IGNORECASE) is not None
+    ]
+    return " ".join(clauses) if clauses else support_sentence
+
+
+def _label_pattern(label: str) -> str:
+    normalized = " ".join(label.strip().split())
+    if normalized == "":
+        return ""
+    return r"\b" + r"\s+".join(re.escape(token) for token in normalized.split()) + r"\b"
+
+
+def _split_candidate_clauses(sentence: str) -> tuple[str, ...]:
+    return tuple(
+        clause.strip(" ,")
+        for clause in re.split(
+            r"(?:[.;:]|,\s*(?:and|while|whereas|but)\b|\b(?:while|whereas|but)\b)",
+            sentence,
+        )
+        if clause.strip(" ,")
     )
 
 

--- a/services/artana_evidence_api/tests/unit/test_document_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction.py
@@ -736,6 +736,348 @@ async def test_extract_relation_candidates_with_llm_repairs_known_label_curies(
 
 
 @pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_uses_agent_review_only_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts: list[str] = []
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        prompt = str(kwargs["prompt"])
+        prompts.append(prompt)
+        if "WEAK REVIEW-ONLY EXTRACTION PASS" not in prompt:
+            return SimpleNamespace(output={"relations": []})
+        return SimpleNamespace(
+            output={
+                "relations": [
+                    {
+                        "subject": "MED13",
+                        "relation_type": "ASSOCIATED_WITH",
+                        "object": "congenital heart disease",
+                        "sentence": (
+                            "MED13 may be linked to congenital heart disease "
+                            "in a subset of families."
+                        ),
+                    },
+                ],
+            },
+        )
+
+    monkeypatch.setattr(runtime_support, "has_configured_openai_api_key", lambda: True)
+    monkeypatch.setattr(
+        runtime_support,
+        "get_model_registry",
+        lambda: SimpleNamespace(
+            get_default_model=lambda _capability: SimpleNamespace(
+                model_id="openai:gpt-5.4-mini",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "normalize_litellm_model_id",
+        lambda model_id: model_id,
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "create_artana_postgres_store",
+        lambda: _FakeKernelStore(),
+    )
+    monkeypatch.setattr("artana.kernel.ArtanaKernel", _FakeKernel)
+    monkeypatch.setattr("artana.agent.SingleStepModelClient", _FakeSingleStepClient)
+    monkeypatch.setattr(
+        document_extraction,
+        "run_single_step_with_policy",
+        _fake_run_single_step_with_policy,
+    )
+
+    candidates = await extract_relation_candidates_with_llm(
+        "MED13 may be linked to congenital heart disease in a subset of families.",
+    )
+
+    assert len(prompts) == 2
+    assert len(candidates) == 1
+    assert candidates[0].subject_label == "MED13"
+    assert candidates[0].object_label == "congenital heart disease"
+    assert candidates[0].review_status == "review_only"
+    assert candidates[0].review_reason_codes == (
+        "hedged_language",
+        "may_link",
+        "weak_review_agent_pass",
+    )
+    assert candidates[0].trusted_evidence_eligible is False
+
+
+@pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_drops_invalid_weak_pass_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts: list[str] = []
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        prompt = str(kwargs["prompt"])
+        prompts.append(prompt)
+        if "WEAK REVIEW-ONLY EXTRACTION PASS" not in prompt:
+            return SimpleNamespace(output={"relations": []})
+        return SimpleNamespace(
+            output={
+                "relations": [
+                    {
+                        "subject": "MED13",
+                        "relation_type": "CASES",
+                        "object": "congenital heart disease",
+                        "sentence": (
+                            "MED13 may be linked to congenital heart disease "
+                            "in a subset of families."
+                        ),
+                    },
+                ],
+            },
+        )
+
+    monkeypatch.setattr(runtime_support, "has_configured_openai_api_key", lambda: True)
+    monkeypatch.setattr(
+        runtime_support,
+        "get_model_registry",
+        lambda: SimpleNamespace(
+            get_default_model=lambda _capability: SimpleNamespace(
+                model_id="openai:gpt-5.4-mini",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "normalize_litellm_model_id",
+        lambda model_id: model_id,
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "create_artana_postgres_store",
+        lambda: _FakeKernelStore(),
+    )
+    monkeypatch.setattr("artana.kernel.ArtanaKernel", _FakeKernel)
+    monkeypatch.setattr("artana.agent.SingleStepModelClient", _FakeSingleStepClient)
+    monkeypatch.setattr(
+        document_extraction,
+        "run_single_step_with_policy",
+        _fake_run_single_step_with_policy,
+    )
+
+    candidates = await extract_relation_candidates_with_llm(
+        "MED13 may be linked to congenital heart disease in a subset of families.",
+    )
+
+    assert len(prompts) == 2
+    assert candidates == []
+
+
+@pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_does_not_downgrade_strong_claims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        if "WEAK REVIEW-ONLY EXTRACTION PASS" not in str(kwargs["prompt"]):
+            return SimpleNamespace(
+                output={
+                    "relations": [
+                        {
+                            "subject": "BRCA1",
+                            "relation_type": "ACTIVATES",
+                            "object": "EGFR",
+                            "sentence": "BRCA1 activates EGFR.",
+                        },
+                    ],
+                },
+            )
+        return SimpleNamespace(
+            output={
+                "relations": [
+                    {
+                        "subject": "BRCA1",
+                        "relation_type": "ACTIVATES",
+                        "object": "EGFR",
+                        "sentence": "BRCA1 activates EGFR.",
+                        "review_status": "review_only",
+                        "review_reason_codes": ["weak_review_only"],
+                    },
+                ],
+            },
+        )
+
+    monkeypatch.setattr(runtime_support, "has_configured_openai_api_key", lambda: True)
+    monkeypatch.setattr(
+        runtime_support,
+        "get_model_registry",
+        lambda: SimpleNamespace(
+            get_default_model=lambda _capability: SimpleNamespace(
+                model_id="openai:gpt-5.4-mini",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "normalize_litellm_model_id",
+        lambda model_id: model_id,
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "create_artana_postgres_store",
+        lambda: _FakeKernelStore(),
+    )
+    monkeypatch.setattr("artana.kernel.ArtanaKernel", _FakeKernel)
+    monkeypatch.setattr("artana.agent.SingleStepModelClient", _FakeSingleStepClient)
+    monkeypatch.setattr(
+        document_extraction,
+        "run_single_step_with_policy",
+        _fake_run_single_step_with_policy,
+    )
+
+    candidates = await extract_relation_candidates_with_llm("BRCA1 activates EGFR.")
+
+    assert len(candidates) == 1
+    assert candidates[0].review_status == "candidate"
+    assert candidates[0].review_reason_codes == ()
+    assert candidates[0].trusted_evidence_eligible is True
+
+
+@pytest.mark.asyncio
+async def test_weak_pass_does_not_poison_strong_claim_in_mixed_sentence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentence = (
+        "BRCA1 activates EGFR, while MED13 may be linked to congenital heart "
+        "disease."
+    )
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        return SimpleNamespace(
+            output={
+                "relations": [
+                    {
+                        "subject": "BRCA1",
+                        "relation_type": "ACTIVATES",
+                        "object": "EGFR",
+                        "sentence": sentence,
+                        "review_status": (
+                            "review_only"
+                            if "WEAK REVIEW-ONLY EXTRACTION PASS"
+                            in str(kwargs["prompt"])
+                            else "candidate"
+                        ),
+                        "review_reason_codes": (
+                            ["weak_review_only"]
+                            if "WEAK REVIEW-ONLY EXTRACTION PASS"
+                            in str(kwargs["prompt"])
+                            else []
+                        ),
+                    },
+                ],
+            },
+        )
+
+    monkeypatch.setattr(runtime_support, "has_configured_openai_api_key", lambda: True)
+    monkeypatch.setattr(
+        runtime_support,
+        "get_model_registry",
+        lambda: SimpleNamespace(
+            get_default_model=lambda _capability: SimpleNamespace(
+                model_id="openai:gpt-5.4-mini",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "normalize_litellm_model_id",
+        lambda model_id: model_id,
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "create_artana_postgres_store",
+        lambda: _FakeKernelStore(),
+    )
+    monkeypatch.setattr("artana.kernel.ArtanaKernel", _FakeKernel)
+    monkeypatch.setattr("artana.agent.SingleStepModelClient", _FakeSingleStepClient)
+    monkeypatch.setattr(
+        document_extraction,
+        "run_single_step_with_policy",
+        _fake_run_single_step_with_policy,
+    )
+
+    candidates = await extract_relation_candidates_with_llm(sentence)
+
+    assert len(candidates) == 1
+    assert candidates[0].review_status == "candidate"
+    assert candidates[0].review_reason_codes == ()
+    assert candidates[0].trusted_evidence_eligible is True
+
+
+@pytest.mark.asyncio
+async def test_weak_pass_drops_structured_relation_type_proposals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts: list[str] = []
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        prompt = str(kwargs["prompt"])
+        prompts.append(prompt)
+        if "WEAK REVIEW-ONLY EXTRACTION PASS" not in prompt:
+            return SimpleNamespace(output={"relations": []})
+        return SimpleNamespace(
+            output={
+                "relations": [
+                    {
+                        "subject": "MED13",
+                        "relation_type": "PROPOSE_NEW_RELATION_TYPE",
+                        "proposed_relation_type": "WEAKLY_LINKED_TO",
+                        "new_relation_type_rationale": (
+                            "Hedged association should stay out of relation "
+                            "governance from the weak pass."
+                        ),
+                        "object": "congenital heart disease",
+                        "sentence": (
+                            "MED13 may be linked to congenital heart disease."
+                        ),
+                    },
+                ],
+            },
+        )
+
+    monkeypatch.setattr(runtime_support, "has_configured_openai_api_key", lambda: True)
+    monkeypatch.setattr(
+        runtime_support,
+        "get_model_registry",
+        lambda: SimpleNamespace(
+            get_default_model=lambda _capability: SimpleNamespace(
+                model_id="openai:gpt-5.4-mini",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "normalize_litellm_model_id",
+        lambda model_id: model_id,
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "create_artana_postgres_store",
+        lambda: _FakeKernelStore(),
+    )
+    monkeypatch.setattr("artana.kernel.ArtanaKernel", _FakeKernel)
+    monkeypatch.setattr("artana.agent.SingleStepModelClient", _FakeSingleStepClient)
+    monkeypatch.setattr(
+        document_extraction,
+        "run_single_step_with_policy",
+        _fake_run_single_step_with_policy,
+    )
+
+    candidates = await extract_relation_candidates_with_llm(
+        "MED13 may be linked to congenital heart disease.",
+    )
+
+    assert len(prompts) == 2
+    assert candidates == []
+
+
+@pytest.mark.asyncio
 async def test_extract_relation_candidates_with_llm_keeps_structured_new_type_proposals(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -996,7 +1338,7 @@ async def test_discover_relation_candidates_reports_llm_pruned_generic_siblings(
 
 
 @pytest.mark.asyncio
-async def test_extract_relation_candidates_with_llm_suppresses_weak_generic_correlations(
+async def test_extract_relation_candidates_with_llm_keeps_weak_generic_review_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def _fake_run_single_step_with_policy(*_args, **_kwargs):
@@ -1048,7 +1390,12 @@ async def test_extract_relation_candidates_with_llm_suppresses_weak_generic_corr
         "MET amplification was correlated with resistance in a small exploratory cohort.",
     )
 
-    assert candidates == []
+    assert len(candidates) == 1
+    assert candidates[0].subject_label == "MET amplification"
+    assert candidates[0].relation_type == "ASSOCIATED_WITH"
+    assert candidates[0].object_label == "resistance"
+    assert candidates[0].review_status == "review_only"
+    assert candidates[0].trusted_evidence_eligible is False
 
 
 def test_llm_extraction_step_key_uses_full_text_beyond_prefix() -> None:
@@ -1057,11 +1404,11 @@ def test_llm_extraction_step_key_uses_full_text_beyond_prefix() -> None:
     second_text = f"{shared_prefix} MED13 regulates cardiomyopathy."
 
     assert first_text[:4000] == second_text[:4000]
-    assert document_extraction._llm_extraction_step_key(
+    assert document_extraction.llm_extraction_step_key(
         text=first_text,
         max_relations=10,
         model_id="openai/gpt-5.4-mini",
-    ) != document_extraction._llm_extraction_step_key(
+    ) != document_extraction.llm_extraction_step_key(
         text=second_text,
         max_relations=10,
         model_id="openai/gpt-5.4-mini",
@@ -1194,24 +1541,45 @@ async def test_extract_relation_candidates_with_llm_scopes_step_key_to_document_
     await extract_relation_candidates_with_llm(second_text)
 
     assert captured_step_keys == [
-        document_extraction._llm_extraction_step_key(
+        document_extraction.llm_extraction_step_key(
             text=first_text,
             max_relations=10,
             model_id="openai:gpt-5.4-mini",
         ),
-        document_extraction._llm_extraction_step_key(
+        document_extraction.llm_extraction_step_key(
+            text=first_text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=document_extraction.LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+        ),
+        document_extraction.llm_extraction_step_key(
             text=first_text,
             max_relations=10,
             model_id="openai:gpt-5.4-mini",
         ),
-        document_extraction._llm_extraction_step_key(
+        document_extraction.llm_extraction_step_key(
+            text=first_text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=document_extraction.LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+        ),
+        document_extraction.llm_extraction_step_key(
             text=second_text,
             max_relations=10,
             model_id="openai:gpt-5.4-mini",
         ),
+        document_extraction.llm_extraction_step_key(
+            text=second_text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=document_extraction.LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+        ),
     ]
-    assert captured_step_keys[0] == captured_step_keys[1]
-    assert captured_step_keys[0] != captured_step_keys[2]
+    assert captured_step_keys[0] == captured_step_keys[2]
+    assert captured_step_keys[1] == captured_step_keys[3]
+    assert captured_step_keys[0] != captured_step_keys[1]
+    assert captured_step_keys[0] != captured_step_keys[4]
+    assert captured_step_keys[1] != captured_step_keys[5]
 
 
 @pytest.mark.asyncio

--- a/services/artana_evidence_api/tests/unit/test_document_extraction_modules.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction_modules.py
@@ -45,6 +45,7 @@ from artana_evidence_api.document_extraction_entities import (
 from artana_evidence_api.document_extraction_prompting import (
     LLM_EXTRACTION_SYSTEM_PROMPT,
     build_llm_extraction_output_schema,
+    build_llm_weak_review_extraction_output_schema,
     build_proposal_review_output_schema,
 )
 from artana_evidence_api.document_extraction_relation_taxonomy import (
@@ -61,6 +62,7 @@ from artana_evidence_api.document_extraction_review import (
     shorten_text,
 )
 from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+    LLM_EXTRACTION_PROMPT_VERSION,
     llm_relations_to_candidates,
 )
 from artana_evidence_api.document_store import HarnessDocumentRecord
@@ -215,6 +217,83 @@ def test_llm_extraction_schema_rejects_raw_unknown_relation_type() -> None:
                 ],
             },
         )
+
+
+def test_llm_extraction_prompt_preserves_useful_weak_claims_as_review_only() -> None:
+    normalized_prompt = " ".join(LLM_EXTRACTION_SYSTEM_PROMPT.split())
+
+    assert "WEAK REVIEW-ONLY RELATIONS" in normalized_prompt
+    assert "only as review_only" in normalized_prompt
+    assert "do not treat them as trusted evidence" in normalized_prompt
+    assert "do not invent relations absent from the support sentence" in (
+        normalized_prompt
+    )
+    assert "Reject vague non-relational role statements" in normalized_prompt
+    assert "MED13 may be linked to congenital heart disease" in normalized_prompt
+    assert "MET amplification was correlated with resistance" in normalized_prompt
+    assert "AKT activation showed a trend toward association" in normalized_prompt
+
+
+def test_llm_extraction_prompt_prioritizes_specific_sensitizes_relation() -> None:
+    normalized_prompt = " ".join(LLM_EXTRACTION_SYSTEM_PROMPT.split())
+
+    assert "BRCA1 loss sensitizes triple-negative breast cancer to cisplatin" in (
+        normalized_prompt
+    )
+    assert "subject BRCA1 loss" in normalized_prompt
+    assert "object cisplatin" in normalized_prompt
+    assert "Do not replace this with ASSOCIATED_WITH DNA repair defects" in (
+        normalized_prompt
+    )
+
+
+def test_llm_extraction_prompt_version_changes_for_review_only_schema() -> None:
+    assert LLM_EXTRACTION_PROMPT_VERSION == "document_extraction.llm_extraction.v4"
+
+
+def test_llm_extraction_schema_accepts_review_only_lane_fields() -> None:
+    extraction_schema = build_llm_extraction_output_schema(max_relations=1)
+
+    parsed = extraction_schema.model_validate(
+        {
+            "relations": [
+                {
+                    "subject": "MED13",
+                    "relation_type": "ASSOCIATED_WITH",
+                    "object": "congenital heart disease",
+                    "sentence": "MED13 may be linked to congenital heart disease.",
+                    "review_status": "review_only",
+                    "review_reason_codes": ["hedged_language", "may_link"],
+                },
+            ],
+        },
+    )
+
+    assert parsed.relations[0].review_status == "review_only"
+    assert parsed.relations[0].review_reason_codes == [
+        "hedged_language",
+        "may_link",
+    ]
+
+
+def test_weak_review_extraction_schema_allows_raw_relation_type_for_guard() -> None:
+    extraction_schema = build_llm_weak_review_extraction_output_schema(max_relations=1)
+
+    parsed = extraction_schema.model_validate(
+        {
+            "relations": [
+                {
+                    "subject": "MED13",
+                    "relation_type": "CASES",
+                    "object": "congenital heart disease",
+                    "sentence": "MED13 may be linked to congenital heart disease.",
+                    "review_status": "review_only",
+                },
+            ],
+        },
+    )
+
+    assert parsed.relations[0].relation_type == "CASES"
 
 
 def test_llm_extraction_schema_accepts_confers_resistance_as_canonical() -> None:
@@ -399,6 +478,33 @@ def test_llm_conversion_preserves_specific_relation_arguments() -> None:
     assert unknown_relation_types == set()
     assert len(candidates) == 1
     assert candidates[0].object_label == "BRCA-mutated ovarian cancer"
+
+
+def test_llm_conversion_preserves_model_review_only_reason_hints() -> None:
+    parsed = SimpleNamespace(
+        relations=[
+            SimpleNamespace(
+                subject="MED13",
+                subject_curie=None,
+                relation_type="ASSOCIATED_WITH",
+                proposed_relation_type=None,
+                new_relation_type_rationale=None,
+                object="congenital heart disease",
+                object_curie=None,
+                sentence="MED13 was associated with congenital heart disease.",
+                review_status="review_only",
+                review_reason_codes=["agent_review_hint"],
+            ),
+        ],
+    )
+
+    candidates, unknown_relation_types = llm_relations_to_candidates(parsed)
+
+    assert unknown_relation_types == set()
+    assert len(candidates) == 1
+    assert candidates[0].review_status == "review_only"
+    assert candidates[0].review_reason_codes == ("agent_review_hint",)
+    assert candidates[0].trusted_evidence_eligible is False
 
 
 def test_llm_conversion_keeps_confers_resistance_as_canonical_candidate() -> None:

--- a/services/artana_evidence_api/tests/unit/test_llm_fallback_observability.py
+++ b/services/artana_evidence_api/tests/unit/test_llm_fallback_observability.py
@@ -591,7 +591,7 @@ async def test_llm_extraction_logs_debug_for_filtered_candidates(
     ]
     assert records
     record = records[-1]
-    assert record.raw_relation_count == 1
+    assert record.raw_relation_count == 2
     assert record.usable_candidate_count == 0
 
 

--- a/services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py
+++ b/services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from artana_evidence_api.document_extraction_contracts import (
     ExtractedRelationCandidate,
 )
@@ -185,6 +186,68 @@ def test_quality_filter_keeps_uncertain_candidate_as_review_only() -> None:
         "hedged_language",
         "possible_biomarker",
     )
+    assert result.candidates[0].trusted_evidence_eligible is False
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected_reason_codes"),
+    [
+        (
+            ExtractedRelationCandidate(
+                subject_label="AKT activation",
+                relation_type="ASSOCIATED_WITH",
+                object_label="reduced survival",
+                sentence="AKT activation showed a trend toward reduced survival.",
+            ),
+            ("hedged_language", "trend_only"),
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="MED13",
+                relation_type="ASSOCIATED_WITH",
+                object_label="congenital heart disease",
+                sentence="MED13 may be linked to congenital heart disease.",
+            ),
+            ("hedged_language", "may_link"),
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="MET amplification",
+                relation_type="ASSOCIATED_WITH",
+                object_label="resistance",
+                sentence="MET amplification correlated with resistance.",
+            ),
+            ("hedged_language", "correlated_only"),
+        ),
+    ],
+)
+def test_quality_filter_keeps_weak_review_candidates_as_review_only(
+    candidate: ExtractedRelationCandidate,
+    expected_reason_codes: tuple[str, ...],
+) -> None:
+    result = filter_low_value_relation_candidates((candidate,))
+
+    assert result.filtered_candidates == ()
+    assert result.candidates[0].review_status == "review_only"
+    assert result.candidates[0].review_reason_codes == expected_reason_codes
+    assert result.candidates[0].trusted_evidence_eligible is False
+
+
+def test_quality_filter_keeps_model_review_hint_candidate_as_review_only() -> None:
+    candidate = ExtractedRelationCandidate(
+        subject_label="MED13",
+        relation_type="ASSOCIATED_WITH",
+        object_label="congenital heart disease",
+        sentence="MED13 was associated with congenital heart disease.",
+        review_status="review_only",
+        review_reason_codes=("agent_review_hint",),
+    )
+
+    result = filter_low_value_relation_candidates((candidate,))
+
+    assert result.filtered_candidates == ()
+    assert result.candidates[0].review_status == "review_only"
+    assert result.candidates[0].review_reason_codes == ("agent_review_hint",)
     assert result.candidates[0].trusted_evidence_eligible is False
 
 

--- a/services/artana_evidence_api/tests/unit/test_review_only_candidate_policy.py
+++ b/services/artana_evidence_api/tests/unit/test_review_only_candidate_policy.py
@@ -9,29 +9,41 @@ from artana_evidence_api.document_extraction_support.review_policy.review_only_c
 
 
 @pytest.mark.parametrize(
-    ("support_sentence", "expected_reason"),
+    ("support_sentence", "expected_reasons"),
     [
         (
             "AKT activation showed a trend toward association with reduced survival.",
-            "trend_only",
+            {"hedged_language", "trend_only"},
+        ),
+        (
+            "AKT activation showed a trend toward reduced survival.",
+            {"hedged_language", "trend_only"},
         ),
         (
             "HRD score was described as a possible biomarker for platinum sensitivity.",
-            "possible_biomarker",
+            {"hedged_language", "possible_biomarker"},
         ),
         (
             "IL6 may regulate inflammatory signaling in stressed epithelial cells.",
-            "may_regulate",
+            {"hedged_language", "may_regulate"},
+        ),
+        (
+            "MED13 may be linked to congenital heart disease.",
+            {"hedged_language", "may_link"},
         ),
         (
             "MET amplification was correlated with resistance in a small cohort.",
-            "correlated_only",
+            {"hedged_language", "correlated_only"},
+        ),
+        (
+            "MET amplification correlated with resistance.",
+            {"hedged_language", "correlated_only"},
         ),
     ],
 )
 def test_hedged_relation_claims_are_review_only(
     support_sentence: str,
-    expected_reason: str,
+    expected_reasons: set[str],
 ) -> None:
     decision = classify_review_only_candidate(
         relation_type="ASSOCIATED_WITH",
@@ -40,8 +52,7 @@ def test_hedged_relation_claims_are_review_only(
     )
 
     assert decision.review_only is True
-    assert expected_reason in decision.reason_codes
-    assert "hedged_language" in decision.reason_codes
+    assert set(decision.reason_codes) == expected_reasons
     assert decision.trusted_promotion_allowed is False
 
 
@@ -55,3 +66,28 @@ def test_direct_relation_claims_remain_trusted_candidate_by_policy() -> None:
     assert decision.review_only is False
     assert decision.reason_codes == ()
     assert decision.trusted_promotion_allowed is True
+
+
+def test_weak_cues_are_scoped_to_candidate_arguments() -> None:
+    sentence = (
+        "BRCA1 activates EGFR, while MED13 may be linked to congenital heart "
+        "disease."
+    )
+
+    strong_decision = classify_review_only_candidate(
+        relation_type="ACTIVATES",
+        support_sentence=sentence,
+        subject_label="BRCA1",
+        object_label="EGFR",
+    )
+    weak_decision = classify_review_only_candidate(
+        relation_type="ASSOCIATED_WITH",
+        support_sentence=sentence,
+        subject_label="MED13",
+        object_label="congenital heart disease",
+    )
+
+    assert strong_decision.review_only is False
+    assert strong_decision.reason_codes == ()
+    assert weak_decision.review_only is True
+    assert set(weak_decision.reason_codes) == {"hedged_language", "may_link"}

--- a/tests/unit/test_relation_feasibility_audit.py
+++ b/tests/unit/test_relation_feasibility_audit.py
@@ -899,17 +899,26 @@ def test_low_value_review_metrics_require_review_only_candidate() -> None:
         ),
     )
 
-    def extractor(_: str) -> list[ExtractedRelation]:
-        return [
-            ExtractedRelation(
-                subject="MED13",
-                relation_type="PROPOSE_NEW_RELATION_TYPE",
-                proposed_relation_type="WEAKLY_LINKED_TO",
-                relation_governance_status="requires_relation_review",
-                object="clinical features",
-                sentence="MED13 had a weak exploratory connection to clinical features.",
+    def extractor(_: str) -> RelationExtractionResult:
+        return RelationExtractionResult(
+            relations=(
+                ExtractedRelation(
+                    subject="MED13",
+                    relation_type="PROPOSE_NEW_RELATION_TYPE",
+                    proposed_relation_type="WEAKLY_LINKED_TO",
+                    relation_governance_status="requires_relation_review",
+                    object="clinical features",
+                    sentence=(
+                        "MED13 had a weak exploratory connection to clinical features."
+                    ),
+                ),
             ),
-        ]
+            trace=ExtractionTrace(
+                extractor_mode="agent",
+                llm_candidate_status="completed",
+                llm_candidate_count=1,
+            ),
+        )
 
     report = run_feasibility_audit(cases=cases, extractor=extractor)
 
@@ -942,22 +951,29 @@ def test_low_value_review_metrics_count_review_only_canonical_candidate() -> Non
         ),
     )
 
-    def extractor(_: str) -> list[ExtractedRelation]:
-        return [
-            ExtractedRelation(
-                subject="IL6",
-                relation_type="REGULATES",
-                object="inflammatory signaling",
-                sentence=(
-                    "IL6 may regulate inflammatory signaling in stressed "
-                    "epithelial cells."
+    def extractor(_: str) -> RelationExtractionResult:
+        return RelationExtractionResult(
+            relations=(
+                ExtractedRelation(
+                    subject="IL6",
+                    relation_type="REGULATES",
+                    object="inflammatory signaling",
+                    sentence=(
+                        "IL6 may regulate inflammatory signaling in stressed "
+                        "epithelial cells."
+                    ),
+                    subject_curie="HGNC:6018",
+                    subject_curie_source="verified_linker",
+                    review_status="review_only",
+                    review_reason_codes=("hedged_language", "may_regulate"),
                 ),
-                subject_curie="HGNC:6018",
-                subject_curie_source="verified_linker",
-                review_status="review_only",
-                review_reason_codes=("hedged_language", "may_regulate"),
             ),
-        ]
+            trace=ExtractionTrace(
+                extractor_mode="agent",
+                llm_candidate_status="completed",
+                llm_candidate_count=1,
+            ),
+        )
 
     report = run_feasibility_audit(cases=cases, extractor=extractor)
     assessment = report.case_results[0].candidate_assessments[0]
@@ -973,6 +989,228 @@ def test_low_value_review_metrics_count_review_only_canonical_candidate() -> Non
     assert report.summary.low_value_review_gold_match_count == 1
     assert report.summary.low_value_review_recall == 1.0
     assert "Low-value review candidates: 1" in markdown
+
+
+def test_low_value_review_metrics_ignore_fallback_review_only_candidates() -> None:
+    cases = (
+        _case(
+            case_id="fallback_low_value_review",
+            text="MED13 may be linked to congenital heart disease.",
+            gold=(
+                GoldRelation(
+                    subject="MED13",
+                    relation_type="ASSOCIATED_WITH",
+                    object="congenital heart disease",
+                    support_sentence=(
+                        "MED13 may be linked to congenital heart disease."
+                    ),
+                    value_level="low",
+                    rationale="Fallback review-only output is not agent evidence.",
+                    requires_entailment=False,
+                ),
+            ),
+        ),
+    )
+
+    def extractor(_: str) -> RelationExtractionResult:
+        return RelationExtractionResult(
+            relations=(
+                ExtractedRelation(
+                    subject="MED13",
+                    relation_type="ASSOCIATED_WITH",
+                    object="congenital heart disease",
+                    sentence="MED13 may be linked to congenital heart disease.",
+                    review_status="review_only",
+                    review_reason_codes=("hedged_language", "may_link"),
+                ),
+            ),
+            trace=ExtractionTrace(
+                extractor_mode="agent",
+                llm_candidate_status="fallback_error",
+                fallback_candidate_count=1,
+            ),
+        )
+
+    report = run_feasibility_audit(cases=cases, extractor=extractor)
+
+    assert report.summary.fallback_case_count == 1
+    assert report.summary.low_value_review_candidate_count == 0
+    assert report.summary.low_value_review_gold_match_count == 0
+    assert report.summary.low_value_review_recall == 0.0
+
+
+def test_low_value_review_recall_captures_pr23_weak_cases_without_trust_leakage() -> None:
+    cases = (
+        _case(
+            case_id="trusted_high_value_anchor",
+            text="MED13 activates MAPK signaling.",
+            gold=(
+                GoldRelation(
+                    subject="MED13",
+                    relation_type="ACTIVATES",
+                    object="MAPK signaling",
+                    support_sentence="MED13 activates MAPK signaling.",
+                    value_level="high",
+                    rationale="High-value trusted mechanism anchor.",
+                    subject_curie="HGNC:22474",
+                    object_curie="GO:0000165",
+                ),
+            ),
+        ),
+        _case(
+            case_id="weak_med13_may_link_chd",
+            text="MED13 may be linked to congenital heart disease in a subset of families.",
+            gold=(
+                GoldRelation(
+                    subject="MED13",
+                    relation_type="ASSOCIATED_WITH",
+                    object="congenital heart disease",
+                    support_sentence=(
+                        "MED13 may be linked to congenital heart disease in a "
+                        "subset of families."
+                    ),
+                    value_level="low",
+                    rationale="Hedged association belongs in review lane.",
+                    subject_curie="HGNC:22474",
+                    object_curie="MONDO:0005267",
+                    requires_entailment=False,
+                ),
+            ),
+        ),
+        _case(
+            case_id="weak_met_correlated_resistance",
+            text=(
+                "MET amplification was correlated with resistance in a small "
+                "exploratory cohort."
+            ),
+            gold=(
+                GoldRelation(
+                    subject="MET amplification",
+                    relation_type="ASSOCIATED_WITH",
+                    object="resistance",
+                    support_sentence=(
+                        "MET amplification was correlated with resistance in a "
+                        "small exploratory cohort."
+                    ),
+                    value_level="low",
+                    rationale="Exploratory correlation belongs in review lane.",
+                    subject_curie="HGNC:7029",
+                    requires_entailment=False,
+                ),
+            ),
+        ),
+        _case(
+            case_id="weak_akt_trend_survival",
+            text="AKT activation showed a trend toward association with reduced survival.",
+            gold=(
+                GoldRelation(
+                    subject="AKT activation",
+                    relation_type="ASSOCIATED_WITH",
+                    object="reduced survival",
+                    support_sentence=(
+                        "AKT activation showed a trend toward association with "
+                        "reduced survival."
+                    ),
+                    value_level="low",
+                    rationale="Trend language belongs in review lane.",
+                    subject_curie="HGNC:391",
+                    requires_entailment=False,
+                ),
+            ),
+        ),
+    )
+
+    def agent_result(relation: ExtractedRelation) -> RelationExtractionResult:
+        return RelationExtractionResult(
+            relations=(relation,),
+            trace=ExtractionTrace(
+                extractor_mode="agent",
+                llm_candidate_status="completed",
+                llm_candidate_count=1,
+            ),
+        )
+
+    def extractor(text: str) -> RelationExtractionResult:
+        if "MED13 activates" in text:
+            return agent_result(
+                ExtractedRelation(
+                    subject="MED13",
+                    relation_type="ACTIVATES",
+                    object="MAPK signaling",
+                    sentence="MED13 activates MAPK signaling.",
+                    subject_curie="HGNC:22474",
+                    subject_curie_source="verified_linker",
+                    object_curie="GO:0000165",
+                    object_curie_source="verified_linker",
+                ),
+            )
+        if "may be linked" in text:
+            return agent_result(
+                ExtractedRelation(
+                    subject="MED13",
+                    relation_type="ASSOCIATED_WITH",
+                    object="congenital heart disease",
+                    sentence=(
+                        "MED13 may be linked to congenital heart disease in a "
+                        "subset of families."
+                    ),
+                    subject_curie="HGNC:22474",
+                    subject_curie_source="verified_linker",
+                    object_curie="MONDO:0005267",
+                    object_curie_source="verified_linker",
+                    review_status="review_only",
+                    review_reason_codes=("hedged_language", "may_link"),
+                ),
+            )
+        if "MET amplification" in text:
+            return agent_result(
+                ExtractedRelation(
+                    subject="MET amplification",
+                    relation_type="ASSOCIATED_WITH",
+                    object="resistance",
+                    sentence=(
+                        "MET amplification was correlated with resistance in a "
+                        "small exploratory cohort."
+                    ),
+                    subject_curie="HGNC:7029",
+                    subject_curie_source="verified_linker",
+                    review_status="review_only",
+                    review_reason_codes=("hedged_language", "correlated_only"),
+                ),
+            )
+        return agent_result(
+            ExtractedRelation(
+                subject="AKT activation",
+                relation_type="ASSOCIATED_WITH",
+                object="reduced survival",
+                sentence=(
+                    "AKT activation showed a trend toward association with "
+                    "reduced survival."
+                ),
+                subject_curie="HGNC:391",
+                subject_curie_source="verified_linker",
+                review_status="review_only",
+                review_reason_codes=("hedged_language", "trend_only"),
+            ),
+        )
+
+    report = run_feasibility_audit(cases=cases, extractor=extractor)
+    low_value_flags = {
+        result.case.case_id: result.candidate_assessments[0].quality_flags
+        for result in report.case_results
+        if result.case.case_id.startswith("weak_")
+    }
+
+    assert report.summary.low_value_review_recall >= 0.8
+    assert report.summary.weak_claim_trusted_leakage_count == 0
+    assert report.summary.trusted_high_value_recall >= 0.85
+    assert report.summary.precision_against_gold == 1.0
+    assert "review_only_candidate" in low_value_flags["weak_med13_may_link_chd"]
+    assert "review_reason:may_link" in low_value_flags["weak_med13_may_link_chd"]
+    assert "review_reason:correlated_only" in low_value_flags[
+        "weak_met_correlated_resistance"
+    ]
+    assert "review_reason:trend_only" in low_value_flags["weak_akt_trend_survival"]
 
 
 def test_endpoint_metrics_split_trusted_eligible_from_low_value_review() -> None:
@@ -1011,34 +1249,43 @@ def test_endpoint_metrics_split_trusted_eligible_from_low_value_review() -> None
         ),
     )
 
-    def extractor(text: str) -> list[ExtractedRelation]:
+    def extractor(text: str) -> RelationExtractionResult:
         if "IL6" in text:
-            return [
+            relations = (
                 ExtractedRelation(
-                    subject="IL6",
-                    relation_type="REGULATES",
-                    object="inflammatory signaling",
-                    sentence="IL6 may regulate inflammatory signaling.",
-                    subject_curie="HGNC:6018",
-                    subject_curie_source="verified_linker",
-                    object_curie="GO:0006954",
-                    object_curie_source="verified_linker",
-                    review_status="review_only",
-                    review_reason_codes=("hedged_language", "may_regulate"),
+                        subject="IL6",
+                        relation_type="REGULATES",
+                        object="inflammatory signaling",
+                        sentence="IL6 may regulate inflammatory signaling.",
+                        subject_curie="HGNC:6018",
+                        subject_curie_source="verified_linker",
+                        object_curie="GO:0006954",
+                        object_curie_source="verified_linker",
+                        review_status="review_only",
+                        review_reason_codes=("hedged_language", "may_regulate"),
                 ),
-            ]
-        return [
-            ExtractedRelation(
-                subject="MED13",
-                relation_type="ACTIVATES",
-                object="MAPK signaling",
-                sentence="MED13 activates MAPK signaling.",
-                subject_curie="HGNC:22474",
-                subject_curie_source="verified_linker",
-                object_curie="GO:0000165",
-                object_curie_source="verified_linker",
+            )
+        else:
+            relations = (
+                ExtractedRelation(
+                    subject="MED13",
+                    relation_type="ACTIVATES",
+                    object="MAPK signaling",
+                    sentence="MED13 activates MAPK signaling.",
+                    subject_curie="HGNC:22474",
+                    subject_curie_source="verified_linker",
+                    object_curie="GO:0000165",
+                    object_curie_source="verified_linker",
+                ),
+            )
+        return RelationExtractionResult(
+            relations=relations,
+            trace=ExtractionTrace(
+                extractor_mode="agent",
+                llm_candidate_status="completed",
+                llm_candidate_count=len(relations),
             ),
-        ]
+        )
 
     report = run_feasibility_audit(cases=cases, extractor=extractor)
     summary_json = report.summary.to_json()
@@ -1122,21 +1369,35 @@ def test_verdict_uses_trusted_eligible_endpoint_rate_not_all_gold_rate() -> None
         ),
     )
 
-    def extractor(text: str) -> list[ExtractedRelation]:
+    def extractor(text: str) -> RelationExtractionResult:
         if "MED13" not in text:
-            return []
-        return [
-            ExtractedRelation(
-                subject="MED13",
-                relation_type="ACTIVATES",
-                object="MAPK signaling",
-                sentence="MED13 activates MAPK signaling.",
-                subject_curie="HGNC:22474",
-                subject_curie_source="verified_linker",
-                object_curie="GO:0000165",
-                object_curie_source="verified_linker",
+            return RelationExtractionResult(
+                relations=(),
+                trace=ExtractionTrace(
+                    extractor_mode="agent",
+                    llm_candidate_status="completed",
+                    llm_candidate_count=0,
+                ),
+            )
+        return RelationExtractionResult(
+            relations=(
+                ExtractedRelation(
+                    subject="MED13",
+                    relation_type="ACTIVATES",
+                    object="MAPK signaling",
+                    sentence="MED13 activates MAPK signaling.",
+                    subject_curie="HGNC:22474",
+                    subject_curie_source="verified_linker",
+                    object_curie="GO:0000165",
+                    object_curie_source="verified_linker",
+                ),
             ),
-        ]
+            trace=ExtractionTrace(
+                extractor_mode="agent",
+                llm_candidate_status="completed",
+                llm_candidate_count=1,
+            ),
+        )
 
     report = run_feasibility_audit(cases=cases, extractor=extractor)
 


### PR DESCRIPTION
## Summary

- add a weak-review live-agent extraction pass that is forced to review-only by code
- scope weak-cue policy to the candidate arguments so weak wording cannot downgrade unrelated strong claims
- drop weak-pass raw relation types/proposals before governance and require completed-agent cases for low-value review metric credit
- document PR23 run7 evidence in the validation tracker and PR summary

## Validation

- `uv run --python python3.13 --with ruff ruff check ...touched files...`
- `PYTHONPATH="$(pwd)/services:$(pwd)" .venv/bin/python3 -m pytest ...affected PR23 suites... -q`
- `make relation-feasibility-quality-gate`
- strict live-agent audit artifact: `reports/relation_feasibility/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_report.md`
- failure attribution artifact: `reports/relation_feasibility_failure_analysis/2026-07-05-pr23-low-value-review-recall-run7/relation_feasibility_failure_analysis_report.md`
- `make service-checks` with coverage 87.03% against the 86% gate
- `uv run --python python3.13 --with pre-commit pre-commit run --all-files`
- `git diff --check`

## Live-Agent Result

- verdict: GREEN
- completed-agent precision/recall: 1.0000 / 1.0000
- high-value recall: 1.0000
- low-value review recall: 1.0000
- weak-claim trusted leakage: 0
- fallback cases: 0
- invalid strict-agent cases: 0
- missed gold relations: 0
- false positives: 0

## Remaining Risk

This does not complete final trusted-graph readiness. Repeatability, generic review-lane noise, endpoint grounding for broad labels, and graph-side independent promotion enforcement remain follow-up work.
