### PR TITLE
PR27: add benchmark v3 proof docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ coverage-check: ## Enforce service coverage threshold
 
 relation-feasibility-quality-gate: ## Run relation feasibility quality regression tests
 	$(call check_venv)
-	PYTHONPATH="$(CURDIR)/services:$(CURDIR)" $(USE_PYTHON) -m pytest tests/unit/test_relation_feasibility_audit.py tests/unit/test_relation_feasibility_readiness_gate.py tests/unit/test_relation_feasibility_model_comparison.py -q
+	PYTHONPATH="$(CURDIR)/services:$(CURDIR)" $(USE_PYTHON) -m pytest tests/unit/test_relation_feasibility_audit.py tests/unit/test_relation_feasibility_readiness_gate.py tests/unit/test_relation_feasibility_model_comparison.py tests/unit/test_relation_feasibility_fixture_validation.py tests/unit/test_generate_relation_feasibility_summary.py -q
 
 artana-evidence-api-static-checks-core: ## Run evidence API static gates except repo-wide size check
 	@$(MAKE) -s artana-evidence-api-lint

--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -145,6 +145,7 @@ Status values:
 | 13 | PR-24 | `alvaro/evidence-pr24-grounding-decision-table` | Implemented locally; final gates pending | Give every remaining endpoint gap a safe verified or review-only grounding decision without trusting model hints. | All remaining CURIE gaps have explicit review-only decision metadata and wrong verified CURIE links remain 0. | Review-only grounding decision metadata, eight-label endpoint policy table, review-only-before-verified collision handling, link metadata for `grounding_reason_code`, failure-analysis `review_only_endpoint` rows, guarded primary LLM schema for raw relation-type cleanup, focused RED/GREEN tests, relation-feasibility gate, and strict live run3 with verdict GREEN, precision 0.9615, recall 1.0000, trusted endpoint rate 1.0000, verified CURIE match rate 1.0000, one review-only false positive, missed gold 0, fallback 0, invalid agent 0, wrong verified CURIE links 0. Repeatability and generic relation rate 0.1154 remain follow-up work. |
 | 14 | PR-25 | `alvaro/evidence-pr25-repeatability-model-ab` | In progress; harness implemented, live A/B pending | Prove repeatability and evaluate whether a stronger model improves trusted readiness without safety regressions. | Candidate model can be recommended only from worst-run readiness, zero safety failures, and no trusted-endpoint regression. | Artifact-only model-comparison module, repeated-run wrapper with `ARTANA_STRONGER_MODEL_CANDIDATE` fail-closed guard, readiness-backed adoption decision, failure-analysis trust-lane model metrics, focused RED/GREEN tests, and updated `relation-feasibility-quality-gate`. Live six-run A/B remains pending because `ARTANA_STRONGER_MODEL_CANDIDATE` is not configured in `.env.postgres`. |
 | 15 | PR-26 | `alvaro/evidence-pr26-graph-promotion-fail-closed` | Implemented locally; final gates pass | Make Graph DB independently reject unsafe trusted AI evidence even if a caller labels it trusted. | Graph validation rejects fallback, incomplete-agent, review-only, weak-reason, model-only endpoint, unlinked endpoint, non-ENTAILS, malformed floor metadata, and failed trust-floor promotion attempts. | Graph-owned review-lane floor, verified endpoint marker floor, malformed metadata fail-closed checks, `/claims` trusted-floor rejection, claim and direct relation regression tests, RED unit/integration/adversarial proof, focused 71-test graph validation pass, changed-file Ruff pass, post-adversarial `make graph-service-checks` pass, and post-adversarial `make service-checks` pass with coverage 87.03%. Summary: `docs/validation/reports/2026-07-06-pr26-graph-promotion-fail-closed-summary.md`. |
+| 16 | PR-27 | `alvaro/evidence-pr27-benchmark-v3-doc-proof` | Implemented locally; final gates pass | Expand benchmark breadth and make proof summaries generated from JSON artifacts. | v3 fixture validation passes and generated summaries expose reproducible metrics, blockers, warning reasons, artifact hashes, and remaining failures from tracked JSON. | 40-case v3 fixture, fixture validator, generated summary CLI, tracked PR27 proof JSON/Markdown, quality-gate tests, v2 GREEN run, v3 RED run2, v3 failure attribution, adversarial re-review PASS, pre-commit pass, and `make service-checks` pass with coverage 87.03%. V3 proves current agent path is safe on hard negatives but not trusted-graph ready: precision 0.7333, trusted high-value recall 0.2000, trusted endpoint rate 0.3000, generic rate 0.3000, model-only wrong CURIE hints 9, fallback 0, invalid agent 0, negative leakage 0, weak trusted leakage 0, wrong verified links 0. Summary: `docs/validation/reports/2026-07-06-pr27-benchmark-v3-doc-proof-summary.md`. |
 
 ## PR Evidence Packet
 
@@ -205,6 +206,65 @@ Run only the service checks relevant to the changed boundary, then run the
 aggregate gate before merge when the PR is ready.
 
 ## Evidence Log
+
+### 2026-07-06 - PR-27 Benchmark V3 And Generated Proof Docs
+
+PR: PR-27 benchmark v3 and generated proof docs
+
+Branch: `alvaro/evidence-pr27-benchmark-v3-doc-proof`
+
+Goal: Make the relation-feasibility benchmark harder and broader, then generate
+proof summaries from JSON so metrics and blockers do not drift from artifacts.
+
+Evidence:
+
+- `docs/validation/reports/2026-07-06-pr27-benchmark-v3-doc-proof-summary.md`
+- `docs/validation/reports/2026-07-06-pr27-v2-relation-feasibility-report.json`
+- `docs/validation/reports/2026-07-06-pr27-v2-generated-summary.md`
+- `docs/validation/reports/2026-07-06-pr27-v3-relation-feasibility-report.json`
+- `docs/validation/reports/2026-07-06-pr27-v3-failure-analysis-report.json`
+- `docs/validation/reports/2026-07-06-pr27-v3-generated-summary.md`
+- `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json`
+- `reports/relation_feasibility/2026-07-06-pr27-v2-run1/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-06-pr27-v3-run2/relation_feasibility_report.json`
+- `reports/relation_feasibility_failure_analysis/2026-07-06-pr27-v3-run2/relation_feasibility_failure_analysis_report.json`
+
+Result:
+
+- V2 seed fixture verdict: GREEN
+- V3 expanded fixture verdict: RED
+- V3 completed-agent precision: 0.7333
+- V3 completed-agent recall: 0.7333
+- V3 high-value recall: 0.7000
+- V3 trusted high-value recall: 0.2000
+- V3 trusted-eligible CURIE endpoint rate: 0.3000
+- V3 completed-agent valuable candidate rate: 0.3667
+- V3 generic relation rate: 0.3000
+- V3 model-only wrong CURIE hints: 9
+- V3 fallback cases: 0
+- V3 invalid strict-agent cases: 0
+- V3 negative-control leakage: 0
+- V3 weak-claim trusted leakage: 0
+- V3 wrong verified CURIE links: 0
+
+Interpretation:
+
+PR27 shows that the previous v2 seed was too curated to prove production
+biomedical value. The live agent path remains safe on hard negative controls,
+but the expanded fixture exposes real quality blockers in high-value recall,
+trusted endpoint recovery, generic relation noise, and near-miss specificity.
+
+Validation:
+
+- Focused PR27 tests passed.
+- `make relation-feasibility-quality-gate` passed.
+- V3 live-agent run2 completed with fallback 0 and invalid agent 0.
+- Failure attribution completed for V3 run2.
+- Adversarial re-review passed after tracked proof docs, metric, and fixture
+  validation fixes.
+- `git diff --check` passed.
+- `pre-commit run --all-files` passed.
+- `make service-checks` passed with coverage 87.03%.
 
 ### 2026-07-06 - PR-24 Grounding Decision Table
 

