### PR TITLE
PR24: add endpoint grounding decision table

### DIFF
--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -142,6 +142,7 @@ Status values:
 | 10 | PR-21 | `alvaro/evidence-pr21-verified-grounding-closure` | Implemented locally; adversarial blockers fixed; strict gate RED | Improve verified grounding and review-only abstention without trusting raw model hints. | Trusted high-value recall >= 0.8500 and wrong verified CURIE links remain 0. | Grounding dictionary split, verified process labels, review-only broad/composite labels, verified-linker spoof regression, safe relation-alias scoring, missed-gold CURIE attribution, focused tests, relation-feasibility gate, strict live run3 with precision 1.0000, high-value recall 1.0000, trusted high-value recall 0.8500, verified endpoint rate 0.8810, false positives 0, fallback 0. Overall readiness remains RED. |
 | 11 | PR-22 | `alvaro/evidence-pr22-low-value-review-lane` | Implemented locally; strict single-run GREEN; repeatability pending | Split trusted-eligible endpoint recovery from low-value review evidence. | Trusted-eligible CURIE-linked endpoint rate >= 0.9500 and weak-claim trusted leakage remains 0. | Review-only candidate policy, review status propagation, `review_only_candidate` trust floor, promotion metadata protection, trusted/review endpoint metric split, single-run verdict contract fix, scoring/readiness helper refactor, focused tests, direct touched-file ruff, relation-feasibility gate, strict live run4 with verdict GREEN, precision 1.0000, high-value recall 1.0000, trusted endpoint rate 1.0000, weak leakage 0, fallback 0. Low-value review recall remains 0.4000 and final readiness still needs repeated runs. |
 | 12 | PR-23 | `alvaro/evidence-pr23-low-value-review-recall` | Draft PR #106 open; GitHub CI clean | Recover weak-but-useful low-value review evidence through the live agent path without deterministic fallback. | Low-value review recall >= 0.8000 and weak-claim trusted leakage remains 0. | Weak-review agent pass, weak-pass prompt/schema versioning, code-forced review-only metadata, policy-backed weak-pass keep filter, candidate-argument scoped weak-cue policy, raw weak-pass relation-type/proposal drop, review-only pruning preservation, fallback-gated review metrics, sensitization prompt repair, focused RED/GREEN tests, relation-feasibility gate, strict live run7 with verdict GREEN, precision 1.0000, low-value review recall 1.0000, high-value recall 1.0000, trusted endpoint rate 1.0000, false positives 0, missed gold 0, weak leakage 0, fallback 0, invalid agent 0, `make service-checks` with coverage 87.03%, and PR #106 GitHub checks passing. Repeatability remains pending. |
+| 13 | PR-24 | `alvaro/evidence-pr24-grounding-decision-table` | Implemented locally; final gates pending | Give every remaining endpoint gap a safe verified or review-only grounding decision without trusting model hints. | All remaining CURIE gaps have explicit review-only decision metadata and wrong verified CURIE links remain 0. | Review-only grounding decision metadata, eight-label endpoint policy table, review-only-before-verified collision handling, link metadata for `grounding_reason_code`, failure-analysis `review_only_endpoint` rows, guarded primary LLM schema for raw relation-type cleanup, focused RED/GREEN tests, relation-feasibility gate, and strict live run3 with verdict GREEN, precision 0.9615, recall 1.0000, trusted endpoint rate 1.0000, verified CURIE match rate 1.0000, one review-only false positive, missed gold 0, fallback 0, invalid agent 0, wrong verified CURIE links 0. Repeatability and generic relation rate 0.1154 remain follow-up work. |
 
 ## PR Evidence Packet
 
@@ -202,6 +203,75 @@ Run only the service checks relevant to the changed boundary, then run the
 aggregate gate before merge when the PR is ready.
 
 ## Evidence Log