--- a/docs/validation/reports/2026-07-06-pr27-benchmark-v3-doc-proof-summary.md
+++ b/docs/validation/reports/2026-07-06-pr27-benchmark-v3-doc-proof-summary.md
@@ -1,0 +1,207 @@
+# PR27 Benchmark V3 And Generated Proof Docs Summary
+
+Date: 2026-07-06
+
+Branch: `alvaro/evidence-pr27-benchmark-v3-doc-proof`
+
+Run commit: `6e67477+pr27-working-tree`
+
+## Goal
+
+PR27 expands the relation-feasibility benchmark beyond the curated v2 seed and
+adds generated Markdown summaries from JSON artifacts so evidence reports can
+be reproduced instead of hand-copied.
+
+This PR is a measurement and proof-doc slice. It does not claim final
+trusted-graph readiness.
+
+## Implementation
+
+- Added fixture validation rules for duplicate case IDs, missing support
+  sentences, incomplete gold relation fields, trusted high-value rows missing
+  endpoint CURIEs, negative controls with gold relations, and weak/low-value
+  rows missing `value_level`.
+- Added topic-specific fixture validation so broad coverage cannot be faked by
+  labels alone: long-document cases must be long enough, negated near-miss
+  cases must list co-mentioned entities, weak rows must be review-only, and
+  trusted high-value rows must require entailment.
+- Added `biomedical_relation_goldset_v3.json` with 40 cases:
+  - 20 high-value specific relation cases
+  - 10 low-value review-only weak or hedged cases
+  - 10 negative controls
+- Covered oncology drug response, rare disease gene-to-phenotype,
+  variant-to-disease risk, pathway regulation, biomarker/treatment response,
+  long-document chunking, and adversarial negated near-miss cases.
+- Added `generate_relation_feasibility_summary.py`, which writes Markdown
+  summaries containing run context, artifact hashes, key metrics, blocking
+  reasons, warning reasons, remaining failures, and optional
+  failure/readiness artifacts.
+- Added the fixture and summary tests to `relation-feasibility-quality-gate`.
+
+## Generated Evidence Artifacts
+
+Tracked v2 seed proof packet:
+
+- `docs/validation/reports/2026-07-06-pr27-v2-relation-feasibility-report.json`
+- `docs/validation/reports/2026-07-06-pr27-v2-generated-summary.md`
+
+Tracked v3 expanded proof packet:
+
+- `docs/validation/reports/2026-07-06-pr27-v3-relation-feasibility-report.json`
+- `docs/validation/reports/2026-07-06-pr27-v3-failure-analysis-report.json`
+- `docs/validation/reports/2026-07-06-pr27-v3-generated-summary.md`
+
+## V2 Seed Result
+
+| Metric | Value |
+|---|---:|
+| Verdict | GREEN |
+| Cases | 30 |
+| Completed-agent precision | 1.0000 |
+| Completed-agent recall | 1.0000 |
+| High-value recall | 1.0000 |
+| Trusted high-value recall | 0.8500 |
+| Low-value review recall | 1.0000 |
+| Trusted-eligible CURIE endpoint rate | 1.0000 |
+| Completed-agent valuable candidate rate | 0.8000 |
+| Generic relation rate | 0.1200 |
+| Fallback cases | 0 |
+| Invalid strict-agent cases | 0 |
+| Negative-control leakage | 0 |
+| Weak-claim trusted leakage | 0 |
+| Wrong verified CURIE links | 0 |
+
+## V3 Expanded Result
+
+| Metric | Value |
+|---|---:|
+| Verdict | RED |
+| Cases | 40 |
+| Completed-agent precision | 0.7333 |
+| Completed-agent recall | 0.7333 |
+| High-value recall | 0.7000 |
+| Trusted high-value recall | 0.2000 |
+| Low-value review recall | 0.8000 |
+| Trusted-eligible CURIE endpoint rate | 0.3000 |
+| Completed-agent valuable candidate rate | 0.3667 |
+| Generic relation rate | 0.3000 |
+| Model-only wrong CURIE hints | 9 |
+| Fallback cases | 0 |
+| Invalid strict-agent cases | 0 |
+| Negative-control leakage | 0 |
+| Weak-claim trusted leakage | 0 |
+| Wrong verified CURIE links | 0 |
+
+Blocking reason:
+
+- Too few trusted-eligible CURIE-linked gold endpoints were recovered by
+  extraction.
+
+Failure attribution:
+
+- Missed gold relations: 8
+- False-positive candidate patterns: 8
+- CURIE-gap rows: 28
+
+## Interpretation
+
+The v2 seed benchmark remains green, but the expanded v3 fixture is red. That
+means the earlier seed fixture was not enough evidence for trusted-graph
+readiness.
+
+The live agent path is still behaving safely on the hard safety invariants:
+fallback cases, invalid-agent cases, negative-control leakage, weak-claim
+trusted leakage, and wrong verified CURIE links are all zero in v3 run2.
+
+The remaining blockers are quality and specificity blockers:
+
+- high-value biomedical recall is too low on the broader fixture
+- trusted high-value recall is far below the readiness target
+- trusted-eligible endpoint recovery is far below the readiness target
+- generic relation rate is too high
+- valuable candidate rate is too low
+- several false positives are near-miss specificity errors, such as shortened
+  subjects, overly broad disease or tumor objects, and pathway-vs-target
+  substitutions
+
+This is useful negative evidence: PR27 raises the benchmark difficulty and
+prevents a green v2 seed run from being mistaken for production confidence.
+
+## Validation Commands
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  tests/unit/test_relation_feasibility_fixture_validation.py \
+  tests/unit/test_generate_relation_feasibility_summary.py \
+  tests/unit/test_control_files.py \
+  -q
+```
+
+```bash
+make relation-feasibility-quality-gate
+```
+
+```bash
+bash -lc 'set -a; source .env.postgres; set +a; \
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v2.json \
+  --output-dir reports/relation_feasibility/2026-07-06-pr27-v2-run1'
+```
+
+```bash
+bash -lc 'set -a; source .env.postgres; set +a; \
+  PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json \
+  --output-dir reports/relation_feasibility/2026-07-06-pr27-v3-run2'
+```
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/summarize_relation_readiness_failures.py \
+  --report current=reports/relation_feasibility/2026-07-06-pr27-v3-run2/relation_feasibility_report.json \
+  --output-dir reports/relation_feasibility_failure_analysis/2026-07-06-pr27-v3-run2
+```
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  tests/unit/test_generate_relation_feasibility_summary.py::test_pr27_committed_generated_summaries_are_reproducible \
+  -q
+```
+
+```bash
+git diff --check
+```
+
+```bash
+PATH="$(pwd)/.venv/bin:$PATH" pre-commit run --all-files
+```
+
+```bash
+make service-checks
+```
+
+Final local validation:
+
+- Focused PR27 tests passed: 35 tests.
+- `make relation-feasibility-quality-gate` passed: 81 tests.
+- `git diff --check` passed.
+- `pre-commit run --all-files` passed.
+- `make service-checks` passed with coverage 87.03%.
+- Adversarial re-review passed after fixing tracked proof docs, generated
+  metrics/warnings, and topic-specific fixture validation.
+
+## Remaining Risk
+
+PR27 makes the evaluation stronger, but it intentionally leaves the product
+readiness gate red. The next implementation loop should attack the v3 failure
+classes directly: broader biomedical relation recall, stricter near-miss
+specificity, better verified endpoint linking, and lower generic relation
+noise. A stronger model may help, but it must be proven through the PR25
+repeatability/model A/B gate without regressing the zero-leakage safety
+invariants.

--- a/docs/validation/reports/2026-07-06-pr27-v2-generated-summary.md
+++ b/docs/validation/reports/2026-07-06-pr27-v2-generated-summary.md
@@ -1,0 +1,52 @@
+# Relation Feasibility Generated Summary
+
+## Run Context
+
+- Branch: `alvaro/evidence-pr27-benchmark-v3-doc-proof`
+- Commit: `6e67477+pr27-working-tree`
+- Command: `scripts/run_relation_feasibility_audit.py --extractor agent --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v2.json --output-dir reports/relation_feasibility/2026-07-06-pr27-v2-run1`
+- Model label: `current-agent`
+- Fixture path: `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v2.json`
+
+## Artifact Hashes
+
+- `2026-07-06-pr27-v2-relation-feasibility-report.json`: `25ed1ee4bf020bf7f65e8cbe929d2cc11d4abfc55c3f906316d852d152065929`
+
+## Key Metrics
+
+- Verdict: `GREEN`
+- case_count: 30
+- gold_relation_count: 25
+- candidate_count: 25
+- completed_agent_candidate_count: 25
+- completed_agent_precision_against_gold: 1.0
+- completed_agent_recall_against_gold: 1.0
+- high_value_recall: 1.0
+- trusted_high_value_recall: 0.85
+- low_value_review_recall: 1.0
+- trusted_eligible_curie_linked_gold_endpoint_rate: 1.0
+- candidate_curie_present_rate: 0.84
+- verified_curie_match_rate: 1.0
+- valuable_candidate_rate: 0.8
+- completed_agent_valuable_candidate_rate: 0.8
+- generic_relation_rate: 0.12
+- raw_unknown_relation_type_count: 0
+- raw_unknown_relation_type_surface_count: 0
+- model_curie_wrong_count: 0
+- wrong_verified_curie_link_count: 0
+- fallback_case_count: 0
+- invalid_agent_case_count: 0
+- negative_control_leakage_count: 0
+- weak_claim_trusted_leakage_count: 0
+
+## Blocking Reasons
+
+- none
+
+## Warning Reasons
+
+- none
+
+## Remaining Failures
+
+- none

--- a/docs/validation/reports/2026-07-06-pr27-v2-relation-feasibility-report.json
+++ b/docs/validation/reports/2026-07-06-pr27-v2-relation-feasibility-report.json
@@ -1,0 +1,270 @@
+{
+  "summary": {
+    "case_count": 30,
+    "gold_relation_count": 25,
+    "candidate_count": 25,
+    "supported_candidate_count": 25,
+    "valuable_candidate_count": 20,
+    "generic_relation_count": 3,
+    "pruned_generic_relation_count": 3,
+    "quality_filtered_candidate_count": 4,
+    "raw_unknown_relation_type_count": 0,
+    "relation_type_surface_count": 25,
+    "raw_unknown_relation_type_surface_count": 0,
+    "proposal_candidate_count": 0,
+    "proposal_gold_match_count": 0,
+    "proposal_eligible_gold_count": 0,
+    "proposal_recall_against_gold": 0.0,
+    "proposal_recall_against_proposal_eligible_gold": 0.0,
+    "gold_curie_endpoint_count": 42,
+    "candidate_curie_endpoint_count": 42,
+    "curie_linked_gold_endpoint_count": 42,
+    "verified_curie_match_count": 42,
+    "model_curie_wrong_count": 0,
+    "wrong_verified_curie_link_count": 0,
+    "support_sentence_aligned_count": 25,
+    "both_arguments_present_count": 25,
+    "entailment_required_count": 20,
+    "entailment_checked_count": 20,
+    "entailment_supported_count": 20,
+    "agent_completed_case_count": 30,
+    "agent_zero_candidate_case_count": 5,
+    "fallback_case_count": 0,
+    "fallback_candidate_count": 0,
+    "fallback_credited_as_agent_count": 0,
+    "completed_agent_candidate_count": 25,
+    "completed_agent_supported_candidate_count": 25,
+    "completed_agent_valuable_candidate_count": 20,
+    "completed_agent_gold_relation_count": 25,
+    "completed_agent_missed_gold_count": 0,
+    "invalid_agent_case_count": 0,
+    "high_value_gold_relation_count": 20,
+    "high_value_missed_gold_count": 0,
+    "high_value_recall": 1.0,
+    "trusted_high_value_match_count": 17,
+    "trusted_high_value_recall": 0.85,
+    "low_value_gold_relation_count": 5,
+    "low_value_missed_gold_count": 0,
+    "low_value_recall": 1.0,
+    "low_value_review_candidate_count": 5,
+    "low_value_review_gold_match_count": 5,
+    "low_value_review_recall": 1.0,
+    "trusted_eligible_gold_curie_endpoint_count": 37,
+    "trusted_eligible_curie_linked_gold_endpoint_count": 37,
+    "trusted_eligible_curie_linked_gold_endpoint_rate": 1.0,
+    "low_value_review_gold_curie_endpoint_count": 5,
+    "low_value_review_curie_linked_gold_endpoint_count": 5,
+    "low_value_review_curie_endpoint_capture_rate": 1.0,
+    "weak_claim_trusted_leakage_count": 0,
+    "negative_control_case_count": 5,
+    "negative_control_empty_count": 5,
+    "negative_control_empty_rate": 1.0,
+    "negative_control_leakage_count": 0,
+    "missed_gold_count": 0,
+    "precision_against_gold": 1.0,
+    "recall_against_gold": 1.0,
+    "completed_agent_precision_against_gold": 1.0,
+    "completed_agent_recall_against_gold": 1.0,
+    "specificity_rate": 1.0,
+    "relation_specificity_rate": 0.88,
+    "generic_relation_rate": 0.12,
+    "raw_unknown_relation_type_rate": 0.0,
+    "raw_unknown_relation_type_surface_rate": 0.0,
+    "curie_linked_gold_endpoint_rate": 1.0,
+    "candidate_curie_present_rate": 0.84,
+    "verified_curie_match_rate": 1.0,
+    "valuable_candidate_rate": 0.8,
+    "completed_agent_valuable_candidate_rate": 0.8,
+    "grounded_sentence_rate": 1.0,
+    "both_arguments_present_rate": 1.0,
+    "support_sentence_alignment_rate": 1.0,
+    "entailment_checked_rate": 1.0,
+    "entailment_supported_rate": 1.0,
+    "verdict": "GREEN",
+    "verdict_reason": "The benchmark outputs are mostly supported, specific, and valuable.",
+    "blocking_reasons": [],
+    "warning_reasons": []
+  },
+  "case_results": [
+    {
+      "case": {
+        "case_id": "strong_med13_activates_septal_development"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "strong_osimertinib_targets_egfr_t790m"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "strong_brca1_regulates_dna_repair"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "strong_olaparib_treats_ovarian_cancer"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "strong_sotorasib_targets_kras_g12c"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "strong_tp53_loss_predisposes_cancer"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "strong_mek_inhibits_erk"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "strong_pdl1_biomarker_immunotherapy"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "strong_braf_v600e_activates_mapk"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "strong_cisplatin_treats_tnbc"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "weak_med13_may_link_chd"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "weak_met_correlated_resistance"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "weak_hrd_possible_biomarker"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "weak_il6_may_regulate_inflammation"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "weak_akt_trend_survival"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "negative_methods_rna_seq"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "negative_funding_acknowledgment"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "negative_author_contribution"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "negative_database_search"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "negative_cell_culture_protocol"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "complex_sotorasib_mispairing"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "complex_ret_variant_alias"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "complex_nsclc_alias"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "complex_her2_amplification_growth"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "generic_sibling_met_resistance"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "generic_sibling_egfr_t790m_resistance"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "generic_sibling_brca1_loss_cisplatin"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "long_document_tail_relation_braf"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "long_document_tail_relation_jak2"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "long_document_tail_relation_vegf"
+      },
+      "missed_gold_relations": []
+    }
+  ]
+}

--- a/docs/validation/reports/2026-07-06-pr27-v3-failure-analysis-report.json
+++ b/docs/validation/reports/2026-07-06-pr27-v3-failure-analysis-report.json
@@ -1,0 +1,546 @@
+{
+  "repeated_missed_gold_relations": [
+    {
+      "case_id": "v3_apc_predisposes_fap",
+      "subject": "APC pathogenic variants",
+      "relation_type": "PREDISPOSES_TO",
+      "object": "familial adenomatous polyposis",
+      "value_level": "high",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_brca1_predisposes_hereditary_breast_ovarian_cancer",
+      "subject": "BRCA1 truncating variants",
+      "relation_type": "PREDISPOSES_TO",
+      "object": "hereditary breast and ovarian cancer syndrome",
+      "value_level": "high",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_fbn1_associated_with_marfan_syndrome",
+      "subject": "FBN1 loss-of-function variants",
+      "relation_type": "ASSOCIATED_WITH",
+      "object": "Marfan syndrome",
+      "value_level": "high",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_larotrectinib_treats_ntrk_fusion_tumors",
+      "subject": "Larotrectinib",
+      "relation_type": "TREATS",
+      "object": "NTRK fusion solid tumors",
+      "value_level": "high",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_ldlr_predisposes_familial_hypercholesterolemia",
+      "subject": "LDLR loss-of-function variants",
+      "relation_type": "PREDISPOSES_TO",
+      "object": "familial hypercholesterolemia",
+      "value_level": "high",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_osimertinib_treats_egfr_exon19_luad",
+      "subject": "Osimertinib",
+      "relation_type": "TREATS",
+      "object": "EGFR exon 19 deletion lung adenocarcinoma",
+      "value_level": "high",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_egfr_trend_response_erlotinib",
+      "subject": "EGFR expression",
+      "relation_type": "ASSOCIATED_WITH",
+      "object": "erlotinib response",
+      "value_level": "low",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_met_correlated_resistance",
+      "subject": "MET amplification",
+      "relation_type": "ASSOCIATED_WITH",
+      "object": "resistance to EGFR inhibition",
+      "value_level": "low",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    }
+  ],
+  "repeated_false_positive_candidates": [
+    {
+      "case_id": "v3_alectinib_treats_alk_fusion_lung_cancer",
+      "subject": "Alectinib",
+      "relation_type": "TREATS",
+      "proposed_relation_type": null,
+      "object": "central nervous system involvement",
+      "support_verification": "ENTAILS",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_larotrectinib_treats_ntrk_fusion_tumors",
+      "subject": "Larotrectinib",
+      "relation_type": "TREATS",
+      "proposed_relation_type": null,
+      "object": "solid tumors",
+      "support_verification": "ENTAILS",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_mecp2_associated_with_rett_syndrome",
+      "subject": "MECP2 pathogenic variants",
+      "relation_type": "ASSOCIATED_WITH",
+      "proposed_relation_type": null,
+      "object": "developmental regression",
+      "support_verification": "ENTAILS",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_msi_high_biomarker_checkpoint_response",
+      "subject": "MSI-high status",
+      "relation_type": "BIOMARKER_FOR",
+      "proposed_relation_type": null,
+      "object": "colorectal cancer",
+      "support_verification": "ENTAILS",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_osimertinib_treats_egfr_exon19_luad",
+      "subject": "osimertinib",
+      "relation_type": "TREATS",
+      "proposed_relation_type": null,
+      "object": "EGFR",
+      "support_verification": "ENTAILS",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_pah_associated_with_phenylketonuria",
+      "subject": "PAH pathogenic variants",
+      "relation_type": "ASSOCIATED_WITH",
+      "proposed_relation_type": null,
+      "object": "elevated phenylalanine",
+      "support_verification": "ENTAILS",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_vemurafenib_targets_braf_v600e",
+      "subject": "vemurafenib",
+      "relation_type": "INHIBITS",
+      "proposed_relation_type": null,
+      "object": "MAPK signaling",
+      "support_verification": "ENTAILS",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_met_correlated_resistance",
+      "subject": "MET amplification",
+      "relation_type": "ASSOCIATED_WITH",
+      "proposed_relation_type": null,
+      "object": "EGFR inhibition",
+      "support_verification": "ENTAILS",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    }
+  ],
+  "curie_gaps": [
+    {
+      "case_id": "v3_alectinib_treats_alk_fusion_lung_cancer",
+      "endpoint_role": "subject",
+      "label": "Alectinib",
+      "candidate_curie": "CHEBI:75086",
+      "candidate_curie_source": "model",
+      "gap_type": "unverified_model_hint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_alectinib_treats_alk_fusion_lung_cancer",
+      "endpoint_role": "object",
+      "label": "ALK fusion-positive lung cancer",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_gla_associated_with_fabry_disease",
+      "endpoint_role": "subject",
+      "label": "GLA variants",
+      "candidate_curie": "HGNC:4297",
+      "candidate_curie_source": "model",
+      "gap_type": "unverified_model_hint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_gla_associated_with_fabry_disease",
+      "endpoint_role": "object",
+      "label": "Fabry disease",
+      "candidate_curie": "MONDO:0007739",
+      "candidate_curie_source": "model",
+      "gap_type": "unverified_model_hint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_il6_regulates_inflammatory_signaling",
+      "endpoint_role": "object",
+      "label": "inflammatory signaling",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "review_only_endpoint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ],
+      "grounding_curation_status": "review_only_for_relation_feasibility_v2",
+      "grounding_reason_code": "broad_process_label",
+      "trusted_identifier_allowed": false
+    },
+    {
+      "case_id": "v3_kras_g12d_activates_mapk",
+      "endpoint_role": "subject",
+      "label": "KRAS G12D",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_mecp2_associated_with_rett_syndrome",
+      "endpoint_role": "subject",
+      "label": "MECP2 pathogenic variants",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_mecp2_associated_with_rett_syndrome",
+      "endpoint_role": "object",
+      "label": "Rett syndrome",
+      "candidate_curie": "MESH:C536314",
+      "candidate_curie_source": "model",
+      "gap_type": "unverified_model_hint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_msi_high_biomarker_checkpoint_response",
+      "endpoint_role": "subject",
+      "label": "MSI-high status",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_msi_high_biomarker_checkpoint_response",
+      "endpoint_role": "object",
+      "label": "immune checkpoint inhibitor response",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_pah_associated_with_phenylketonuria",
+      "endpoint_role": "subject",
+      "label": "PAH pathogenic variants",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_pah_associated_with_phenylketonuria",
+      "endpoint_role": "object",
+      "label": "phenylketonuria",
+      "candidate_curie": "MONDO:0005148",
+      "candidate_curie_source": "model",
+      "gap_type": "unverified_model_hint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_pdl1_biomarker_pembrolizumab_response",
+      "endpoint_role": "object",
+      "label": "response to pembrolizumab",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "review_only_endpoint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ],
+      "grounding_curation_status": "review_only_for_relation_feasibility_v2",
+      "grounding_reason_code": "composite_treatment_response_label",
+      "trusted_identifier_allowed": false
+    },
+    {
+      "case_id": "v3_pten_loss_activates_pi3k_akt",
+      "endpoint_role": "subject",
+      "label": "PTEN loss",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_pten_loss_activates_pi3k_akt",
+      "endpoint_role": "object",
+      "label": "PI3K-AKT signaling",
+      "candidate_curie": "GO:0007173",
+      "candidate_curie_source": "model",
+      "gap_type": "unverified_model_hint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_vemurafenib_targets_braf_v600e",
+      "endpoint_role": "subject",
+      "label": "vemurafenib",
+      "candidate_curie": "CHEBI:63637",
+      "candidate_curie_source": "model",
+      "gap_type": "unverified_model_hint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_akt_trend_survival",
+      "endpoint_role": "object",
+      "label": "reduced survival",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "review_only_endpoint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ],
+      "grounding_curation_status": "review_only_for_relation_feasibility_v2",
+      "grounding_reason_code": "prognosis_outcome_label",
+      "trusted_identifier_allowed": false
+    },
+    {
+      "case_id": "v3_weak_hrd_possible_biomarker_platinum",
+      "endpoint_role": "subject",
+      "label": "HRD score",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "review_only_endpoint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ],
+      "grounding_curation_status": "review_only_for_relation_feasibility_v2",
+      "grounding_reason_code": "biomarker_score_label",
+      "trusted_identifier_allowed": false
+    },
+    {
+      "case_id": "v3_weak_hrd_possible_biomarker_platinum",
+      "endpoint_role": "object",
+      "label": "platinum sensitivity",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "review_only_endpoint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ],
+      "grounding_curation_status": "review_only_for_relation_feasibility_v2",
+      "grounding_reason_code": "drug_response_phenotype_label",
+      "trusted_identifier_allowed": false
+    },
+    {
+      "case_id": "v3_weak_il6_may_regulate_inflammation",
+      "endpoint_role": "object",
+      "label": "inflammatory signaling",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "review_only_endpoint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ],
+      "grounding_curation_status": "review_only_for_relation_feasibility_v2",
+      "grounding_reason_code": "broad_process_label",
+      "trusted_identifier_allowed": false
+    },
+    {
+      "case_id": "v3_weak_jak2_possible_link_thrombosis",
+      "endpoint_role": "subject",
+      "label": "JAK2 V617F",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_jak2_possible_link_thrombosis",
+      "endpoint_role": "object",
+      "label": "thrombosis",
+      "candidate_curie": "MESH:D013927",
+      "candidate_curie_source": "model",
+      "gap_type": "unverified_model_hint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_mtor_might_activate_autophagy",
+      "endpoint_role": "subject",
+      "label": "MTOR signaling",
+      "candidate_curie": "GO:0032006",
+      "candidate_curie_source": "model",
+      "gap_type": "unverified_model_hint",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_mtor_might_activate_autophagy",
+      "endpoint_role": "object",
+      "label": "autophagy markers",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_ntrk_may_predict_larotrectinib_response",
+      "endpoint_role": "subject",
+      "label": "NTRK fusion",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_ntrk_may_predict_larotrectinib_response",
+      "endpoint_role": "object",
+      "label": "larotrectinib response",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_tp53_potential_predictor_chemo",
+      "endpoint_role": "subject",
+      "label": "TP53 mutation status",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    },
+    {
+      "case_id": "v3_weak_tp53_potential_predictor_chemo",
+      "endpoint_role": "object",
+      "label": "chemotherapy response",
+      "candidate_curie": null,
+      "candidate_curie_source": "none",
+      "gap_type": "missing_curie",
+      "occurrence_count": 1,
+      "run_labels": [
+        "2026-07-06-pr27-v3-run2"
+      ]
+    }
+  ]
+}

--- a/docs/validation/reports/2026-07-06-pr27-v3-generated-summary.md
+++ b/docs/validation/reports/2026-07-06-pr27-v3-generated-summary.md
@@ -1,0 +1,89 @@
+# Relation Feasibility Generated Summary
+
+## Run Context
+
+- Branch: `alvaro/evidence-pr27-benchmark-v3-doc-proof`
+- Commit: `6e67477+pr27-working-tree`
+- Command: `scripts/run_relation_feasibility_audit.py --extractor agent --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json --output-dir reports/relation_feasibility/2026-07-06-pr27-v3-run2`
+- Model label: `current-agent`
+- Fixture path: `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json`
+
+## Artifact Hashes
+
+- `2026-07-06-pr27-v3-relation-feasibility-report.json`: `3dd87040d11e615fff6ced0ae45a302c9e74b9a4e3ba1dc98ff9078fec621fc2`
+- `2026-07-06-pr27-v3-failure-analysis-report.json`: `eadcd476f2385051eae739375f913b0a02e330c841fcbb0171134185b608871a`
+
+## Key Metrics
+
+- Verdict: `RED`
+- case_count: 40
+- gold_relation_count: 30
+- candidate_count: 30
+- completed_agent_candidate_count: 30
+- completed_agent_precision_against_gold: 0.7333
+- completed_agent_recall_against_gold: 0.7333
+- high_value_recall: 0.7
+- trusted_high_value_recall: 0.2
+- low_value_review_recall: 0.8
+- trusted_eligible_curie_linked_gold_endpoint_rate: 0.3
+- candidate_curie_present_rate: 0.5833
+- verified_curie_match_rate: 0.2667
+- valuable_candidate_rate: 0.3667
+- completed_agent_valuable_candidate_rate: 0.3667
+- generic_relation_rate: 0.3
+- raw_unknown_relation_type_count: 0
+- raw_unknown_relation_type_surface_count: 0
+- model_curie_wrong_count: 9
+- wrong_verified_curie_link_count: 0
+- fallback_case_count: 0
+- invalid_agent_case_count: 0
+- negative_control_leakage_count: 0
+- weak_claim_trusted_leakage_count: 0
+
+## Blocking Reasons
+
+- Too few trusted-eligible CURIE-linked gold endpoints were recovered by extraction.
+
+## Warning Reasons
+
+- Precision is below trusted graph construction target.
+- Trusted high-value recall is below target.
+- Valuable candidate rate is below target.
+- Generic relation rate is above target.
+
+## Remaining Failures
+
+- v3_osimertinib_treats_egfr_exon19_luad: Osimertinib TREATS EGFR exon 19 deletion lung adenocarcinoma
+- v3_larotrectinib_treats_ntrk_fusion_tumors: Larotrectinib TREATS NTRK fusion solid tumors
+- v3_fbn1_associated_with_marfan_syndrome: FBN1 loss-of-function variants ASSOCIATED_WITH Marfan syndrome
+- v3_ldlr_predisposes_familial_hypercholesterolemia: LDLR loss-of-function variants PREDISPOSES_TO familial hypercholesterolemia
+- v3_brca1_predisposes_hereditary_breast_ovarian_cancer: BRCA1 truncating variants PREDISPOSES_TO hereditary breast and ovarian cancer syndrome
+- v3_apc_predisposes_fap: APC pathogenic variants PREDISPOSES_TO familial adenomatous polyposis
+- v3_weak_met_correlated_resistance: MET amplification ASSOCIATED_WITH resistance to EGFR inhibition
+- v3_weak_egfr_trend_response_erlotinib: EGFR expression ASSOCIATED_WITH erlotinib response
+- repeated_missed_gold_relations: v3_apc_predisposes_fap: APC pathogenic variants PREDISPOSES_TO familial adenomatous polyposis
+- repeated_missed_gold_relations: v3_brca1_predisposes_hereditary_breast_ovarian_cancer: BRCA1 truncating variants PREDISPOSES_TO hereditary breast and ovarian cancer syndrome
+- repeated_missed_gold_relations: v3_fbn1_associated_with_marfan_syndrome: FBN1 loss-of-function variants ASSOCIATED_WITH Marfan syndrome
+- repeated_missed_gold_relations: v3_larotrectinib_treats_ntrk_fusion_tumors: Larotrectinib TREATS NTRK fusion solid tumors
+- repeated_missed_gold_relations: v3_ldlr_predisposes_familial_hypercholesterolemia: LDLR loss-of-function variants PREDISPOSES_TO familial hypercholesterolemia
+- repeated_missed_gold_relations: v3_osimertinib_treats_egfr_exon19_luad: Osimertinib TREATS EGFR exon 19 deletion lung adenocarcinoma
+- repeated_missed_gold_relations: v3_weak_egfr_trend_response_erlotinib: EGFR expression ASSOCIATED_WITH erlotinib response
+- repeated_missed_gold_relations: v3_weak_met_correlated_resistance: MET amplification ASSOCIATED_WITH resistance to EGFR inhibition
+- repeated_false_positive_candidates: v3_alectinib_treats_alk_fusion_lung_cancer: Alectinib TREATS central nervous system involvement
+- repeated_false_positive_candidates: v3_larotrectinib_treats_ntrk_fusion_tumors: Larotrectinib TREATS solid tumors
+- repeated_false_positive_candidates: v3_mecp2_associated_with_rett_syndrome: MECP2 pathogenic variants ASSOCIATED_WITH developmental regression
+- repeated_false_positive_candidates: v3_msi_high_biomarker_checkpoint_response: MSI-high status BIOMARKER_FOR colorectal cancer
+- repeated_false_positive_candidates: v3_osimertinib_treats_egfr_exon19_luad: osimertinib TREATS EGFR
+- repeated_false_positive_candidates: v3_pah_associated_with_phenylketonuria: PAH pathogenic variants ASSOCIATED_WITH elevated phenylalanine
+- repeated_false_positive_candidates: v3_vemurafenib_targets_braf_v600e: vemurafenib INHIBITS MAPK signaling
+- repeated_false_positive_candidates: v3_weak_met_correlated_resistance: MET amplification ASSOCIATED_WITH EGFR inhibition
+- curie_gaps: v3_alectinib_treats_alk_fusion_lung_cancer: unverified_model_hint subject Alectinib -> CHEBI:75086 (model)
+- curie_gaps: v3_alectinib_treats_alk_fusion_lung_cancer: missing_curie object ALK fusion-positive lung cancer -> no_curie
+- curie_gaps: v3_gla_associated_with_fabry_disease: unverified_model_hint subject GLA variants -> HGNC:4297 (model)
+- curie_gaps: v3_gla_associated_with_fabry_disease: unverified_model_hint object Fabry disease -> MONDO:0007739 (model)
+- curie_gaps: v3_il6_regulates_inflammatory_signaling: review_only_endpoint object inflammatory signaling -> no_curie
+- curie_gaps: v3_kras_g12d_activates_mapk: missing_curie subject KRAS G12D -> no_curie
+- curie_gaps: v3_mecp2_associated_with_rett_syndrome: missing_curie subject MECP2 pathogenic variants -> no_curie
+- curie_gaps: v3_mecp2_associated_with_rett_syndrome: unverified_model_hint object Rett syndrome -> MESH:C536314 (model)
+- curie_gaps: v3_msi_high_biomarker_checkpoint_response: missing_curie subject MSI-high status -> no_curie
+- curie_gaps: v3_msi_high_biomarker_checkpoint_response: missing_curie object immune checkpoint inhibitor response -> no_curie

--- a/docs/validation/reports/2026-07-06-pr27-v3-relation-feasibility-report.json
+++ b/docs/validation/reports/2026-07-06-pr27-v3-relation-feasibility-report.json
@@ -1,0 +1,433 @@
+{
+  "summary": {
+    "case_count": 40,
+    "gold_relation_count": 30,
+    "candidate_count": 30,
+    "supported_candidate_count": 22,
+    "valuable_candidate_count": 11,
+    "generic_relation_count": 9,
+    "pruned_generic_relation_count": 0,
+    "quality_filtered_candidate_count": 11,
+    "raw_unknown_relation_type_count": 0,
+    "relation_type_surface_count": 30,
+    "raw_unknown_relation_type_surface_count": 0,
+    "proposal_candidate_count": 0,
+    "proposal_gold_match_count": 0,
+    "proposal_eligible_gold_count": 0,
+    "proposal_recall_against_gold": 0.0,
+    "proposal_recall_against_proposal_eligible_gold": 0.0,
+    "gold_curie_endpoint_count": 60,
+    "candidate_curie_endpoint_count": 35,
+    "curie_linked_gold_endpoint_count": 16,
+    "verified_curie_match_count": 16,
+    "model_curie_wrong_count": 9,
+    "wrong_verified_curie_link_count": 0,
+    "support_sentence_aligned_count": 22,
+    "both_arguments_present_count": 30,
+    "entailment_required_count": 22,
+    "entailment_checked_count": 22,
+    "entailment_supported_count": 22,
+    "agent_completed_case_count": 40,
+    "agent_zero_candidate_case_count": 15,
+    "fallback_case_count": 0,
+    "fallback_candidate_count": 0,
+    "fallback_credited_as_agent_count": 0,
+    "completed_agent_candidate_count": 30,
+    "completed_agent_supported_candidate_count": 22,
+    "completed_agent_valuable_candidate_count": 11,
+    "completed_agent_gold_relation_count": 30,
+    "completed_agent_missed_gold_count": 8,
+    "invalid_agent_case_count": 0,
+    "high_value_gold_relation_count": 20,
+    "high_value_missed_gold_count": 6,
+    "high_value_recall": 0.7,
+    "trusted_high_value_match_count": 4,
+    "trusted_high_value_recall": 0.2,
+    "low_value_gold_relation_count": 10,
+    "low_value_missed_gold_count": 2,
+    "low_value_recall": 0.8,
+    "low_value_review_candidate_count": 8,
+    "low_value_review_gold_match_count": 8,
+    "low_value_review_recall": 0.8,
+    "trusted_eligible_gold_curie_endpoint_count": 40,
+    "trusted_eligible_curie_linked_gold_endpoint_count": 12,
+    "trusted_eligible_curie_linked_gold_endpoint_rate": 0.3,
+    "low_value_review_gold_curie_endpoint_count": 20,
+    "low_value_review_curie_linked_gold_endpoint_count": 4,
+    "low_value_review_curie_endpoint_capture_rate": 0.2,
+    "weak_claim_trusted_leakage_count": 0,
+    "negative_control_case_count": 10,
+    "negative_control_empty_count": 10,
+    "negative_control_empty_rate": 1.0,
+    "negative_control_leakage_count": 0,
+    "missed_gold_count": 8,
+    "precision_against_gold": 0.7333,
+    "recall_against_gold": 0.7333,
+    "completed_agent_precision_against_gold": 0.7333,
+    "completed_agent_recall_against_gold": 0.7333,
+    "specificity_rate": 1.0,
+    "relation_specificity_rate": 0.7,
+    "generic_relation_rate": 0.3,
+    "raw_unknown_relation_type_rate": 0.0,
+    "raw_unknown_relation_type_surface_rate": 0.0,
+    "curie_linked_gold_endpoint_rate": 0.2667,
+    "candidate_curie_present_rate": 0.5833,
+    "verified_curie_match_rate": 0.2667,
+    "valuable_candidate_rate": 0.3667,
+    "completed_agent_valuable_candidate_rate": 0.3667,
+    "grounded_sentence_rate": 1.0,
+    "both_arguments_present_rate": 1.0,
+    "support_sentence_alignment_rate": 0.7333,
+    "entailment_checked_rate": 1.0,
+    "entailment_supported_rate": 1.0,
+    "verdict": "RED",
+    "verdict_reason": "Too few trusted-eligible CURIE-linked gold endpoints were recovered by extraction.",
+    "blocking_reasons": [
+      "Too few trusted-eligible CURIE-linked gold endpoints were recovered by extraction."
+    ],
+    "warning_reasons": [
+      "Precision is below trusted graph construction target.",
+      "Trusted high-value recall is below target.",
+      "Valuable candidate rate is below target.",
+      "Generic relation rate is above target."
+    ]
+  },
+  "case_results": [
+    {
+      "case": {
+        "case_id": "v3_osimertinib_treats_egfr_exon19_luad"
+      },
+      "missed_gold_relations": [
+        {
+          "subject": "Osimertinib",
+          "relation_type": "TREATS",
+          "object": "EGFR exon 19 deletion lung adenocarcinoma",
+          "support_sentence": "Osimertinib treats EGFR exon 19 deletion lung adenocarcinoma after first-line molecular testing.",
+          "value_level": "high",
+          "rationale": "Specific drug-to-molecular-subtype treatment relation.",
+          "subject_curie": "DrugBank:DB09330",
+          "object_curie": "MONDO:0005061",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case": {
+        "case_id": "v3_alectinib_treats_alk_fusion_lung_cancer"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_sotorasib_targets_kras_g12c"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_vemurafenib_targets_braf_v600e"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_larotrectinib_treats_ntrk_fusion_tumors"
+      },
+      "missed_gold_relations": [
+        {
+          "subject": "Larotrectinib",
+          "relation_type": "TREATS",
+          "object": "NTRK fusion solid tumors",
+          "support_sentence": "Larotrectinib treats solid tumors harboring NTRK gene fusions regardless of tissue origin.",
+          "value_level": "high",
+          "rationale": "Tumor-agnostic targeted therapy relation.",
+          "subject_curie": "DrugBank:DB14723",
+          "object_curie": "MONDO:0100342",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case": {
+        "case_id": "v3_mecp2_associated_with_rett_syndrome"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_fbn1_associated_with_marfan_syndrome"
+      },
+      "missed_gold_relations": [
+        {
+          "subject": "FBN1 loss-of-function variants",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "Marfan syndrome",
+          "support_sentence": "FBN1 loss-of-function variants are associated with Marfan syndrome and aortic root dilation.",
+          "value_level": "high",
+          "rationale": "Specific rare disease association.",
+          "subject_curie": "HGNC:3603",
+          "object_curie": "MONDO:0007947",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case": {
+        "case_id": "v3_gla_associated_with_fabry_disease"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_pah_associated_with_phenylketonuria"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_ldlr_predisposes_familial_hypercholesterolemia"
+      },
+      "missed_gold_relations": [
+        {
+          "subject": "LDLR loss-of-function variants",
+          "relation_type": "PREDISPOSES_TO",
+          "object": "familial hypercholesterolemia",
+          "support_sentence": "LDLR loss-of-function variants predispose carriers to familial hypercholesterolemia.",
+          "value_level": "high",
+          "rationale": "Specific variant class to disease risk relation.",
+          "subject_curie": "HGNC:6547",
+          "object_curie": "MONDO:0007750",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case": {
+        "case_id": "v3_brca1_predisposes_hereditary_breast_ovarian_cancer"
+      },
+      "missed_gold_relations": [
+        {
+          "subject": "BRCA1 truncating variants",
+          "relation_type": "PREDISPOSES_TO",
+          "object": "hereditary breast and ovarian cancer syndrome",
+          "support_sentence": "BRCA1 truncating variants predispose carriers to hereditary breast and ovarian cancer syndrome.",
+          "value_level": "high",
+          "rationale": "Specific cancer-risk relation.",
+          "subject_curie": "HGNC:1100",
+          "object_curie": "MONDO:0011450",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case": {
+        "case_id": "v3_apc_predisposes_fap"
+      },
+      "missed_gold_relations": [
+        {
+          "subject": "APC pathogenic variants",
+          "relation_type": "PREDISPOSES_TO",
+          "object": "familial adenomatous polyposis",
+          "support_sentence": "APC pathogenic variants predispose carriers to familial adenomatous polyposis.",
+          "value_level": "high",
+          "rationale": "Specific inherited cancer-risk relation.",
+          "subject_curie": "HGNC:583",
+          "object_curie": "MONDO:0008840",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case": {
+        "case_id": "v3_braf_v600e_activates_mapk"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_pten_loss_activates_pi3k_akt"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_il6_regulates_inflammatory_signaling"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_kras_g12d_activates_mapk"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_pdl1_biomarker_pembrolizumab_response"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_msi_high_biomarker_checkpoint_response"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_egfr_t790m_confers_resistance_gefitinib"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_long_document_med13_regulates_septal_development"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_weak_med13_may_link_congenital_heart_disease"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_weak_akt_trend_survival"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_weak_hrd_possible_biomarker_platinum"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_weak_il6_may_regulate_inflammation"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_weak_met_correlated_resistance"
+      },
+      "missed_gold_relations": [
+        {
+          "subject": "MET amplification",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "resistance to EGFR inhibition",
+          "support_sentence": "MET amplification was correlated with resistance to EGFR inhibition in a small exploratory cohort.",
+          "value_level": "low",
+          "rationale": "Correlated-only evidence is useful for review but not trusted promotion.",
+          "subject_curie": "HGNC:7029",
+          "object_curie": "NCIT:C165567",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case": {
+        "case_id": "v3_weak_tp53_potential_predictor_chemo"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_weak_mtor_might_activate_autophagy"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_weak_jak2_possible_link_thrombosis"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_weak_egfr_trend_response_erlotinib"
+      },
+      "missed_gold_relations": [
+        {
+          "subject": "EGFR expression",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "erlotinib response",
+          "support_sentence": "EGFR expression trended with erlotinib response but did not meet the prespecified threshold.",
+          "value_level": "low",
+          "rationale": "Trend-only drug-response evidence is review-only.",
+          "subject_curie": "HGNC:3236",
+          "object_curie": "DrugBank:DB00530",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case": {
+        "case_id": "v3_weak_ntrk_may_predict_larotrectinib_response"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_negative_egfr_gefitinib_negated_relation"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_negative_brca1_olaparib_background_only"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_negative_mecp2_rett_family_history_only"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_negative_braf_mapk_inhibitor_control"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_negative_pdl1_pembrolizumab_threshold_not_met"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_negative_cftr_lung_cancer_unrelated"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_negative_kras_sotorasib_prior_therapy"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_negative_il6_inflammation_assay_failed"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_negative_msi_checkpoint_response_covariate"
+      },
+      "missed_gold_relations": []
+    },
+    {
+      "case": {
+        "case_id": "v3_negative_long_document_distractor"
+      },
+      "missed_gold_relations": []
+    }
+  ]
+}

--- a/docs/validation/trusted-graph-readiness-post-pr22-remediation-plan.md
+++ b/docs/validation/trusted-graph-readiness-post-pr22-remediation-plan.md
@@ -779,18 +779,18 @@ Do not paste `OPENAI_API_KEY` or provider keys into any doc, test, PR body, or r
 **Files:**
 
 - Create: `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json`
-- Create: `scripts/validation/relation_feasibility/fixture_validation.py`
+- Create: `scripts/validation/relation_feasibility/fixture_checks/validation.py`
 - Create: `scripts/generate_relation_feasibility_summary.py`
 - Modify: `tests/unit/test_relation_feasibility_audit.py`
 - Modify: `tests/unit/test_control_files.py`
 - Create: `tests/unit/test_relation_feasibility_fixture_validation.py`
 - Create: `tests/unit/test_generate_relation_feasibility_summary.py`
 - Modify: `docs/validation/evidence-excellence-progress-tracker.md`
-- Create: `docs/validation/reports/2026-07-05-pr27-benchmark-v3-doc-proof-summary.md`
+- Create: `docs/validation/reports/2026-07-06-pr27-benchmark-v3-doc-proof-summary.md`
 
-- [ ] **Step 1: Add fixture validation rules**
+- [x] **Step 1: Add fixture validation rules**
 
-  `fixture_validation.py` must reject:
+  `fixture_checks/validation.py` must reject:
 
   - duplicate `case_id`
   - missing support sentence
@@ -799,7 +799,7 @@ Do not paste `OPENAI_API_KEY` or provider keys into any doc, test, PR body, or r
   - negative-control case with gold relations
   - low-value weak case missing a `value_level`
 
-- [ ] **Step 2: Add v3 fixture coverage**
+- [x] **Step 2: Add v3 fixture coverage**
 
   `biomedical_relation_goldset_v3.json` must include at least:
 
@@ -814,7 +814,7 @@ Do not paste `OPENAI_API_KEY` or provider keys into any doc, test, PR body, or r
   - long-document chunking case
   - adversarial near-miss where entities appear but relation is negated
 
-- [ ] **Step 3: Generate docs from JSON**
+- [x] **Step 3: Generate docs from JSON**
 
   `generate_relation_feasibility_summary.py` must read:
 
@@ -834,7 +834,7 @@ Do not paste `OPENAI_API_KEY` or provider keys into any doc, test, PR body, or r
   - blocking reasons
   - remaining failures
 
-- [ ] **Step 4: Run fixture and summary tests**
+- [x] **Step 4: Run fixture and summary tests**
 
   ```bash
   PYTHONPATH="$(pwd)/services:$(pwd)" \