+
+### 2026-07-06 - PR-24 Grounding Decision Table
+
+PR: PR-24 grounding decision table
+
+Branch: `alvaro/evidence-pr24-grounding-decision-table`
+
+Goal: Make every remaining endpoint-grounding gap either safely verified or
+explicitly review-only, with model hints unable to create trusted identifiers
+for broad or composite labels.
+
+Evidence:
+
+- `docs/validation/reports/2026-07-06-pr24-grounding-decision-table-summary.md`
+- `reports/relation_feasibility/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_report.md`
+- `reports/relation_feasibility_failure_analysis/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_failure_analysis_report.json`
+- `reports/relation_feasibility_failure_analysis/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_failure_analysis_report.md`
+
+Final strict live-agent metrics:
+
+| Metric | Value |
+|---|---:|
+| Verdict | GREEN |
+| Completed-agent precision | 0.9615 |
+| Completed-agent recall | 1.0000 |
+| Completed-agent valuable rate | 0.7692 |
+| High-value recall | 1.0000 |
+| Trusted high-value recall | 0.8500 |
+| Low-value review recall | 1.0000 |
+| Trusted-eligible CURIE-linked endpoint rate | 1.0000 |
+| Verified CURIE match rate | 1.0000 |
+| Weak-claim trusted leakage count | 0 |
+| Fallback cases | 0 |
+| Invalid strict-agent cases | 0 |
+| Wrong verified CURIE links | 0 |
+| Missed gold relations | 0 |
+| False positives | 1 safe review-only candidate |
+| Generic relation rate | 0.1154 |
+
+Failure attribution:
+
+- All eight remaining endpoint gaps are `review_only_endpoint` rows with
+  explicit `grounding_reason_code`, `review_only_for_relation_feasibility_v2`,
+  and `trusted_identifier_allowed=False`.
+- The only false positive in run3 is `cisplatin TREATS platinum-sensitive
+  tumors`; it is `review_only`, has no trusted object CURIE, and carries
+  `context_dependent` plus `subset_relation` review reasons.
+- Generic relation rate remains `0.1154`, above the trusted-graph target, and
+  stays a follow-up blocker.
+
+Validation:
+
+- Focused RED/GREEN grounding decision tests passed.
+- Affected grounding/linking/failure-analysis suites passed.
+- Affected document extraction suites passed.
+- `make relation-feasibility-quality-gate` passed.
+- Strict live-agent run1 passed with fallback 0 and invalid agent 0.
+- Strict live-agent run2 exposed a primary-pass raw relation type crash; PR24
+  now routes primary LLM output through the code-owned unknown-type guard.
+- Strict live-agent run3 passed with fallback 0, invalid agent 0, and wrong
+  verified CURIE links 0.
+
+Known remaining risk:
+
+- This is still single-run evidence.
+- Review-only endpoint policy intentionally abstains rather than inventing broad
+  CURIEs; final readiness still requires repeatability and graph-side
+  promotion enforcement.
 
 ### 2026-07-05 - PR-23 Low-Value Review Recall
 