@@ -845,7 +845,7 @@ Do not paste `OPENAI_API_KEY` or provider keys into any doc, test, PR body, or r
     -q
   ```
 
-- [ ] **Step 5: Run v2 and v3 audits separately**
+- [x] **Step 5: Run v2 and v3 audits separately**
 
   ```bash
   bash -lc 'set -a; source .env.postgres; set +a; \
@@ -853,7 +853,7 @@ Do not paste `OPENAI_API_KEY` or provider keys into any doc, test, PR body, or r
     .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
     --extractor agent \
     --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v2.json \
-    --output-dir reports/relation_feasibility/2026-07-05-pr27-v2-run1'
+    --output-dir reports/relation_feasibility/2026-07-06-pr27-v2-run1'
   ```
 
   ```bash
@@ -862,7 +862,7 @@ Do not paste `OPENAI_API_KEY` or provider keys into any doc, test, PR body, or r
     .venv/bin/python3 scripts/run_relation_feasibility_audit.py \
     --extractor agent \
     --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json \
-    --output-dir reports/relation_feasibility/2026-07-05-pr27-v3-run1'
+    --output-dir reports/relation_feasibility/2026-07-06-pr27-v3-run2'
   ```
 
 **Merge gate:** PR27 is mergeable when v3 fixture validation passes, generated summaries are reproducible from JSON, and the docs clearly separate seed-fixture readiness from broader production confidence.

--- a/scripts/generate_relation_feasibility_summary.py
+++ b/scripts/generate_relation_feasibility_summary.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Generate Markdown evidence summaries from relation feasibility JSON artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+JSONObject = dict[str, object]
+
+_KEY_METRICS = (
+    "case_count",
+    "gold_relation_count",
+    "candidate_count",
+    "completed_agent_candidate_count",
+    "completed_agent_precision_against_gold",
+    "completed_agent_recall_against_gold",
+    "high_value_recall",
+    "trusted_high_value_recall",
+    "low_value_review_recall",
+    "trusted_eligible_curie_linked_gold_endpoint_rate",
+    "candidate_curie_present_rate",
+    "verified_curie_match_rate",
+    "valuable_candidate_rate",
+    "completed_agent_valuable_candidate_rate",
+    "generic_relation_rate",
+    "raw_unknown_relation_type_count",
+    "raw_unknown_relation_type_surface_count",
+    "model_curie_wrong_count",
+    "wrong_verified_curie_link_count",
+    "fallback_case_count",
+    "invalid_agent_case_count",
+    "negative_control_leakage_count",
+    "weak_claim_trusted_leakage_count",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GenerateSummaryInput:
+    """Inputs for one generated evidence summary."""
+
+    relation_report: Path
+    branch: str
+    commit: str
+    command: str
+    model_label: str
+    fixture_path: Path
+    output_path: Path | None = None
+    failure_analysis_report: Path | None = None
+    readiness_report: Path | None = None
+
+
+def generate_summary_markdown(summary_input: GenerateSummaryInput) -> str:
+    """Return a generated Markdown evidence summary."""
+
+    relation_payload = _load_json_object(summary_input.relation_report)
+    relation_summary = _object(relation_payload.get("summary"))
+    failure_payload = (
+        _load_json_object(summary_input.failure_analysis_report)
+        if summary_input.failure_analysis_report is not None
+        else None
+    )
+    readiness_payload = (
+        _load_json_object(summary_input.readiness_report)
+        if summary_input.readiness_report is not None
+        else None
+    )
+    artifact_paths = [
+        summary_input.relation_report,
+        summary_input.failure_analysis_report,
+        summary_input.readiness_report,
+    ]
+    lines = [
+        "# Relation Feasibility Generated Summary",
+        "",
+        "## Run Context",
+        "",
+        f"- Branch: `{summary_input.branch}`",
+        f"- Commit: `{summary_input.commit}`",
+        f"- Command: `{summary_input.command}`",
+        f"- Model label: `{summary_input.model_label}`",
+        f"- Fixture path: `{summary_input.fixture_path}`",
+        "",
+        "## Artifact Hashes",
+        "",
+    ]
+    for artifact_path in artifact_paths:
+        if artifact_path is not None:
+            lines.append(
+                f"- `{artifact_path.name}`: `{_sha256_file(artifact_path)}`",
+            )
+    lines.extend(
+        [
+            "",
+            "## Key Metrics",
+            "",
+            f"- Verdict: `{relation_summary.get('verdict', 'unknown')}`",
+        ],
+    )
+    lines.extend(_metric_lines(relation_summary))
+    lines.extend(
+        [
+            "",
+            "## Blocking Reasons",
+            "",
+        ],
+    )
+    blocking_reasons = [
+        *_string_list(relation_summary.get("blocking_reasons")),
+        *_string_list(
+            readiness_payload.get("blocking_reasons")
+            if readiness_payload is not None
+            else None,
+        ),
+    ]
+    lines.extend(_bullet_lines(blocking_reasons))
+    lines.extend(
+        [
+            "",
+            "## Warning Reasons",
+            "",
+        ],
+    )
+    warning_reasons = _string_list(relation_summary.get("warning_reasons"))
+    lines.extend(_bullet_lines(warning_reasons))
+    lines.extend(
+        [
+            "",
+            "## Remaining Failures",
+            "",
+        ],
+    )
+    remaining_failures = [
+        *_missed_gold_lines(relation_payload),
+        *_failure_analysis_lines(failure_payload),
+    ]
+    lines.extend(_bullet_lines(remaining_failures))
+    if readiness_payload is not None:
+        lines.extend(
+            [
+                "",
+                "## Readiness",
+                "",
+                f"- Status: `{readiness_payload.get('readiness_status', 'unknown')}`",
+            ],
+        )
+        lines.extend(_object_metric_lines(_object(readiness_payload.get("worst_metrics"))))
+        lines.extend(
+            _object_metric_lines(_object(readiness_payload.get("hard_failure_counts"))),
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_generated_summary(summary_input: GenerateSummaryInput) -> Path:
+    """Write one generated Markdown summary and return its path."""
+
+    output_path = summary_input.output_path
+    if output_path is None:
+        output_path = summary_input.relation_report.with_name(
+            "relation_feasibility_generated_summary.md",
+        )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(generate_summary_markdown(summary_input), encoding="utf-8")
+    return output_path
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Generate a Markdown summary from relation feasibility JSON.",
+    )
+    parser.add_argument("--relation-report", type=Path, required=True)
+    parser.add_argument("--failure-analysis-report", type=Path)
+    parser.add_argument("--readiness-report", type=Path)
+    parser.add_argument("--output-path", type=Path, required=True)
+    parser.add_argument("--branch", default=None)
+    parser.add_argument("--commit", default=None)
+    parser.add_argument("--command", required=True)
+    parser.add_argument("--model-label", required=True)
+    parser.add_argument("--fixture-path", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Generate a Markdown evidence summary from the CLI."""
+
+    args = parse_args(argv)
+    output_path = write_generated_summary(
+        GenerateSummaryInput(
+            relation_report=args.relation_report,
+            failure_analysis_report=args.failure_analysis_report,
+            readiness_report=args.readiness_report,
+            output_path=args.output_path,
+            branch=args.branch or _git_output(("branch", "--show-current")),
+            commit=args.commit or _git_output(("rev-parse", "--short", "HEAD")),
+            command=args.command,
+            model_label=args.model_label,
+            fixture_path=args.fixture_path,
+        ),
+    )
+    print(f"Wrote generated summary: {output_path}")
+    return 0
+
+
+def _load_json_object(path: Path) -> JSONObject:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = f"{path} must contain a JSON object"
+        raise TypeError(msg)
+    return payload
+
+
+def _object(value: object) -> JSONObject:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item.strip()]
+
+
+def _metric_lines(summary: JSONObject) -> list[str]:
+    lines: list[str] = []
+    for metric in _KEY_METRICS:
+        if metric in summary:
+            lines.append(f"- {metric}: {summary[metric]}")
+    return lines
+
+
+def _object_metric_lines(metrics: JSONObject) -> list[str]:
+    return [f"- {key}: {value}" for key, value in sorted(metrics.items())]
+
+
+def _bullet_lines(values: Sequence[str]) -> list[str]:
+    if not values:
+        return ["- none"]
+    return [f"- {value}" for value in values]
+
+
+def _missed_gold_lines(relation_payload: JSONObject) -> list[str]:
+    lines: list[str] = []
+    raw_case_results = relation_payload.get("case_results")
+    if not isinstance(raw_case_results, list):
+        return lines
+    for raw_case_result in raw_case_results:
+        if not isinstance(raw_case_result, dict):
+            continue
+        case = _object(raw_case_result.get("case"))
+        case_id = str(case.get("case_id", "unknown_case"))
+        missed_gold = raw_case_result.get("missed_gold_relations")
+        if not isinstance(missed_gold, list):
+            continue
+        for raw_relation in missed_gold:
+            relation = _object(raw_relation)
+            lines.append(
+                f"{case_id}: {_relation_label(relation)}",
+            )
+    return lines
+
+
+def _failure_analysis_lines(failure_payload: JSONObject | None) -> list[str]:
+    if failure_payload is None:
+        return []
+    lines: list[str] = []
+    for key in ("repeated_missed_gold_relations", "repeated_false_positive_candidates"):
+        raw_rows = failure_payload.get(key)
+        if not isinstance(raw_rows, list):
+            continue
+        for raw_row in raw_rows[:10]:
+            row = _object(raw_row)
+            case_id = str(row.get("case_id", "unknown_case"))
+            lines.append(f"{key}: {case_id}: {_relation_label(row)}")
+    raw_curie_gaps = failure_payload.get("curie_gaps")
+    if isinstance(raw_curie_gaps, list):
+        for raw_row in raw_curie_gaps[:10]:
+            row = _object(raw_row)
+            case_id = str(row.get("case_id", "unknown_case"))
+            lines.append(f"curie_gaps: {case_id}: {_curie_gap_label(row)}")
+    return lines
+
+
+def _relation_label(payload: JSONObject) -> str:
+    subject = str(payload.get("subject", "unknown_subject"))
+    relation_type = str(payload.get("relation_type", "unknown_relation"))
+    object_label = str(payload.get("object", "unknown_object"))
+    return f"{subject} {relation_type} {object_label}"
+
+
+def _curie_gap_label(payload: JSONObject) -> str:
+    gap_type = str(payload.get("gap_type", "unknown_gap"))
+    endpoint_role = str(payload.get("endpoint_role", "unknown_endpoint"))
+    label = str(payload.get("label", "unknown_label"))
+    curie_label = _curie_gap_identifier(payload)
+    return f"{gap_type} {endpoint_role} {label} -> {curie_label}"
+
+
+def _curie_gap_identifier(payload: JSONObject) -> str:
+    gold_curie = payload.get("gold_curie")
+    if isinstance(gold_curie, str) and gold_curie.strip():
+        return gold_curie
+    candidate_curie = payload.get("candidate_curie")
+    if isinstance(candidate_curie, str) and candidate_curie.strip():
+        source = payload.get("candidate_curie_source")
+        if isinstance(source, str) and source.strip():
+            return f"{candidate_curie} ({source})"
+        return candidate_curie
+    return "no_curie"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _git_output(args: tuple[str, ...]) -> str:
+    result = subprocess.run(  # noqa: S603
+        ("git", *args),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/relation_feasibility/fixture_checks/__init__.py
+++ b/scripts/validation/relation_feasibility/fixture_checks/__init__.py
@@ -1,0 +1,17 @@
+"""Fixture validation checks for relation feasibility benchmarks."""
+
+from scripts.validation.relation_feasibility.fixture_checks.validation import (
+    FixtureCoverage,
+    FixtureValidationIssue,
+    fixture_coverage,
+    validate_fixture_file,
+    validate_fixture_payload,
+)
+
+__all__ = [
+    "FixtureCoverage",
+    "FixtureValidationIssue",
+    "fixture_coverage",
+    "validate_fixture_file",
+    "validate_fixture_payload",
+]

--- a/scripts/validation/relation_feasibility/fixture_checks/validation.py
+++ b/scripts/validation/relation_feasibility/fixture_checks/validation.py
@@ -1,0 +1,404 @@
+"""Validation helpers for relation feasibility benchmark fixtures."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+JSONObject = dict[str, object]
+_LONG_DOCUMENT_MIN_CHARACTERS = 600
+_LONG_DOCUMENT_MIN_SENTENCES = 5
+_NEAR_MISS_MIN_ENTITY_COUNT = 2
+_NEGATED_RELATION_PHRASES = (
+    "no evidence",
+    "no relation",
+    "not significant",
+    "did not",
+    "without",
+    "not establish",
+    "no sentence asserts",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FixtureValidationIssue:
+    """One structural fixture validation issue."""
+
+    code: str
+    message: str
+    case_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FixtureCoverage:
+    """Coverage counts for one relation feasibility fixture."""
+
+    issue_count: int
+    case_count: int
+    high_value_specific_case_count: int
+    low_value_review_case_count: int
+    negative_control_case_count: int
+    topic_counts: dict[str, int]
+
+
+def validate_fixture_file(path: Path) -> tuple[FixtureValidationIssue, ...]:
+    """Validate one fixture JSON file."""
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return validate_fixture_payload(payload)
+
+
+def validate_fixture_payload(payload: object) -> tuple[FixtureValidationIssue, ...]:
+    """Return structural validation issues for a fixture payload."""
+
+    if not isinstance(payload, Mapping):
+        return (
+            FixtureValidationIssue(
+                code="fixture_not_object",
+                message="Fixture root must be a JSON object.",
+            ),
+        )
+    raw_cases = payload.get("cases")
+    if not isinstance(raw_cases, list):
+        return (
+            FixtureValidationIssue(
+                code="cases_not_list",
+                message="Fixture root must contain a cases list.",
+            ),
+        )
+    issues: list[FixtureValidationIssue] = []
+    seen_case_ids: set[str] = set()
+    for raw_case in raw_cases:
+        if not isinstance(raw_case, Mapping):
+            issues.append(
+                FixtureValidationIssue(
+                    code="case_not_object",
+                    message="Each fixture case must be an object.",
+                ),
+            )
+            continue
+        case_id = _string_field(raw_case, "case_id")
+        if case_id is None:
+            issues.append(
+                FixtureValidationIssue(
+                    code="missing_case_id",
+                    message="Fixture case is missing case_id.",
+                ),
+            )
+        elif case_id in seen_case_ids:
+            issues.append(
+                FixtureValidationIssue(
+                    code="duplicate_case_id",
+                    message=f"Duplicate case_id: {case_id}",
+                    case_id=case_id,
+                ),
+            )
+        else:
+            seen_case_ids.add(case_id)
+        issues.extend(_case_issues(raw_case, case_id=case_id))
+    return tuple(issues)
+
+
+def fixture_coverage(path: Path) -> FixtureCoverage:
+    """Return validation and coverage counts for one fixture path."""
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    issues = validate_fixture_payload(payload)
+    cases = _case_list(payload)
+    topic_counts: Counter[str] = Counter()
+    for case in cases:
+        topic_counts.update(_case_topics(case))
+    return FixtureCoverage(
+        issue_count=len(issues),
+        case_count=len(cases),
+        high_value_specific_case_count=sum(
+            1 for case in cases if _has_high_value_specific_gold(case)
+        ),
+        low_value_review_case_count=sum(
+            1 for case in cases if _has_low_value_review_gold(case)
+        ),
+        negative_control_case_count=sum(1 for case in cases if _is_negative_case(case)),
+        topic_counts=dict(topic_counts),
+    )
+
+
+def _case_issues(
+    raw_case: Mapping[str, object],
+    *,
+    case_id: str | None,
+) -> tuple[FixtureValidationIssue, ...]:
+    issues: list[FixtureValidationIssue] = []
+    raw_relations = raw_case.get("gold_relations")
+    if raw_relations is None:
+        raw_relations = []
+    if not isinstance(raw_relations, list):
+        return (
+            FixtureValidationIssue(
+                code="gold_relations_not_list",
+                message="gold_relations must be a list when present.",
+                case_id=case_id,
+            ),
+        )
+    if _is_negative_case(raw_case) and raw_relations:
+        issues.append(
+            FixtureValidationIssue(
+                code="negative_control_has_gold_relations",
+                message="Negative-control cases must not contain gold relations.",
+                case_id=case_id,
+            ),
+        )
+    issues.extend(_topic_issues(raw_case, raw_relations, case_id=case_id))
+    for raw_relation in raw_relations:
+        if not isinstance(raw_relation, Mapping):
+            issues.append(
+                FixtureValidationIssue(
+                    code="gold_relation_not_object",
+                    message="Gold relation must be an object.",
+                    case_id=case_id,
+                ),
+            )
+            continue
+        issues.extend(_relation_issues(raw_case, raw_relation, case_id=case_id))
+    return tuple(issues)
+
+
+def _relation_issues(
+    raw_case: Mapping[str, object],
+    raw_relation: Mapping[str, object],
+    *,
+    case_id: str | None,
+) -> tuple[FixtureValidationIssue, ...]:
+    issues: list[FixtureValidationIssue] = []
+    for field in ("subject", "relation_type", "object"):
+        if _string_field(raw_relation, field) is None:
+            issues.append(
+                FixtureValidationIssue(
+                    code="missing_gold_relation_field",
+                    message=f"Gold relation is missing {field}.",
+                    case_id=case_id,
+                ),
+            )
+    if _string_field(raw_relation, "support_sentence") is None:
+        issues.append(
+            FixtureValidationIssue(
+                code="missing_support_sentence",
+                message="Gold relation is missing support_sentence.",
+                case_id=case_id,
+            ),
+        )
+    value_level = _string_field(raw_relation, "value_level")
+    if _is_weak_case(raw_case) and value_level is None:
+        issues.append(
+            FixtureValidationIssue(
+                code="low_value_case_missing_value_level",
+                message="Weak low-value cases must mark gold value_level.",
+                case_id=case_id,
+            ),
+        )
+    if _is_weak_case(raw_case):
+        if _string_field(raw_relation, "review_status") != "review_only":
+            issues.append(
+                FixtureValidationIssue(
+                    code="weak_case_not_review_only",
+                    message="Weak low-value gold rows must be review-only.",
+                    case_id=case_id,
+                ),
+            )
+        if _bool_field(raw_relation, "requires_entailment") is not False:
+            issues.append(
+                FixtureValidationIssue(
+                    code="weak_case_requires_entailment",
+                    message="Weak low-value rows must not require trusted entailment.",
+                    case_id=case_id,
+                ),
+            )
+    if (
+        value_level == "high"
+        and _string_field(raw_relation, "review_status") != "review_only"
+        and (
+            _string_field(raw_relation, "subject_curie") is None
+            or _string_field(raw_relation, "object_curie") is None
+        )
+    ):
+        issues.append(
+            FixtureValidationIssue(
+                code="trusted_high_value_missing_curie",
+                message=(
+                    "Trusted high-value gold rows must include subject and object "
+                    "CURIEs unless they are review-only."
+                ),
+                case_id=case_id,
+            ),
+        )
+    if (
+        value_level == "high"
+        and _string_field(raw_relation, "review_status") != "review_only"
+        and _bool_field(raw_relation, "requires_entailment") is not True
+    ):
+        issues.append(
+            FixtureValidationIssue(
+                code="trusted_high_value_missing_entailment_requirement",
+                message="Trusted high-value gold rows must require entailment.",
+                case_id=case_id,
+            ),
+        )
+    return tuple(issues)
+
+
+def _topic_issues(
+    raw_case: Mapping[str, object],
+    raw_relations: Sequence[object],
+    *,
+    case_id: str | None,
+) -> tuple[FixtureValidationIssue, ...]:
+    issues: list[FixtureValidationIssue] = []
+    topics = set(_case_topics(raw_case))
+    text = _string_field(raw_case, "text") or ""
+    if "long_document_chunking" in topics and (
+        len(text) < _LONG_DOCUMENT_MIN_CHARACTERS
+        or _sentence_count(text) < _LONG_DOCUMENT_MIN_SENTENCES
+    ):
+        issues.append(
+            FixtureValidationIssue(
+                code="long_document_case_too_short",
+                message=(
+                    "Long-document chunking cases must contain enough text and "
+                    "sentences to stress chunk-local extraction."
+                ),
+                case_id=case_id,
+            ),
+        )
+    if "adversarial_negated_near_miss" in topics:
+        if not _has_negated_relation_phrase(text):
+            issues.append(
+                FixtureValidationIssue(
+                    code="near_miss_missing_negation",
+                    message=(
+                        "Adversarial near-miss cases must contain negated "
+                        "relation language."
+                    ),
+                    case_id=case_id,
+                ),
+            )
+        near_miss_entities = _string_sequence_field(raw_case, "near_miss_entities")
+        lowered_text = text.lower()
+        if len(near_miss_entities) < _NEAR_MISS_MIN_ENTITY_COUNT or any(
+            entity.lower() not in lowered_text for entity in near_miss_entities
+        ):
+            issues.append(
+                FixtureValidationIssue(
+                    code="near_miss_entities_missing",
+                    message=(
+                        "Adversarial near-miss cases must list at least two "
+                        "co-mentioned entities that appear in the text."
+                    ),
+                    case_id=case_id,
+                ),
+            )
+        if raw_relations:
+            issues.append(
+                FixtureValidationIssue(
+                    code="near_miss_has_gold_relations",
+                    message="Adversarial near-miss cases must not contain gold relations.",
+                    case_id=case_id,
+                ),
+            )
+    return tuple(issues)
+
+
+def _case_list(payload: object) -> tuple[Mapping[str, object], ...]:
+    if not isinstance(payload, Mapping):
+        return ()
+    raw_cases = payload.get("cases")
+    if not isinstance(raw_cases, list):
+        return ()
+    return tuple(case for case in raw_cases if isinstance(case, Mapping))
+
+
+def _relation_list(case: Mapping[str, object]) -> tuple[Mapping[str, object], ...]:
+    raw_relations = case.get("gold_relations")
+    if not isinstance(raw_relations, list):
+        return ()
+    return tuple(
+        relation for relation in raw_relations if isinstance(relation, Mapping)
+    )
+
+
+def _case_topics(case: Mapping[str, object]) -> tuple[str, ...]:
+    raw_topics = case.get("topics")
+    if not isinstance(raw_topics, Sequence) or isinstance(raw_topics, str):
+        return ()
+    return tuple(topic.strip() for topic in raw_topics if isinstance(topic, str))
+
+
+def _string_sequence_field(
+    payload: Mapping[str, object],
+    field: str,
+) -> tuple[str, ...]:
+    raw_value = payload.get(field)
+    if not isinstance(raw_value, Sequence) or isinstance(raw_value, str):
+        return ()
+    return tuple(
+        value.strip() for value in raw_value if isinstance(value, str) and value.strip()
+    )
+
+
+def _is_negative_case(case: Mapping[str, object]) -> bool:
+    category = _string_field(case, "category")
+    return category == "negative_control" or "negative_control" in _case_topics(case)
+
+
+def _is_weak_case(case: Mapping[str, object]) -> bool:
+    category = _string_field(case, "category") or ""
+    return category.startswith("weak") or "low_value_review" in _case_topics(case)
+
+
+def _has_high_value_specific_gold(case: Mapping[str, object]) -> bool:
+    if _is_negative_case(case) or _is_weak_case(case):
+        return False
+    return any(
+        _string_field(relation, "value_level") == "high"
+        for relation in _relation_list(case)
+    )
+
+
+def _has_low_value_review_gold(case: Mapping[str, object]) -> bool:
+    return any(
+        _string_field(relation, "value_level") == "low"
+        or _string_field(relation, "review_status") == "review_only"
+        for relation in _relation_list(case)
+    )
+
+
+def _string_field(payload: Mapping[str, object], field: str) -> str | None:
+    value = payload.get(field)
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _bool_field(payload: Mapping[str, object], field: str) -> bool | None:
+    value = payload.get(field)
+    return value if isinstance(value, bool) else None
+
+
+def _sentence_count(text: str) -> int:
+    return sum(text.count(separator) for separator in (".", "?", "!"))
+
+
+def _has_negated_relation_phrase(text: str) -> bool:
+    lowered_text = text.lower()
+    return any(phrase in lowered_text for phrase in _NEGATED_RELATION_PHRASES)
+
+
+__all__ = [
+    "FixtureCoverage",
+    "FixtureValidationIssue",
+    "fixture_coverage",
+    "validate_fixture_file",
+    "validate_fixture_payload",
+]

--- a/scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json
+++ b/scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json
@@ -1,0 +1,698 @@
+{
+  "benchmark_name": "biomedical_relation_feasibility_v3",
+  "description": "Broader synthetic benchmark for trusted-graph readiness confidence. V3 keeps v2 as the stable regression seed while adding domain breadth, weak review-only rows, negative controls, long-document chunking, and adversarial near-misses.",
+  "provenance": "curated_synthetic_breadth_fixture",
+  "cases": [
+    {
+      "case_id": "v3_osimertinib_treats_egfr_exon19_luad",
+      "title": "Osimertinib treats EGFR exon 19 lung adenocarcinoma",
+      "category": "strong_specific",
+      "topics": ["oncology_drug_response"],
+      "text": "Osimertinib treats EGFR exon 19 deletion lung adenocarcinoma after first-line molecular testing.",
+      "gold_relations": [
+        {
+          "subject": "Osimertinib",
+          "relation_type": "TREATS",
+          "object": "EGFR exon 19 deletion lung adenocarcinoma",
+          "support_sentence": "Osimertinib treats EGFR exon 19 deletion lung adenocarcinoma after first-line molecular testing.",
+          "value_level": "high",
+          "rationale": "Specific drug-to-molecular-subtype treatment relation.",
+          "subject_curie": "DrugBank:DB09330",
+          "object_curie": "MONDO:0005061",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_alectinib_treats_alk_fusion_lung_cancer",
+      "title": "Alectinib treats ALK fusion lung cancer",
+      "category": "strong_specific",
+      "topics": ["oncology_drug_response"],
+      "text": "Alectinib treats ALK fusion-positive lung cancer with central nervous system involvement.",
+      "gold_relations": [
+        {
+          "subject": "Alectinib",
+          "relation_type": "TREATS",
+          "object": "ALK fusion-positive lung cancer",
+          "support_sentence": "Alectinib treats ALK fusion-positive lung cancer with central nervous system involvement.",
+          "value_level": "high",
+          "rationale": "Specific targeted therapy relation.",
+          "subject_curie": "DrugBank:DB11363",
+          "object_curie": "MONDO:0005233",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_sotorasib_targets_kras_g12c",
+      "title": "Sotorasib targets KRAS G12C",
+      "category": "strong_specific",
+      "topics": ["oncology_drug_response", "variant_disease_risk"],
+      "text": "Sotorasib targets KRAS G12C by binding the switch-II pocket in mutant lung cancer.",
+      "gold_relations": [
+        {
+          "subject": "Sotorasib",
+          "relation_type": "TARGETS",
+          "object": "KRAS G12C",
+          "support_sentence": "Sotorasib targets KRAS G12C by binding the switch-II pocket in mutant lung cancer.",
+          "value_level": "high",
+          "rationale": "Direct drug-to-variant target relation.",
+          "subject_curie": "DrugBank:DB15569",
+          "object_curie": "ClinVar:KRAS_G12C",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_vemurafenib_targets_braf_v600e",
+      "title": "Vemurafenib targets BRAF V600E",
+      "category": "strong_specific",
+      "topics": ["oncology_drug_response", "pathway_regulation"],
+      "text": "Vemurafenib targets BRAF V600E and suppresses downstream MAPK signaling in melanoma.",
+      "gold_relations": [
+        {
+          "subject": "Vemurafenib",
+          "relation_type": "TARGETS",
+          "object": "BRAF V600E",
+          "support_sentence": "Vemurafenib targets BRAF V600E and suppresses downstream MAPK signaling in melanoma.",
+          "value_level": "high",
+          "rationale": "Specific inhibitor-to-variant target relation.",
+          "subject_curie": "DrugBank:DB08881",
+          "object_curie": "ClinVar:BRAF_V600E",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_larotrectinib_treats_ntrk_fusion_tumors",
+      "title": "Larotrectinib treats NTRK fusion tumors",
+      "category": "strong_specific",
+      "topics": ["oncology_drug_response"],
+      "text": "Larotrectinib treats solid tumors harboring NTRK gene fusions regardless of tissue origin.",
+      "gold_relations": [
+        {
+          "subject": "Larotrectinib",
+          "relation_type": "TREATS",
+          "object": "NTRK fusion solid tumors",
+          "support_sentence": "Larotrectinib treats solid tumors harboring NTRK gene fusions regardless of tissue origin.",
+          "value_level": "high",
+          "rationale": "Tumor-agnostic targeted therapy relation.",
+          "subject_curie": "DrugBank:DB14723",
+          "object_curie": "MONDO:0100342",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_mecp2_associated_with_rett_syndrome",
+      "title": "MECP2 is associated with Rett syndrome",
+      "category": "strong_specific",
+      "topics": ["rare_disease_gene_phenotype"],
+      "text": "MECP2 pathogenic variants are associated with Rett syndrome and developmental regression.",
+      "gold_relations": [
+        {
+          "subject": "MECP2 pathogenic variants",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "Rett syndrome",
+          "support_sentence": "MECP2 pathogenic variants are associated with Rett syndrome and developmental regression.",
+          "value_level": "high",
+          "rationale": "Specific rare-disease gene-to-phenotype relation.",
+          "subject_curie": "HGNC:6990",
+          "object_curie": "MONDO:0010726",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_fbn1_associated_with_marfan_syndrome",
+      "title": "FBN1 is associated with Marfan syndrome",
+      "category": "strong_specific",
+      "topics": ["rare_disease_gene_phenotype"],
+      "text": "FBN1 loss-of-function variants are associated with Marfan syndrome and aortic root dilation.",
+      "gold_relations": [
+        {
+          "subject": "FBN1 loss-of-function variants",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "Marfan syndrome",
+          "support_sentence": "FBN1 loss-of-function variants are associated with Marfan syndrome and aortic root dilation.",
+          "value_level": "high",
+          "rationale": "Specific rare disease association.",
+          "subject_curie": "HGNC:3603",
+          "object_curie": "MONDO:0007947",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_gla_associated_with_fabry_disease",
+      "title": "GLA is associated with Fabry disease",
+      "category": "strong_specific",
+      "topics": ["rare_disease_gene_phenotype"],
+      "text": "GLA variants are associated with Fabry disease through deficient alpha-galactosidase A activity.",
+      "gold_relations": [
+        {
+          "subject": "GLA variants",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "Fabry disease",
+          "support_sentence": "GLA variants are associated with Fabry disease through deficient alpha-galactosidase A activity.",
+          "value_level": "high",
+          "rationale": "Specific rare disease association.",
+          "subject_curie": "HGNC:4296",
+          "object_curie": "MONDO:0010526",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_pah_associated_with_phenylketonuria",
+      "title": "PAH is associated with phenylketonuria",
+      "category": "strong_specific",
+      "topics": ["rare_disease_gene_phenotype"],
+      "text": "PAH pathogenic variants are associated with phenylketonuria and elevated phenylalanine.",
+      "gold_relations": [
+        {
+          "subject": "PAH pathogenic variants",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "phenylketonuria",
+          "support_sentence": "PAH pathogenic variants are associated with phenylketonuria and elevated phenylalanine.",
+          "value_level": "high",
+          "rationale": "Specific gene-to-metabolic disease relation.",
+          "subject_curie": "HGNC:8582",
+          "object_curie": "MONDO:0009861",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_ldlr_predisposes_familial_hypercholesterolemia",
+      "title": "LDLR predisposes to familial hypercholesterolemia",
+      "category": "strong_specific",
+      "topics": ["rare_disease_gene_phenotype", "variant_disease_risk"],
+      "text": "LDLR loss-of-function variants predispose carriers to familial hypercholesterolemia.",
+      "gold_relations": [
+        {
+          "subject": "LDLR loss-of-function variants",
+          "relation_type": "PREDISPOSES_TO",
+          "object": "familial hypercholesterolemia",
+          "support_sentence": "LDLR loss-of-function variants predispose carriers to familial hypercholesterolemia.",
+          "value_level": "high",
+          "rationale": "Specific variant class to disease risk relation.",
+          "subject_curie": "HGNC:6547",
+          "object_curie": "MONDO:0007750",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_brca1_predisposes_hereditary_breast_ovarian_cancer",
+      "title": "BRCA1 predisposes to hereditary breast and ovarian cancer",
+      "category": "strong_specific",
+      "topics": ["variant_disease_risk"],
+      "text": "BRCA1 truncating variants predispose carriers to hereditary breast and ovarian cancer syndrome.",
+      "gold_relations": [
+        {
+          "subject": "BRCA1 truncating variants",
+          "relation_type": "PREDISPOSES_TO",
+          "object": "hereditary breast and ovarian cancer syndrome",
+          "support_sentence": "BRCA1 truncating variants predispose carriers to hereditary breast and ovarian cancer syndrome.",
+          "value_level": "high",
+          "rationale": "Specific cancer-risk relation.",
+          "subject_curie": "HGNC:1100",
+          "object_curie": "MONDO:0011450",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_apc_predisposes_fap",
+      "title": "APC predisposes to familial adenomatous polyposis",
+      "category": "strong_specific",
+      "topics": ["variant_disease_risk"],
+      "text": "APC pathogenic variants predispose carriers to familial adenomatous polyposis.",
+      "gold_relations": [
+        {
+          "subject": "APC pathogenic variants",
+          "relation_type": "PREDISPOSES_TO",
+          "object": "familial adenomatous polyposis",
+          "support_sentence": "APC pathogenic variants predispose carriers to familial adenomatous polyposis.",
+          "value_level": "high",
+          "rationale": "Specific inherited cancer-risk relation.",
+          "subject_curie": "HGNC:583",
+          "object_curie": "MONDO:0008840",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_braf_v600e_activates_mapk",
+      "title": "BRAF V600E activates MAPK signaling",
+      "category": "strong_specific",
+      "topics": ["pathway_regulation"],
+      "text": "BRAF V600E activates MAPK signaling in melanoma cells with constitutive kinase output.",
+      "gold_relations": [
+        {
+          "subject": "BRAF V600E",
+          "relation_type": "ACTIVATES",
+          "object": "MAPK signaling",
+          "support_sentence": "BRAF V600E activates MAPK signaling in melanoma cells with constitutive kinase output.",
+          "value_level": "high",
+          "rationale": "Specific variant-to-pathway activation relation.",
+          "subject_curie": "ClinVar:BRAF_V600E",
+          "object_curie": "GO:0000165",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_pten_loss_activates_pi3k_akt",
+      "title": "PTEN loss activates PI3K-AKT signaling",
+      "category": "strong_specific",
+      "topics": ["pathway_regulation"],
+      "text": "PTEN loss activates PI3K-AKT signaling by removing lipid phosphatase restraint.",
+      "gold_relations": [
+        {
+          "subject": "PTEN loss",
+          "relation_type": "ACTIVATES",
+          "object": "PI3K-AKT signaling",
+          "support_sentence": "PTEN loss activates PI3K-AKT signaling by removing lipid phosphatase restraint.",
+          "value_level": "high",
+          "rationale": "Specific loss-of-function to pathway activation relation.",
+          "subject_curie": "HGNC:9588",
+          "object_curie": "GO:0043491",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_il6_regulates_inflammatory_signaling",
+      "title": "IL6 regulates inflammatory signaling",
+      "category": "strong_specific",
+      "topics": ["pathway_regulation"],
+      "text": "IL6 regulates inflammatory signaling through JAK-STAT activation in macrophages.",
+      "gold_relations": [
+        {
+          "subject": "IL6",
+          "relation_type": "REGULATES",
+          "object": "inflammatory signaling",
+          "support_sentence": "IL6 regulates inflammatory signaling through JAK-STAT activation in macrophages.",
+          "value_level": "high",
+          "rationale": "Specific cytokine-to-process regulation relation.",
+          "subject_curie": "HGNC:6018",
+          "object_curie": "GO:0006954",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_kras_g12d_activates_mapk",
+      "title": "KRAS G12D activates MAPK signaling",
+      "category": "strong_specific",
+      "topics": ["pathway_regulation", "variant_disease_risk"],
+      "text": "KRAS G12D activates MAPK signaling and increases pancreatic cancer cell proliferation.",
+      "gold_relations": [
+        {
+          "subject": "KRAS G12D",
+          "relation_type": "ACTIVATES",
+          "object": "MAPK signaling",
+          "support_sentence": "KRAS G12D activates MAPK signaling and increases pancreatic cancer cell proliferation.",
+          "value_level": "high",
+          "rationale": "Specific variant-to-pathway activation relation.",
+          "subject_curie": "ClinVar:KRAS_G12D",
+          "object_curie": "GO:0000165",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_pdl1_biomarker_pembrolizumab_response",
+      "title": "PD-L1 is a biomarker for pembrolizumab response",
+      "category": "strong_specific",
+      "topics": ["biomarker_treatment_response", "oncology_drug_response"],
+      "text": "PD-L1 expression is a biomarker for response to pembrolizumab in non-small cell lung cancer.",
+      "gold_relations": [
+        {
+          "subject": "PD-L1 expression",
+          "relation_type": "BIOMARKER_FOR",
+          "object": "response to pembrolizumab",
+          "support_sentence": "PD-L1 expression is a biomarker for response to pembrolizumab in non-small cell lung cancer.",
+          "value_level": "high",
+          "rationale": "Specific biomarker-to-treatment-response relation.",
+          "subject_curie": "HGNC:17635",
+          "object_curie": "DrugBank:DB09037",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_msi_high_biomarker_checkpoint_response",
+      "title": "MSI-high status is a biomarker for checkpoint inhibitor response",
+      "category": "strong_specific",
+      "topics": ["biomarker_treatment_response"],
+      "text": "MSI-high status is a biomarker for immune checkpoint inhibitor response in colorectal cancer.",
+      "gold_relations": [
+        {
+          "subject": "MSI-high status",
+          "relation_type": "BIOMARKER_FOR",
+          "object": "immune checkpoint inhibitor response",
+          "support_sentence": "MSI-high status is a biomarker for immune checkpoint inhibitor response in colorectal cancer.",
+          "value_level": "high",
+          "rationale": "Specific biomarker response relation.",
+          "subject_curie": "NCIT:C150719",
+          "object_curie": "NCIT:C157484",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_egfr_t790m_confers_resistance_gefitinib",
+      "title": "EGFR T790M confers resistance to gefitinib",
+      "category": "strong_specific",
+      "topics": ["oncology_drug_response", "biomarker_treatment_response"],
+      "text": "EGFR T790M confers resistance to gefitinib in previously responsive lung tumors.",
+      "gold_relations": [
+        {
+          "subject": "EGFR T790M",
+          "relation_type": "CONFERS_RESISTANCE_TO",
+          "object": "gefitinib",
+          "support_sentence": "EGFR T790M confers resistance to gefitinib in previously responsive lung tumors.",
+          "value_level": "high",
+          "rationale": "Specific variant-to-drug resistance relation.",
+          "subject_curie": "ClinVar:EGFR_T790M",
+          "object_curie": "DrugBank:DB00317",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_long_document_med13_regulates_septal_development",
+      "title": "Long document MED13 regulation case",
+      "category": "strong_specific",
+      "topics": ["long_document_chunking", "pathway_regulation"],
+      "text": "Background sections describe unrelated chromatin remodeling, murine atrial morphology, and cohort ascertainment. The methods then discuss sequencing controls, variant filters, and imaging protocols across several paragraphs. A supplemental paragraph lists EGFR, BRAF, MAPK signaling, pembrolizumab, and congenital heart disease only as examples used by the annotation team. Another section explains that reviewer calibration included negative controls, weak association examples, and entity-linking edge cases. In the mechanistic results, MED13 regulates cardiac septal development by coordinating transcriptional programs in embryonic cardiomyocytes. The discussion separately mentions EGFR and MAPK signaling only as examples of unrelated pathway curation challenges.",
+      "gold_relations": [
+        {
+          "subject": "MED13",
+          "relation_type": "REGULATES",
+          "object": "cardiac septal development",
+          "support_sentence": "In the mechanistic results, MED13 regulates cardiac septal development by coordinating transcriptional programs in embryonic cardiomyocytes.",
+          "value_level": "high",
+          "rationale": "Specific long-document relation requiring chunk-local extraction.",
+          "subject_curie": "HGNC:22474",
+          "object_curie": "GO:0003279",
+          "requires_entailment": true
+        }
+      ]
+    },
+    {
+      "case_id": "v3_weak_med13_may_link_congenital_heart_disease",
+      "title": "MED13 may link to congenital heart disease",
+      "category": "weak_association",
+      "topics": ["low_value_review"],
+      "text": "MED13 may be linked to congenital heart disease in a small family series.",
+      "gold_relations": [
+        {
+          "subject": "MED13",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "congenital heart disease",
+          "support_sentence": "MED13 may be linked to congenital heart disease in a small family series.",
+          "value_level": "low",
+          "review_status": "review_only",
+          "rationale": "Hedged weak association should stay in review.",
+          "subject_curie": "HGNC:22474",
+          "object_curie": "MONDO:0005267",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case_id": "v3_weak_akt_trend_survival",
+      "title": "AKT activation trends with reduced survival",
+      "category": "weak_association",
+      "topics": ["low_value_review"],
+      "text": "AKT activation showed a trend toward reduced survival in an exploratory subgroup.",
+      "gold_relations": [
+        {
+          "subject": "AKT activation",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "reduced survival",
+          "support_sentence": "AKT activation showed a trend toward reduced survival in an exploratory subgroup.",
+          "value_level": "low",
+          "review_status": "review_only",
+          "rationale": "Trend-only outcome evidence is review-only.",
+          "subject_curie": "HGNC:391",
+          "object_curie": "NCIT:C17177",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case_id": "v3_weak_hrd_possible_biomarker_platinum",
+      "title": "HRD score possible biomarker for platinum sensitivity",
+      "category": "weak_association",
+      "topics": ["low_value_review", "biomarker_treatment_response"],
+      "text": "HRD score was described as a possible biomarker for platinum sensitivity in a pilot cohort.",
+      "gold_relations": [
+        {
+          "subject": "HRD score",
+          "relation_type": "BIOMARKER_FOR",
+          "object": "platinum sensitivity",
+          "support_sentence": "HRD score was described as a possible biomarker for platinum sensitivity in a pilot cohort.",
+          "value_level": "low",
+          "review_status": "review_only",
+          "rationale": "Possible biomarker language requires review.",
+          "subject_curie": "NCIT:C120466",
+          "object_curie": "NCIT:C18295",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case_id": "v3_weak_il6_may_regulate_inflammation",
+      "title": "IL6 may regulate inflammation",
+      "category": "weak_association",
+      "topics": ["low_value_review", "pathway_regulation"],
+      "text": "IL6 may regulate inflammatory signaling under hypoxic culture conditions.",
+      "gold_relations": [
+        {
+          "subject": "IL6",
+          "relation_type": "REGULATES",
+          "object": "inflammatory signaling",
+          "support_sentence": "IL6 may regulate inflammatory signaling under hypoxic culture conditions.",
+          "value_level": "low",
+          "review_status": "review_only",
+          "rationale": "May-regulate language is review-only.",
+          "subject_curie": "HGNC:6018",
+          "object_curie": "GO:0006954",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case_id": "v3_weak_met_correlated_resistance",
+      "title": "MET amplification correlated with resistance",
+      "category": "weak_association",
+      "topics": ["low_value_review", "oncology_drug_response"],
+      "text": "MET amplification was correlated with resistance to EGFR inhibition in a small exploratory cohort.",
+      "gold_relations": [
+        {
+          "subject": "MET amplification",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "resistance to EGFR inhibition",
+          "support_sentence": "MET amplification was correlated with resistance to EGFR inhibition in a small exploratory cohort.",
+          "value_level": "low",
+          "review_status": "review_only",
+          "rationale": "Correlated-only evidence is useful for review but not trusted promotion.",
+          "subject_curie": "HGNC:7029",
+          "object_curie": "NCIT:C165567",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case_id": "v3_weak_tp53_potential_predictor_chemo",
+      "title": "TP53 status potential predictor of chemotherapy response",
+      "category": "weak_association",
+      "topics": ["low_value_review", "biomarker_treatment_response"],
+      "text": "TP53 mutation status was a potential predictor of chemotherapy response in retrospective analysis.",
+      "gold_relations": [
+        {
+          "subject": "TP53 mutation status",
+          "relation_type": "BIOMARKER_FOR",
+          "object": "chemotherapy response",
+          "support_sentence": "TP53 mutation status was a potential predictor of chemotherapy response in retrospective analysis.",
+          "value_level": "low",
+          "review_status": "review_only",
+          "rationale": "Potential predictor language stays review-only.",
+          "subject_curie": "HGNC:11998",
+          "object_curie": "NCIT:C15632",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case_id": "v3_weak_mtor_might_activate_autophagy",
+      "title": "MTOR might activate autophagy",
+      "category": "weak_association",
+      "topics": ["low_value_review", "pathway_regulation"],
+      "text": "MTOR signaling might activate autophagy markers after nutrient withdrawal in one assay.",
+      "gold_relations": [
+        {
+          "subject": "MTOR signaling",
+          "relation_type": "ACTIVATES",
+          "object": "autophagy markers",
+          "support_sentence": "MTOR signaling might activate autophagy markers after nutrient withdrawal in one assay.",
+          "value_level": "low",
+          "review_status": "review_only",
+          "rationale": "Might-activate language is weak review evidence.",
+          "subject_curie": "HGNC:3942",
+          "object_curie": "GO:0006914",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case_id": "v3_weak_jak2_possible_link_thrombosis",
+      "title": "JAK2 possible link to thrombosis",
+      "category": "weak_association",
+      "topics": ["low_value_review", "variant_disease_risk"],
+      "text": "JAK2 V617F was noted as a possible link to thrombosis in a small registry.",
+      "gold_relations": [
+        {
+          "subject": "JAK2 V617F",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "thrombosis",
+          "support_sentence": "JAK2 V617F was noted as a possible link to thrombosis in a small registry.",
+          "value_level": "low",
+          "review_status": "review_only",
+          "rationale": "Possible-link evidence should be reviewed.",
+          "subject_curie": "ClinVar:JAK2_V617F",
+          "object_curie": "MONDO:0000831",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case_id": "v3_weak_egfr_trend_response_erlotinib",
+      "title": "EGFR expression trends with erlotinib response",
+      "category": "weak_association",
+      "topics": ["low_value_review", "oncology_drug_response"],
+      "text": "EGFR expression trended with erlotinib response but did not meet the prespecified threshold.",
+      "gold_relations": [
+        {
+          "subject": "EGFR expression",
+          "relation_type": "ASSOCIATED_WITH",
+          "object": "erlotinib response",
+          "support_sentence": "EGFR expression trended with erlotinib response but did not meet the prespecified threshold.",
+          "value_level": "low",
+          "review_status": "review_only",
+          "rationale": "Trend-only drug-response evidence is review-only.",
+          "subject_curie": "HGNC:3236",
+          "object_curie": "DrugBank:DB00530",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case_id": "v3_weak_ntrk_may_predict_larotrectinib_response",
+      "title": "NTRK fusion may predict larotrectinib response",
+      "category": "weak_association",
+      "topics": ["low_value_review", "biomarker_treatment_response"],
+      "text": "NTRK fusion may predict larotrectinib response in a limited basket cohort.",
+      "gold_relations": [
+        {
+          "subject": "NTRK fusion",
+          "relation_type": "BIOMARKER_FOR",
+          "object": "larotrectinib response",
+          "support_sentence": "NTRK fusion may predict larotrectinib response in a limited basket cohort.",
+          "value_level": "low",
+          "review_status": "review_only",
+          "rationale": "Hedged prediction claim belongs in review-only lane.",
+          "subject_curie": "NCIT:C129626",
+          "object_curie": "DrugBank:DB14723",
+          "requires_entailment": false
+        }
+      ]
+    },
+    {
+      "case_id": "v3_negative_egfr_gefitinib_negated_relation",
+      "title": "Negated EGFR/gefitinib near miss",
+      "category": "negative_control",
+      "topics": ["negative_control", "adversarial_negated_near_miss", "oncology_drug_response"],
+      "near_miss_entities": ["EGFR expression", "gefitinib response"],
+      "text": "EGFR and gefitinib were both measured, but the authors found no evidence that EGFR expression predicted gefitinib response in this cohort.",
+      "gold_relations": []
+    },
+    {
+      "case_id": "v3_negative_brca1_olaparib_background_only",
+      "title": "BRCA1 and olaparib background mention",
+      "category": "negative_control",
+      "topics": ["negative_control", "oncology_drug_response"],
+      "text": "The introduction discussed BRCA1 and olaparib as background examples, while the experiment tested unrelated imaging endpoints.",
+      "gold_relations": []
+    },
+    {
+      "case_id": "v3_negative_mecp2_rett_family_history_only",
+      "title": "MECP2 and Rett syndrome family-history mention",
+      "category": "negative_control",
+      "topics": ["negative_control", "rare_disease_gene_phenotype"],
+      "text": "A family history form listed Rett syndrome and MECP2 testing, but the paper did not claim a relation for the enrolled patient.",
+      "gold_relations": []
+    },
+    {
+      "case_id": "v3_negative_braf_mapk_inhibitor_control",
+      "title": "BRAF and MAPK co-mentioned in control arm",
+      "category": "negative_control",
+      "topics": ["negative_control", "pathway_regulation"],
+      "text": "BRAF V600E and MAPK signaling were used to describe a control plasmid, not a result about pathway activation.",
+      "gold_relations": []
+    },
+    {
+      "case_id": "v3_negative_pdl1_pembrolizumab_threshold_not_met",
+      "title": "PD-L1 biomarker threshold not met",
+      "category": "negative_control",
+      "topics": ["negative_control", "biomarker_treatment_response"],
+      "text": "PD-L1 staining and pembrolizumab response were collected, but the association was not significant and no biomarker claim was made.",
+      "gold_relations": []
+    },
+    {
+      "case_id": "v3_negative_cftr_lung_cancer_unrelated",
+      "title": "CFTR and lung cancer unrelated mention",
+      "category": "negative_control",
+      "topics": ["negative_control", "rare_disease_gene_phenotype"],
+      "text": "CFTR carrier screening was listed in baseline demographics for lung cancer patients, without a disease association claim.",
+      "gold_relations": []
+    },
+    {
+      "case_id": "v3_negative_kras_sotorasib_prior_therapy",
+      "title": "KRAS and sotorasib prior therapy only",
+      "category": "negative_control",
+      "topics": ["negative_control", "oncology_drug_response"],
+      "text": "KRAS G12C and sotorasib appeared only in prior-therapy history; the current study evaluated a different investigational compound.",
+      "gold_relations": []
+    },
+    {
+      "case_id": "v3_negative_il6_inflammation_assay_failed",
+      "title": "IL6 inflammation assay failed",
+      "category": "negative_control",
+      "topics": ["negative_control", "pathway_regulation"],
+      "text": "IL6 and inflammatory signaling were planned assay endpoints, but the assay failed quality control and no regulation result was reported.",
+      "gold_relations": []
+    },
+    {
+      "case_id": "v3_negative_msi_checkpoint_response_covariate",
+      "title": "MSI and checkpoint response covariate only",
+      "category": "negative_control",
+      "topics": ["negative_control", "biomarker_treatment_response"],
+      "text": "MSI-high status and checkpoint inhibitor response were included as covariates in a table, not as a tested biomarker relation.",
+      "gold_relations": []
+    },
+    {
+      "case_id": "v3_negative_long_document_distractor",
+      "title": "Long document distractor with many entity mentions",
+      "category": "negative_control",
+      "topics": ["negative_control", "long_document_chunking"],
+      "text": "The opening review paragraph mentions MED13, EGFR, BRAF, MAPK signaling, pembrolizumab, and congenital heart disease as examples of terms used in the annotation guideline. A methods section then discusses data entry workflows, adjudication forms, and reviewer calibration without presenting experimental results. A later quality-control section lists pathway labels, drug names, and phenotype labels to show how curators should avoid over-linking co-mentioned entities. The document also includes a table-caption narrative about blinded review, duplicate adjudication, and conflict resolution. No sentence asserts a biomedical relation among these entities.",
+      "gold_relations": []
+    }
+  ]
+}

--- a/tests/unit/test_control_files.py
+++ b/tests/unit/test_control_files.py
@@ -124,6 +124,8 @@ def test_relation_feasibility_quality_gate_is_part_of_service_checks() -> None:
     make_targets = _make_targets()
 
     assert "relation-feasibility-quality-gate" in make_targets
+    assert "tests/unit/test_relation_feasibility_fixture_validation.py" in makefile
+    assert "tests/unit/test_generate_relation_feasibility_summary.py" in makefile
     assert re.search(
         r"^service-checks:.*\n(?:\t@.*\n)*\t@\$\(MAKE\) -s relation-feasibility-quality-gate",
         makefile,

--- a/tests/unit/test_generate_relation_feasibility_summary.py
+++ b/tests/unit/test_generate_relation_feasibility_summary.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.generate_relation_feasibility_summary import (
+    GenerateSummaryInput,
+    generate_summary_markdown,
+    write_generated_summary,
+)
+
+
+def test_generated_summary_includes_run_context_hashes_and_blockers(
+    tmp_path: Path,
+) -> None:
+    relation_report = tmp_path / "relation_feasibility_report.json"
+    relation_report.write_text(
+        json.dumps(
+            {
+                "summary": {
+                    "verdict": "RED",
+                    "blocking_reasons": ["fallback_case_count > 0"],
+                    "warning_reasons": ["generic relation rate high"],
+                    "case_count": 3,
+                    "gold_relation_count": 2,
+                    "completed_agent_precision_against_gold": 0.75,
+                    "completed_agent_recall_against_gold": 0.5,
+                    "high_value_recall": 0.5,
+                    "low_value_review_recall": 1.0,
+                    "trusted_eligible_curie_linked_gold_endpoint_rate": 0.5,
+                    "completed_agent_valuable_candidate_rate": 0.4,
+                    "generic_relation_rate": 0.2,
+                    "model_curie_wrong_count": 2,
+                    "raw_unknown_relation_type_count": 0,
+                    "raw_unknown_relation_type_surface_count": 0,
+                    "fallback_case_count": 1,
+                    "invalid_agent_case_count": 0,
+                    "negative_control_leakage_count": 0,
+                    "weak_claim_trusted_leakage_count": 0,
+                    "wrong_verified_curie_link_count": 0,
+                },
+                "case_results": [
+                    {
+                        "case": {"case_id": "missed_case"},
+                        "missed_gold_relations": [
+                            {
+                                "subject": "MED13",
+                                "relation_type": "ASSOCIATED_WITH",
+                                "object": "developmental delay",
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+        + "\n",
+    )
+    failure_report = tmp_path / "relation_feasibility_failure_analysis_report.json"
+    failure_report.write_text(
+        json.dumps(
+            {
+                "repeated_missed_gold_relations": [
+                    {
+                        "case_id": "missed_case",
+                        "subject": "MED13",
+                        "relation_type": "ASSOCIATED_WITH",
+                        "object": "developmental delay",
+                        "count": 2,
+                    },
+                ],
+                "repeated_false_positive_candidates": [],
+            },
+        )
+        + "\n",
+    )
+    readiness_report = tmp_path / "relation_feasibility_readiness_report.json"
+    readiness_report.write_text(
+        json.dumps(
+            {
+                "readiness_status": "not_ready",
+                "blocking_reasons": ["Minimum run count not met."],
+                "hard_failure_counts": {"fallback_case_count": 1},
+                "worst_metrics": {
+                    "completed_agent_precision_against_gold": 0.75,
+                },
+            },
+        )
+        + "\n",
+    )
+
+    markdown = generate_summary_markdown(
+        GenerateSummaryInput(
+            relation_report=relation_report,
+            failure_analysis_report=failure_report,
+            readiness_report=readiness_report,
+            branch="alvaro/evidence-pr27-benchmark-v3-doc-proof",
+            commit="abc1234",
+            command="scripts/run_relation_feasibility_audit.py --extractor agent",
+            model_label="current",
+            fixture_path=Path(
+                "scripts/validation/relation_feasibility/fixtures/"
+                "biomedical_relation_goldset_v3.json",
+            ),
+        ),
+    )
+
+    assert "# Relation Feasibility Generated Summary" in markdown
+    assert "- Branch: `alvaro/evidence-pr27-benchmark-v3-doc-proof`" in markdown
+    assert "- Commit: `abc1234`" in markdown
+    assert "- Model label: `current`" in markdown
+    assert "biomedical_relation_goldset_v3.json" in markdown
+    assert "relation_feasibility_report.json`:" in markdown
+    assert "fallback_case_count > 0" in markdown
+    assert "generic relation rate high" in markdown
+    assert "Minimum run count not met." in markdown
+    assert "completed_agent_precision_against_gold: 0.75" in markdown
+    assert "completed_agent_valuable_candidate_rate: 0.4" in markdown
+    assert "model_curie_wrong_count: 2" in markdown
+    assert "wrong_verified_curie_link_count: 0" in markdown
+    assert "MED13 ASSOCIATED_WITH developmental delay" in markdown
+
+
+def test_generated_summary_renders_curie_gap_endpoint_rows(tmp_path: Path) -> None:
+    relation_report = tmp_path / "relation_feasibility_report.json"
+    relation_report.write_text(
+        json.dumps({"summary": {"verdict": "RED"}}) + "\n",
+        encoding="utf-8",
+    )
+    failure_report = tmp_path / "relation_feasibility_failure_analysis_report.json"
+    failure_report.write_text(
+        json.dumps(
+            {
+                "curie_gaps": [
+                    {
+                        "case_id": "gap_case",
+                        "gap_type": "missing_curie",
+                        "endpoint_role": "object",
+                        "label": "EGFR exon 19 deletion lung adenocarcinoma",
+                        "gold_curie": "MONDO:0005061",
+                    },
+                    {
+                        "case_id": "hint_case",
+                        "gap_type": "unverified_model_hint",
+                        "endpoint_role": "subject",
+                        "label": "Alectinib",
+                        "candidate_curie": "CHEBI:71267",
+                        "candidate_curie_source": "model",
+                    },
+                ],
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    markdown = generate_summary_markdown(
+        GenerateSummaryInput(
+            relation_report=relation_report,
+            failure_analysis_report=failure_report,
+            branch="branch",
+            commit="commit",
+            command="command",
+            model_label="model",
+            fixture_path=Path("fixture.json"),
+        ),
+    )
+
+    assert (
+        "curie_gaps: gap_case: missing_curie object "
+        "EGFR exon 19 deletion lung adenocarcinoma -> MONDO:0005061"
+    ) in markdown
+    assert (
+        "curie_gaps: hint_case: unverified_model_hint subject "
+        "Alectinib -> CHEBI:71267 (model)"
+    ) in markdown
+    assert "unknown_subject unknown_relation unknown_object" not in markdown
+
+
+def test_write_generated_summary_creates_markdown_file(tmp_path: Path) -> None:
+    relation_report = tmp_path / "relation.json"
+    relation_report.write_text(json.dumps({"summary": {"verdict": "GREEN"}}) + "\n")
+    output = tmp_path / "summary.md"
+
+    written = write_generated_summary(
+        GenerateSummaryInput(
+            relation_report=relation_report,
+            output_path=output,
+            branch="branch",
+            commit="commit",
+            command="command",
+            model_label="model",
+            fixture_path=Path("fixture.json"),
+        ),
+    )
+
+    assert written == output
+    assert output.exists()
+    assert "- Verdict: `GREEN`" in output.read_text(encoding="utf-8")
+
+
+def test_pr27_committed_generated_summaries_are_reproducible() -> None:
+    reports_dir = Path("docs/validation/reports")
+    cases = (
+        (
+            "2026-07-06-pr27-v2-relation-feasibility-report.json",
+            None,
+            "2026-07-06-pr27-v2-generated-summary.md",
+            (
+                "scripts/run_relation_feasibility_audit.py --extractor agent "
+                "--cases scripts/validation/relation_feasibility/fixtures/"
+                "biomedical_relation_goldset_v2.json --output-dir "
+                "reports/relation_feasibility/2026-07-06-pr27-v2-run1"
+            ),
+            "scripts/validation/relation_feasibility/fixtures/"
+            "biomedical_relation_goldset_v2.json",
+        ),
+        (
+            "2026-07-06-pr27-v3-relation-feasibility-report.json",
+            "2026-07-06-pr27-v3-failure-analysis-report.json",
+            "2026-07-06-pr27-v3-generated-summary.md",
+                (
+                    "scripts/run_relation_feasibility_audit.py --extractor agent "
+                    "--cases scripts/validation/relation_feasibility/fixtures/"
+                    "biomedical_relation_goldset_v3.json --output-dir "
+                    "reports/relation_feasibility/2026-07-06-pr27-v3-run2"
+                ),
+            "scripts/validation/relation_feasibility/fixtures/"
+            "biomedical_relation_goldset_v3.json",
+        ),
+    )
+
+    for report_name, failure_name, summary_name, command, fixture_path in cases:
+        relation_report = reports_dir / report_name
+        failure_report = reports_dir / failure_name if failure_name is not None else None
+        generated = generate_summary_markdown(
+            GenerateSummaryInput(
+                relation_report=relation_report,
+                failure_analysis_report=failure_report,
+                branch="alvaro/evidence-pr27-benchmark-v3-doc-proof",
+                commit="6e67477+pr27-working-tree",
+                command=command,
+                model_label="current-agent",
+                fixture_path=Path(fixture_path),
+            ),
+        )
+
+        assert generated == (reports_dir / summary_name).read_text(encoding="utf-8")

--- a/tests/unit/test_relation_feasibility_fixture_validation.py
+++ b/tests/unit/test_relation_feasibility_fixture_validation.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.validation.relation_feasibility.fixture_checks import (
+    fixture_coverage,
+    validate_fixture_payload,
+)
+
+V3_FIXTURE = Path(
+    "scripts/validation/relation_feasibility/fixtures/"
+    "biomedical_relation_goldset_v3.json",
+)
+
+
+def test_fixture_validation_reports_structural_errors() -> None:
+    payload = {
+        "benchmark_name": "invalid_fixture",
+        "cases": [
+            {
+                "case_id": "duplicate",
+                "title": "Duplicate one",
+                "category": "strong_specific",
+                "text": "MED13 activates cardiac development.",
+                "gold_relations": [
+                    {
+                        "subject": "MED13",
+                        "relation_type": "ACTIVATES",
+                        "object": "cardiac development",
+                        "support_sentence": "",
+                        "value_level": "high",
+                        "rationale": "Missing support sentence.",
+                        "subject_curie": "HGNC:22474",
+                        "object_curie": "GO:0007507",
+                    },
+                ],
+            },
+            {
+                "case_id": "duplicate",
+                "title": "Duplicate two",
+                "category": "negative_control",
+                "text": "MED13 and EGFR are mentioned but no relation is claimed.",
+                "gold_relations": [
+                    {
+                        "subject": "",
+                        "relation_type": "",
+                        "object": "EGFR",
+                        "support_sentence": "No relation is claimed.",
+                        "value_level": "high",
+                        "rationale": "Negative control should not have gold.",
+                    },
+                ],
+            },
+            {
+                "case_id": "weak_missing_value",
+                "title": "Weak case missing value level",
+                "category": "weak_association",
+                "text": "MED13 may be associated with congenital heart disease.",
+                "gold_relations": [
+                    {
+                        "subject": "MED13",
+                        "relation_type": "ASSOCIATED_WITH",
+                        "object": "congenital heart disease",
+                        "support_sentence": (
+                            "MED13 may be associated with congenital heart disease."
+                        ),
+                        "rationale": "Weak relation needs value_level=low.",
+                    },
+                ],
+            },
+            {
+                "case_id": "trusted_missing_curie",
+                "title": "Trusted row missing CURIE",
+                "category": "strong_specific",
+                "text": "BRAF V600E activates MAPK signaling.",
+                "gold_relations": [
+                    {
+                        "subject": "BRAF V600E",
+                        "relation_type": "ACTIVATES",
+                        "object": "MAPK signaling",
+                        "support_sentence": "BRAF V600E activates MAPK signaling.",
+                        "value_level": "high",
+                        "rationale": "Trusted high-value rows need endpoint CURIEs.",
+                        "subject_curie": "ClinVar:BRAF_V600E",
+                        "object_curie": None,
+                    },
+                ],
+            },
+        ],
+    }
+
+    issues = validate_fixture_payload(payload)
+
+    assert {issue.code for issue in issues} >= {
+        "duplicate_case_id",
+        "missing_support_sentence",
+        "missing_gold_relation_field",
+        "negative_control_has_gold_relations",
+        "low_value_case_missing_value_level",
+        "trusted_high_value_missing_curie",
+    }
+
+
+def test_fixture_validation_rejects_mislabeled_hard_case_topics() -> None:
+    payload = {
+        "benchmark_name": "invalid_topic_fixture",
+        "cases": [
+            {
+                "case_id": "short_long_doc",
+                "title": "Mislabeled long document",
+                "category": "strong_specific",
+                "topics": ["long_document_chunking"],
+                "text": "MED13 regulates cardiac septal development.",
+                "gold_relations": [
+                    {
+                        "subject": "MED13",
+                        "relation_type": "REGULATES",
+                        "object": "cardiac septal development",
+                        "support_sentence": (
+                            "MED13 regulates cardiac septal development."
+                        ),
+                        "value_level": "high",
+                        "rationale": "Too short to be a chunking stressor.",
+                        "subject_curie": "HGNC:22474",
+                        "object_curie": "GO:0003279",
+                        "requires_entailment": True,
+                    },
+                ],
+            },
+            {
+                "case_id": "near_miss_without_entities",
+                "title": "Mislabeled near miss",
+                "category": "negative_control",
+                "topics": ["negative_control", "adversarial_negated_near_miss"],
+                "text": "The study did not establish a predictive relation.",
+                "gold_relations": [],
+            },
+            {
+                "case_id": "weak_not_review_only",
+                "title": "Weak row not review-only",
+                "category": "weak_association",
+                "topics": ["low_value_review"],
+                "text": "MED13 may be linked to congenital heart disease.",
+                "gold_relations": [
+                    {
+                        "subject": "MED13",
+                        "relation_type": "ASSOCIATED_WITH",
+                        "object": "congenital heart disease",
+                        "support_sentence": (
+                            "MED13 may be linked to congenital heart disease."
+                        ),
+                        "value_level": "low",
+                        "rationale": "Weak evidence should be review-only.",
+                        "subject_curie": "HGNC:22474",
+                        "object_curie": "MONDO:0005267",
+                        "requires_entailment": True,
+                    },
+                ],
+            },
+            {
+                "case_id": "trusted_without_entailment",
+                "title": "Trusted row without entailment",
+                "category": "strong_specific",
+                "topics": ["pathway_regulation"],
+                "text": "KRAS G12D activates MAPK signaling.",
+                "gold_relations": [
+                    {
+                        "subject": "KRAS G12D",
+                        "relation_type": "ACTIVATES",
+                        "object": "MAPK signaling",
+                        "support_sentence": "KRAS G12D activates MAPK signaling.",
+                        "value_level": "high",
+                        "rationale": "Trusted evidence needs entailment.",
+                        "subject_curie": "ClinVar:KRAS_G12D",
+                        "object_curie": "GO:0000165",
+                        "requires_entailment": False,
+                    },
+                ],
+            },
+        ],
+    }
+
+    issues = validate_fixture_payload(payload)
+
+    assert {issue.code for issue in issues} >= {
+        "long_document_case_too_short",
+        "near_miss_entities_missing",
+        "weak_case_not_review_only",
+        "weak_case_requires_entailment",
+        "trusted_high_value_missing_entailment_requirement",
+    }
+
+
+def test_v3_fixture_passes_validation_and_broad_coverage() -> None:
+    coverage = fixture_coverage(V3_FIXTURE)
+
+    assert coverage.issue_count == 0
+    assert coverage.high_value_specific_case_count >= 20
+    assert coverage.low_value_review_case_count >= 10
+    assert coverage.negative_control_case_count >= 10
+    assert set(coverage.topic_counts) >= {
+        "oncology_drug_response",
+        "rare_disease_gene_phenotype",
+        "variant_disease_risk",
+        "pathway_regulation",
+        "biomarker_treatment_response",
+        "long_document_chunking",
+        "adversarial_negated_near_miss",
+    }


### PR DESCRIPTION
## Summary
- Add PR27 biomedical relation benchmark v3 with 40 cases: 20 high-value, 10 low-value review-only, and 10 negative controls.
- Add fixture validation and generated relation-feasibility summary tooling.
- Add tracked PR27 JSON proof packets and generated Markdown summaries under docs/validation/reports so evidence is reviewable even though raw reports/ artifacts are ignored.
- Update the living tracker and remediation plan with v2 GREEN and v3 RED evidence.

## Key Result
- v2 seed remains GREEN.
- v3 expanded fixture is RED: precision 0.7333, trusted high-value recall 0.2000, trusted endpoint rate 0.3000, generic rate 0.3000.
- Safety invariants remain clean on v3 run2: fallback 0, invalid agent 0, negative leakage 0, weak trusted leakage 0, wrong verified links 0.

## Validation
- Focused PR27 tests: 35 passed.
- make relation-feasibility-quality-gate: passed, 81 tests.
- v3 live-agent audit run2 completed with fallback 0 and invalid agent 0.
- v3 failure attribution completed: 8 missed gold, 8 false-positive patterns, 28 CURIE-gap rows.
- Adversarial review: initial blockers fixed; final re-review PASS.
- git diff --check: passed.
- PATH="$(pwd)/.venv/bin:$PATH" pre-commit run --all-files: passed.
- make service-checks: passed, coverage 87.03%.

## Note
This PR improves measurement and proof quality. It intentionally does not claim trusted-graph readiness; v3 exposes the next blockers to attack.