--- a/docs/validation/reports/2026-07-06-pr24-grounding-decision-table-summary.md
+++ b/docs/validation/reports/2026-07-06-pr24-grounding-decision-table-summary.md
@@ -1,0 +1,162 @@
+# PR-24 Grounding Decision Table
+
+Date: 2026-07-06
+
+Branch: `alvaro/evidence-pr24-grounding-decision-table`
+
+Base branch: `alvaro/evidence-pr23-low-value-review-recall`
+
+Commit: see PR head commit
+
+## Goal
+
+PR-24 makes the remaining endpoint-grounding gaps explicit policy decisions.
+Broad, composite, event-like, treatment-response, score, prognosis, and generic
+resistance labels must not become trusted identifiers just because a model
+suggested a plausible CURIE.
+
+## What Changed
+
+- Added explicit review-only decision metadata to `ReviewOnlyEntityRecord`.
+- Expanded the local grounding decision table for all remaining PR23 gap labels:
+  `aggressive tumor growth`, `ERK phosphorylation`, `response to pembrolizumab`,
+  `HRD score`, `platinum sensitivity`, `inflammatory signaling`,
+  `reduced survival`, and `resistance`.
+- Added link metadata for review-only endpoint abstentions:
+  `grounding_curation_status`, `grounding_reason_code`, and
+  `trusted_identifier_allowed`.
+- Updated failure attribution so curated review-only endpoints appear as
+  `review_only_endpoint` with the grounding decision, not as accidental missing
+  CURIEs or trusted model hints.
+- Made review-only grounding decisions take precedence over verified aliases so
+  composite labels such as `resistance to gefitinib` cannot become trusted drug
+  identifiers through an alias collision.
+- Added a guarded primary LLM output schema so raw relation types from the live
+  agent, such as `CASES`, reach the code-owned resolver/drop path instead of
+  crashing schema validation before safeguards run.
+
+## Validation Commands
+
+Focused RED/GREEN tests:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py::test_review_only_dictionary_has_explicit_decisions_for_pr24_endpoint_gaps \
+  services/artana_evidence_api/tests/unit/test_entity_curie_linking.py::test_review_only_grounding_metadata_explains_policy_decision \
+  tests/unit/test_relation_feasibility_failure_analysis.py::test_failure_analysis_reports_review_only_grounding_decision \
+  -q
+```
+
+Affected grounding and attribution suites:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py \
+  services/artana_evidence_api/tests/unit/test_entity_curie_linking.py \
+  tests/unit/test_relation_feasibility_failure_analysis.py \
+  -q
+```
+
+Relation feasibility quality gate:
+
+```bash
+make relation-feasibility-quality-gate
+```
+
+Initial strict live-agent audit:
+
+```bash
+bash -lc 'set -a; source .env.postgres; set +a; \
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-06-pr24-grounding-decision-table-run1'
+```
+
+Final strict live-agent audit after adversarial fixes:
+
+```bash
+bash -lc 'set -a; source .env.postgres; set +a; \
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/2026-07-06-pr24-grounding-decision-table-run3'
+```
+
+Final failure attribution:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/summarize_relation_readiness_failures.py \
+  --report current=reports/relation_feasibility/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_report.json \
+  --output-dir reports/relation_feasibility_failure_analysis/2026-07-06-pr24-grounding-decision-table-run3
+```
+
+## Live-Agent Result
+
+Source artifacts:
+
+- `reports/relation_feasibility/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_report.md`
+- `reports/relation_feasibility_failure_analysis/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_failure_analysis_report.json`
+- `reports/relation_feasibility_failure_analysis/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_failure_analysis_report.md`
+
+| Metric | PR24 run3 |
+|---|---:|
+| Verdict | GREEN |
+| Completed-agent precision | 0.9615 |
+| Completed-agent recall | 1.0000 |
+| Completed-agent valuable rate | 0.7692 |
+| High-value recall | 1.0000 |
+| Trusted high-value recall | 0.8500 |
+| Low-value review recall | 1.0000 |
+| Trusted-eligible CURIE-linked endpoint rate | 1.0000 |
+| Verified CURIE match rate | 1.0000 |
+| Weak-claim trusted leakage count | 0 |
+| Fallback cases | 0 |
+| Invalid strict-agent cases | 0 |
+| Wrong verified CURIE links | 0 |
+| Missed gold relations | 0 |
+| False positives | 1 review-only candidate |
+| Generic relation rate | 0.1154 |
+
+## Endpoint Decisions
+
+Final failure attribution reports no missed gold relations. It reports one false
+positive, `cisplatin TREATS platinum-sensitive tumors`; the candidate is
+`review_only`, has no trusted object CURIE, and carries `context_dependent` plus
+`subset_relation` reasons. All eight remaining endpoint gaps are intentional
+review-only grounding decisions:
+
+| Label | Decision | Reason |
+|---|---|---|
+| `aggressive tumor growth` | review-only | `composite_event_label` |
+| `ERK phosphorylation` | review-only | `broad_process_label` |
+| `response to pembrolizumab` | review-only | `composite_treatment_response_label` |
+| `reduced survival` | review-only | `prognosis_outcome_label` |
+| `HRD score` | review-only | `biomarker_score_label` |
+| `platinum sensitivity` | review-only | `drug_response_phenotype_label` |
+| `inflammatory signaling` | review-only | `broad_process_label` |
+| `resistance` | review-only | `generic_resistance_label` |
+
+Each row has `trusted_identifier_allowed=False`.
+
+## Artifact Hashes
+
+| Artifact | SHA-256 |
+|---|---|
+| relation feasibility JSON | `c27caea9764d72d046f0de047d1812bc2dadbbcb27cc2c9ac5317eafd266b79d` |
+| relation feasibility Markdown | `8b2d8ab8f6fee81206bd864f035997e71a07f10bdba1f53ff9328fa2e3f13b8f` |
+| failure analysis JSON | `459bab353528067abf897d2fbbfa16f674eb7ad17f5f75cc0d39c5696c2372d2` |
+| failure analysis Markdown | `b410e9ded43c8ea634a981368fd629daaf5e7b78e910602087d3c576f3076e87` |
+
+## Interpretation
+
+PR-24 does not claim final trusted-graph readiness. It closes the endpoint
+grounding decision-table gap by making unsafe labels explicit review-only
+abstentions while preserving the live-agent trusted-lane metrics. It also fixes
+the live primary-pass raw-relation crash exposed by run2. The remaining
+trusted-readiness work is repeatability, generic and review-lane noise,
+graph-side promotion enforcement, and broader benchmark proof.

--- a/scripts/validation/relation_feasibility/failure_analysis.py
+++ b/scripts/validation/relation_feasibility/failure_analysis.py
@@ -7,6 +7,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from artana_evidence_api.document_extraction_support.entity_grounding.verified_dictionary import (
+    review_only_record_for_label,
+)
+
 JSONObject = dict[str, object]
 _METRIC_KEYS = (
     "completed_agent_precision_against_gold",
@@ -64,6 +68,9 @@ class _CurieGapKey:
     candidate_curie: str | None
     candidate_curie_source: str
     gap_type: str
+    grounding_curation_status: str | None
+    grounding_reason_code: str | None
+    trusted_identifier_allowed: bool | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -242,6 +249,9 @@ def render_failure_analysis_markdown(report: JSONObject) -> str:
                 "label",
                 "candidate_curie",
                 "candidate_curie_source",
+                "grounding_reason_code",
+                "grounding_curation_status",
+                "trusted_identifier_allowed",
             ),
         ),
     )
@@ -411,16 +421,31 @@ def _collect_curie_gap(
         return
     curie = _optional_string(candidate.get(f"{role}_curie"))
     curie_source = _string_value(candidate.get(f"{role}_curie_source")) or "none"
+    label = _string_value(candidate.get(role))
+    review_record = review_only_record_for_label(label)
+    has_verified_curie = _bool_value(assessment.get(verified_key))
     key = _CurieGapKey(
         case_id=context.case_id,
         endpoint_role=role,
-        label=_string_value(candidate.get(role)),
+        label=label,
         candidate_curie=curie,
         candidate_curie_source=curie_source,
         gap_type=_curie_gap_type(
             curie=curie,
             curie_source=curie_source,
-            has_verified_curie=_bool_value(assessment.get(verified_key)),
+            has_verified_curie=has_verified_curie,
+            has_review_only_policy=review_record is not None,
+        ),
+        grounding_curation_status=(
+            review_record.curation_status if review_record is not None else None
+        ),
+        grounding_reason_code=(
+            review_record.reason_code if review_record is not None else None
+        ),
+        trusted_identifier_allowed=(
+            review_record.trusted_identifier_allowed
+            if review_record is not None
+            else None
         ),
     )
     _add_occurrence(curie_gaps, key, context.run_label)
@@ -431,9 +456,12 @@ def _curie_gap_type(
     curie: str | None,
     curie_source: str,
     has_verified_curie: bool,
+    has_review_only_policy: bool,
 ) -> str:
     if has_verified_curie:
         return "wrong_verified_match"
+    if has_review_only_policy:
+        return "review_only_endpoint"
     if curie is None:
         return "missing_curie"
     if curie_source == "model":
@@ -502,18 +530,23 @@ def _missed_gold_curie_endpoint_rows(
 def _curie_gap_rows(curie_gaps: dict[_CurieGapKey, _Accumulator]) -> list[JSONObject]:
     rows: list[JSONObject] = []
     for key, accumulator in curie_gaps.items():
-        rows.append(
-            {
-                "case_id": key.case_id,
-                "endpoint_role": key.endpoint_role,
-                "label": key.label,
-                "candidate_curie": key.candidate_curie,
-                "candidate_curie_source": key.candidate_curie_source,
-                "gap_type": key.gap_type,
-                "occurrence_count": accumulator.count,
-                "run_labels": sorted(accumulator.run_labels),
-            },
-        )
+        row: JSONObject = {
+            "case_id": key.case_id,
+            "endpoint_role": key.endpoint_role,
+            "label": key.label,
+            "candidate_curie": key.candidate_curie,
+            "candidate_curie_source": key.candidate_curie_source,
+            "gap_type": key.gap_type,
+            "occurrence_count": accumulator.count,
+            "run_labels": sorted(accumulator.run_labels),
+        }
+        if key.grounding_curation_status is not None:
+            row["grounding_curation_status"] = key.grounding_curation_status
+        if key.grounding_reason_code is not None:
+            row["grounding_reason_code"] = key.grounding_reason_code
+        if key.trusted_identifier_allowed is not None:
+            row["trusted_identifier_allowed"] = key.trusted_identifier_allowed
+        rows.append(row)
     return _sort_rows(rows)
 
 

--- a/services/artana_evidence_api/document_extraction.py
+++ b/services/artana_evidence_api/document_extraction.py
@@ -46,6 +46,7 @@ from artana_evidence_api.document_extraction_entities import (
 from artana_evidence_api.document_extraction_prompting import (
     DOCUMENT_PROPOSAL_REVIEW_SYSTEM_PROMPT,
     build_llm_extraction_output_schema,
+    build_llm_guarded_extraction_output_schema,
     build_llm_weak_review_extraction_output_schema,
     build_proposal_review_output_schema,
 )
@@ -476,7 +477,7 @@ async def extract_relation_candidates_with_llm(
             pruned_generic_relation_count=0,
         )
     document_fingerprint = llm_extraction_document_fingerprint(normalized_text)
-    output_schema = build_llm_extraction_output_schema(max_relations)
+    output_schema = build_llm_guarded_extraction_output_schema(max_relations)
     weak_review_output_schema = build_llm_weak_review_extraction_output_schema(
         max_relations,
     )

--- a/services/artana_evidence_api/document_extraction_prompting.py
+++ b/services/artana_evidence_api/document_extraction_prompting.py
@@ -26,6 +26,15 @@ def build_llm_extraction_output_schema(max_relations: int) -> type[BaseModel]:
     )
 
 
+def build_llm_guarded_extraction_output_schema(max_relations: int) -> type[BaseModel]:
+    """Build a primary extraction schema that lets code guard raw relation types."""
+
+    return _build_llm_extraction_output_schema(
+        max_relations=max_relations,
+        strict_relation_type=False,
+    )
+
+
 def build_llm_weak_review_extraction_output_schema(
     max_relations: int,
 ) -> type[BaseModel]:
@@ -329,5 +338,7 @@ __all__ = [
     "DOCUMENT_PROPOSAL_REVIEW_SYSTEM_PROMPT",
     "LLM_EXTRACTION_SYSTEM_PROMPT",
     "build_llm_extraction_output_schema",
+    "build_llm_guarded_extraction_output_schema",
+    "build_llm_weak_review_extraction_output_schema",
     "build_proposal_review_output_schema",
 ]

--- a/services/artana_evidence_api/document_extraction_support/entity_curie_linking.py
+++ b/services/artana_evidence_api/document_extraction_support/entity_curie_linking.py
@@ -46,6 +46,9 @@ class EntityCurieLink:
     entity_type: str | None = None
     source: CurieSource = "none"
     reason: str | None = None
+    grounding_curation_status: str | None = None
+    grounding_reason_code: str | None = None
+    trusted_identifier_allowed: bool | None = None
     model_hint_curie: str | None = None
     model_hint_status: ModelHintStatus | None = None
 
@@ -75,8 +78,14 @@ class EntityCurieLink:
         payload["trusted_identifier"] = (
             self.status == "linked" and self.source == "verified_linker"
         )
+        if self.trusted_identifier_allowed is not None:
+            payload["trusted_identifier_allowed"] = self.trusted_identifier_allowed
         if self.reason is not None:
             payload["reason"] = self.reason
+        if self.grounding_curation_status is not None:
+            payload["grounding_curation_status"] = self.grounding_curation_status
+        if self.grounding_reason_code is not None:
+            payload["grounding_reason_code"] = self.grounding_reason_code
         if self.model_hint_curie is not None:
             payload["model_hint_curie"] = self.model_hint_curie
         if self.model_hint_status is not None:
@@ -92,6 +101,11 @@ def normalize_entity_curie(
 ) -> EntityCurieLink:
     """Normalize a model-supplied CURIE or return a typed abstention."""
 
+    if source in {"model", "verified_linker", "none"}:
+        review_record = review_only_record_for_label(label)
+        if review_record is not None:
+            return _review_only_link_from_record(review_record, raw_curie=raw_curie)
+
     if source in {"model", "verified_linker"}:
         record = verified_record_for_label(label)
         if record is not None:
@@ -99,11 +113,6 @@ def normalize_entity_curie(
                 record,
                 raw_curie=raw_curie,
             )
-
-    if source in {"model", "verified_linker", "none"}:
-        review_record = review_only_record_for_label(label)
-        if review_record is not None:
-            return _review_only_link_from_record(review_record, raw_curie=raw_curie)
 
     if source == "verified_linker":
         return _normalize_raw_curie(raw_curie, label=label, source="model")
@@ -257,6 +266,9 @@ def _review_only_link_from_record(
         status="abstained",
         source="none",
         reason=record.reason,
+        grounding_curation_status=record.curation_status,
+        grounding_reason_code=record.reason_code,
+        trusted_identifier_allowed=record.trusted_identifier_allowed,
         model_hint_curie=model_hint_curie,
         model_hint_status=model_hint_status,
     )

--- a/services/artana_evidence_api/document_extraction_support/entity_grounding/contracts.py
+++ b/services/artana_evidence_api/document_extraction_support/entity_grounding/contracts.py
@@ -43,8 +43,10 @@ class ReviewOnlyEntityRecord:
 
     label: str
     reason: str = "grounding_requires_review"
+    reason_code: str = "grounding_requires_review"
     aliases: tuple[str, ...] = ()
     curation_status: str = "review_only_for_relation_feasibility_v2"
+    trusted_identifier_allowed: bool = False
 
 
 class EntityGrounder(Protocol):

--- a/services/artana_evidence_api/document_extraction_support/entity_grounding/verified_dictionary.py
+++ b/services/artana_evidence_api/document_extraction_support/entity_grounding/verified_dictionary.py
@@ -159,7 +159,6 @@ VERIFIED_ENTITY_RECORDS: tuple[VerifiedEntityRecord, ...] = (
     VerifiedEntityRecord(
         label="gefitinib",
         curie="DrugBank:DB00317",
-        aliases=("resistance to gefitinib",),
     ),
     VerifiedEntityRecord(
         label="triple-negative breast cancer",
@@ -168,12 +167,48 @@ VERIFIED_ENTITY_RECORDS: tuple[VerifiedEntityRecord, ...] = (
 )
 
 REVIEW_ONLY_ENTITY_RECORDS: tuple[ReviewOnlyEntityRecord, ...] = (
-    ReviewOnlyEntityRecord(label="aggressive tumor growth"),
+    ReviewOnlyEntityRecord(
+        label="aggressive tumor growth",
+        reason_code="composite_event_label",
+    ),
     ReviewOnlyEntityRecord(
         label="ERK phosphorylation",
+        reason_code="broad_process_label",
         aliases=("ERK tyrosine phosphorylation",),
     ),
-    ReviewOnlyEntityRecord(label="response to pembrolizumab"),
+    ReviewOnlyEntityRecord(
+        label="response to pembrolizumab",
+        reason_code="composite_treatment_response_label",
+    ),
+    ReviewOnlyEntityRecord(
+        label="HRD score",
+        reason_code="biomarker_score_label",
+        aliases=("homologous recombination deficiency score",),
+    ),
+    ReviewOnlyEntityRecord(
+        label="platinum sensitivity",
+        reason_code="drug_response_phenotype_label",
+        aliases=("sensitivity to platinum",),
+    ),
+    ReviewOnlyEntityRecord(
+        label="inflammatory signaling",
+        reason_code="broad_process_label",
+        aliases=("inflammation signaling",),
+    ),
+    ReviewOnlyEntityRecord(
+        label="reduced survival",
+        reason_code="prognosis_outcome_label",
+    ),
+    ReviewOnlyEntityRecord(
+        label="resistance",
+        reason_code="generic_resistance_label",
+        aliases=(
+            "drug resistance",
+            "therapy resistance",
+            "resistance to gefitinib",
+            "gefitinib resistance",
+        ),
+    ),
 )
 
 _VERIFIED_ENTITY_RECORDS_BY_LABEL: dict[str, VerifiedEntityRecord] = {

--- a/services/artana_evidence_api/tests/unit/test_document_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction.py
@@ -871,6 +871,71 @@ async def test_extract_relation_candidates_with_llm_drops_invalid_weak_pass_type
 
 
 @pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_drops_invalid_primary_pass_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts: list[str] = []
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        prompt = str(kwargs["prompt"])
+        prompts.append(prompt)
+        if "WEAK REVIEW-ONLY EXTRACTION PASS" in prompt:
+            return SimpleNamespace(output={"relations": []})
+        return SimpleNamespace(
+            output={
+                "relations": [
+                    {
+                        "subject": "MED13",
+                        "relation_type": "CASES",
+                        "object": "congenital heart disease",
+                        "sentence": "MED13 cases included congenital heart disease.",
+                    },
+                ],
+            },
+        )
+
+    monkeypatch.setattr(runtime_support, "has_configured_openai_api_key", lambda: True)
+    monkeypatch.setattr(
+        runtime_support,
+        "get_model_registry",
+        lambda: SimpleNamespace(
+            get_default_model=lambda _capability: SimpleNamespace(
+                model_id="openai:gpt-5.4-mini",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "normalize_litellm_model_id",
+        lambda model_id: model_id,
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "create_artana_postgres_store",
+        lambda: _FakeKernelStore(),
+    )
+    monkeypatch.setattr("artana.kernel.ArtanaKernel", _FakeKernel)
+    monkeypatch.setattr("artana.agent.SingleStepModelClient", _FakeSingleStepClient)
+    monkeypatch.setattr(
+        document_extraction,
+        "run_single_step_with_policy",
+        _fake_run_single_step_with_policy,
+    )
+    monkeypatch.setattr(
+        document_extraction,
+        "_graph_ai_preflight_service",
+        lambda: (_ for _ in ()).throw(RuntimeError("resolver unavailable")),
+    )
+
+    candidates = await extract_relation_candidates_with_llm(
+        "MED13 cases included congenital heart disease.",
+    )
+
+    assert len(prompts) == 2
+    assert candidates == []
+
+
+@pytest.mark.asyncio
 async def test_extract_relation_candidates_with_llm_does_not_downgrade_strong_claims(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/artana_evidence_api/tests/unit/test_entity_curie_linking.py
+++ b/services/artana_evidence_api/tests/unit/test_entity_curie_linking.py
@@ -155,6 +155,33 @@ def test_verified_linker_source_does_not_bypass_review_only_grounding() -> None:
     assert metadata["model_hint_curie"] == "DRUGBANK:DB09037"
 
 
+@pytest.mark.parametrize(
+    "label",
+    [
+        "resistance to gefitinib",
+        "gefitinib resistance",
+    ],
+)
+def test_composite_resistance_label_does_not_trust_drug_anchor_hint(
+    label: str,
+) -> None:
+    link = normalize_entity_curie(
+        "DrugBank:DB00317",
+        label=label,
+        source="model",
+    )
+
+    metadata = link.to_metadata()
+    assert link.status == "abstained"
+    assert link.curie is None
+    assert link.source == "none"
+    assert link.reason == "grounding_requires_review"
+    assert metadata["trusted_identifier"] is False
+    assert metadata["trusted_identifier_allowed"] is False
+    assert metadata["grounding_reason_code"] == "generic_resistance_label"
+    assert metadata["model_hint_curie"] == "DRUGBANK:DB00317"
+
+
 def test_unknown_verified_linker_source_is_downgraded_to_untrusted_hint() -> None:
     link = normalize_entity_curie(
         "GO:1234567",
@@ -182,3 +209,40 @@ def test_broad_erk_phosphorylation_grounding_requires_review() -> None:
     assert link.reason == "grounding_requires_review"
     assert metadata["trusted_identifier"] is False
     assert metadata["model_hint_curie"] == "GO:0018108"
+
+
+@pytest.mark.parametrize(
+    ("label", "expected_reason"),
+    [
+        ("aggressive tumor growth", "composite_event_label"),
+        ("ERK phosphorylation", "broad_process_label"),
+        ("response to pembrolizumab", "composite_treatment_response_label"),
+        ("HRD score", "biomarker_score_label"),
+        ("platinum sensitivity", "drug_response_phenotype_label"),
+        ("inflammatory signaling", "broad_process_label"),
+        ("reduced survival", "prognosis_outcome_label"),
+        ("resistance", "generic_resistance_label"),
+    ],
+)
+def test_review_only_grounding_metadata_explains_policy_decision(
+    label: str,
+    expected_reason: str,
+) -> None:
+    link = normalize_entity_curie(
+        "GO:0002526",
+        label=label,
+        source="model",
+    )
+
+    metadata = link.to_metadata()
+    assert link.status == "abstained"
+    assert link.curie is None
+    assert link.source == "none"
+    assert link.reason == "grounding_requires_review"
+    assert metadata["trusted_identifier"] is False
+    assert metadata["trusted_identifier_allowed"] is False
+    assert metadata["grounding_curation_status"] == (
+        "review_only_for_relation_feasibility_v2"
+    )
+    assert metadata["grounding_reason_code"] == expected_reason
+    assert metadata["model_hint_curie"] == "GO:0002526"

--- a/services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py
+++ b/services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
 from artana_evidence_api.document_extraction_support.entity_grounding.verified_dictionary import (
+    REVIEW_ONLY_ENTITY_RECORDS,
     relation_match_label_for_label,
     review_only_record_for_label,
     verified_record_for_label,
@@ -39,6 +41,59 @@ def test_review_only_dictionary_blocks_overbroad_process_grounding() -> None:
     assert record is not None
     assert record.label == "ERK phosphorylation"
     assert verified_record_for_label("ERK phosphorylation") is None
+
+
+@pytest.mark.parametrize(
+    ("label", "expected_reason"),
+    [
+        ("aggressive tumor growth", "composite_event_label"),
+        ("ERK phosphorylation", "broad_process_label"),
+        ("response to pembrolizumab", "composite_treatment_response_label"),
+        ("HRD score", "biomarker_score_label"),
+        ("platinum sensitivity", "drug_response_phenotype_label"),
+        ("inflammatory signaling", "broad_process_label"),
+        ("reduced survival", "prognosis_outcome_label"),
+        ("resistance", "generic_resistance_label"),
+    ],
+)
+def test_review_only_dictionary_has_explicit_decisions_for_pr24_endpoint_gaps(
+    label: str,
+    expected_reason: str,
+) -> None:
+    record = review_only_record_for_label(label)
+
+    assert record is not None
+    assert record.curation_status == "review_only_for_relation_feasibility_v2"
+    assert record.reason_code == expected_reason
+    assert record.trusted_identifier_allowed is False
+    assert verified_record_for_label(label) is None
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "resistance to gefitinib",
+        "gefitinib resistance",
+    ],
+)
+def test_composite_resistance_labels_are_review_only(label: str) -> None:
+    record = review_only_record_for_label(label)
+
+    assert record is not None
+    assert record.label == "resistance"
+    assert record.reason_code == "generic_resistance_label"
+    assert verified_record_for_label(label) is None
+
+
+def test_review_only_labels_and_aliases_never_resolve_as_verified() -> None:
+    labels = (
+        label
+        for record in REVIEW_ONLY_ENTITY_RECORDS
+        for label in (record.label, *record.aliases)
+    )
+
+    for label in labels:
+        assert verified_record_for_label(label) is None
 
 
 def test_relation_match_aliases_do_not_reuse_identity_aliases() -> None:

--- a/tests/unit/test_relation_feasibility_failure_analysis.py
+++ b/tests/unit/test_relation_feasibility_failure_analysis.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from scripts.validation.relation_feasibility.failure_analysis import (
     FailureAnalysisInput,
     build_failure_analysis_report,
+    render_failure_analysis_markdown,
 )
 
 
@@ -242,3 +243,50 @@ def test_failure_analysis_does_not_call_verified_proposal_links_wrong(
     )
 
     assert report["curie_gaps"] == []
+
+
+def test_failure_analysis_reports_review_only_grounding_decision(
+    tmp_path: Path,
+) -> None:
+    assessment = {
+        "candidate": {
+            "subject": "IL6",
+            "relation_type": "REGULATES",
+            "object": "inflammatory signaling",
+            "subject_curie": "HGNC:6018",
+            "object_curie": "GO:0002526",
+            "subject_curie_source": "verified_linker",
+            "object_curie_source": "model",
+        },
+        "matched_gold_index": 0,
+        "proposal_matched_gold_index": None,
+        "is_supported_by_gold": True,
+        "has_verified_subject_curie": True,
+        "has_verified_object_curie": False,
+        "subject_curie_matches_gold": True,
+        "object_curie_matches_gold": False,
+    }
+    report_path = _write_report(tmp_path, "run1", assessments=[assessment])
+
+    report = build_failure_analysis_report(
+        (FailureAnalysisInput(path=report_path, label="run1"),),
+    )
+
+    assert report["curie_gaps"] == [
+        {
+            "case_id": "case_a",
+            "endpoint_role": "object",
+            "label": "inflammatory signaling",
+            "candidate_curie": "GO:0002526",
+            "candidate_curie_source": "model",
+            "gap_type": "review_only_endpoint",
+            "grounding_curation_status": "review_only_for_relation_feasibility_v2",
+            "grounding_reason_code": "broad_process_label",
+            "trusted_identifier_allowed": False,
+            "occurrence_count": 1,
+            "run_labels": ["run1"],
+        },
+    ]
+    markdown = render_failure_analysis_markdown(report)
+    assert "grounding_reason_code" in markdown
+    assert "broad_process_label" in markdown


### PR DESCRIPTION
## Summary
- Add explicit review-only grounding decisions for the remaining endpoint gaps and expose reason metadata in link/failure-analysis output.
- Ensure review-only decisions beat verified alias collisions, including composite resistance labels such as `resistance to gefitinib`.
- Route primary LLM extraction through the guarded relation-type schema so raw live-agent types reach the code-owned resolver/drop path instead of crashing early.

## Validation
- `PYTHONPATH="$(pwd)/services:$(pwd)" .venv/bin/python3 -m pytest services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_drops_invalid_primary_pass_type services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_drops_invalid_weak_pass_type services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py services/artana_evidence_api/tests/unit/test_entity_curie_linking.py tests/unit/test_relation_feasibility_failure_analysis.py -q`
- `PYTHONPATH="$(pwd)/services:$(pwd)" .venv/bin/python3 -m pytest services/artana_evidence_api/tests/unit/test_document_extraction.py services/artana_evidence_api/tests/unit/test_document_extraction_modules.py services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py services/artana_evidence_api/tests/unit/test_entity_curie_linking.py tests/unit/test_relation_feasibility_failure_analysis.py -q`
- `make relation-feasibility-quality-gate`
- `uv run --python python3.13 --with ruff ruff check scripts/validation/relation_feasibility/failure_analysis.py services/artana_evidence_api/document_extraction.py services/artana_evidence_api/document_extraction_prompting.py services/artana_evidence_api/document_extraction_support/entity_curie_linking.py services/artana_evidence_api/document_extraction_support/entity_grounding/contracts.py services/artana_evidence_api/document_extraction_support/entity_grounding/verified_dictionary.py services/artana_evidence_api/tests/unit/test_document_extraction.py services/artana_evidence_api/tests/unit/test_entity_curie_linking.py services/artana_evidence_api/tests/unit/test_verified_entity_dictionary.py tests/unit/test_relation_feasibility_failure_analysis.py`
- `make service-checks`
- `git diff --check`
- `PATH="$(pwd)/.venv/bin:$PATH" pre-commit run --all-files`

## Live-Agent Evidence
- Final strict live-agent run: `reports/relation_feasibility/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_report.json`
- Failure attribution: `reports/relation_feasibility_failure_analysis/2026-07-06-pr24-grounding-decision-table-run3/relation_feasibility_failure_analysis_report.json`
- Verdict GREEN, precision 0.9615, recall 1.0000, trusted endpoint rate 1.0000, verified CURIE match rate 1.0000, fallback 0, invalid agent 0, wrong verified CURIE links 0.
- The one run3 false positive is review-only with no trusted object CURIE; repeatability and generic/review-lane noise remain follow-up work.
