### PR TITLE
PR33: Prune review burden and harden agent retries

### DIFF
--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -151,6 +151,7 @@ Status values:
 | 19 | PR-30 | `alvaro/evidence-pr30-trusted-lane-readiness` | Draft PR #113 open; three-run readiness not_ready | Separate trusted graph readiness from review-only/all-candidate triage so the gate measures auto-promotion safety without hiding review burden. | Readiness thresholds use trusted candidate precision, trusted-eligible high-value recall, trusted candidate valuable rate, trusted candidate generic rate, trusted-eligible CURIE endpoint rate, and review-only gold trusted leakage. | Added trusted-eligible high-value and trusted-candidate metrics, centralized trusted graph candidate eligibility so context relations cannot inflate readiness, made review-only gold trusted leakage a hard failure, rewired single-run verdict warnings and repeatability thresholds to the trusted lane, split Markdown reporting by trusted/review/all-candidate lanes, kept all-candidate metrics visible for triage, updated model comparison/failure attribution/adversarial wording, added RED/GREEN tests for review-only high-value/generic/context/leakage candidates, ran focused tests, failure-analysis tests, touched-file Ruff, `make relation-feasibility-quality-gate`, `make service-checks`, and strict v3 live runs5-7. Three-run readiness remains not_ready with blockers: one RED source audit, worst trusted candidate precision 0.7778, and worst trusted endpoint rate 0.8571. Trusted candidate generic rate is 0.0000 and hard failures are all 0, including review-only gold trusted leakage 0. Remaining issues: run5 missed `Larotrectinib TREATS NTRK fusion solid tumors`; runs6-7 had trusted precision misses including recurring `Vemurafenib INHIBITS MAPK signaling`. Summary: `docs/validation/reports/2026-07-06-pr30-trusted-lane-readiness-summary.md`. |
 | 20 | PR-31 | `alvaro/evidence-pr31-context-precision-guards` | Draft PR #114 open; three-run readiness READY; GitHub checks clean | Demote pathway, process, and cell-context candidates from trusted auto-promotion when they are useful review context but not curated trusted graph evidence. | Three strict v3 live-agent runs report trusted graph readiness ready with worst trusted precision, trusted high-value recall, trusted valuable rate, trusted endpoint recovery, and entailment checked rate all at 1.0000. | Added RED/GREEN quality-filter tests for Vemurafenib/MAPK pathway shadowing, KRAS/proliferation process shadowing, and JAK-STAT/macrophage cell-context activation; added fake-LLM extraction regression proving review-only metadata survives the agent path; ran focused tests, touched-file Ruff, `make relation-feasibility-quality-gate`, strict v3 live runs1-3, readiness aggregate READY, and failure analysis. Hard failures are all 0: fallback, invalid agent, negative leakage, raw unknown relation/surface, wrong verified CURIE links, weak trusted leakage, and review-only gold trusted leakage. Remaining work is review-lane usefulness, not trusted auto-promotion: weak EGFR/MET review misses and all-candidate review burden remain. Summary: `docs/validation/reports/2026-07-06-pr31-context-precision-guards-summary.md`. |
 | 21 | PR-32 | `alvaro/evidence-pr32-weak-review-recovery` | Implemented locally; post-adversarial three-run readiness READY; final gates pass | Recover weak EGFR trend-response and MET correlated-resistance evidence as review-only candidates while preserving trusted-lane safety. | Low-value review recall is 1.0000 across three strict v3 live-agent runs, weak trusted leakage remains 0, and trusted readiness remains READY. | Added weak-review prompt examples, weak-pass prompt reinforcement, `trended with` detection, trend-response relation repair, correlated-resistance object repair, post-repair duplicate merging, and schema recovery for canonical relations with spurious proposal fields. Adversarial review then tightened schema recovery to reject unknown/conflicting proposals, clear stale object CURIE metadata after object repair, and scope repair cues to the candidate claim; re-review then closed bare-`and` claim-boundary leakage. Focused tests pass (`55 passed`), touched-file Ruff passes, `make relation-feasibility-quality-gate` passes, `make service-checks` passes with coverage 87.03%, strict live runs12-14 are GREEN with low-value review recall 1.0000, fallback 0, invalid agent 0, weak trusted leakage 0, and readiness aggregate READY. Summary: `docs/validation/reports/2026-07-06-pr32-weak-review-recovery-summary.md`. |
+| 22 | PR-33 | `alvaro/evidence-pr33-review-burden-pruning` | Implemented locally; final gates pass; three-run readiness READY | Remove repeated review-burden false positives and recover rare zero-candidate/schema-invalid agent responses without deterministic fallback. | Trusted readiness remains READY, hard safety failures stay 0, and missed gold and repeated false positives are 0 across three post-adversarial strict v3 live-agent runs. | Added companion phenotype, pathway/process, downstream context, cell-context, and binding-site sibling pruning; added agent-only zero-candidate and schema-repair retries with retry-specific prompts and distinct replay keys; adversarial review and service-gate failures fixed invalid-sibling shadowing, raw-but-unusable retry suppression, schema-retry ordering, weak-pass candidate loss, partial zero-retry cue coverage, unknown-only candidate retry suppression, and over-broad pruning; focused tests pass (`80 passed`), quality-filter suite passes (`47 passed`), touched-file Ruff passes, `make relation-feasibility-quality-gate` passes, `make service-checks` passes with coverage `87.03%`, and strict post-adversarial3 live runs1-3 aggregate to READY with worst completed-agent precision 1.0000, worst recall 1.0000, worst high-value recall 1.0000, trusted precision 1.0000, trusted valuable rate 1.0000, trusted endpoint rate 1.0000, missed gold 0, false positives 0, fallback 0, invalid agent 0, negative leakage 0, weak trusted leakage 0, and wrong verified CURIE links 0. Summary: `docs/validation/reports/2026-07-06-pr33-review-burden-pruning-summary.md`. |
 
 ## PR Evidence Packet
 
@@ -211,6 +212,73 @@ Run only the service checks relevant to the changed boundary, then run the
 aggregate gate before merge when the PR is ready.
 
 ## Evidence Log
+
+### 2026-07-06 - PR-33 Review Burden Pruning And Agent Retry Hardening
+
+PR: PR-33 review burden pruning
+
+Branch: `alvaro/evidence-pr33-review-burden-pruning`
+
+Goal: Remove repeated low-value live-agent false positives from the review lane
+and add agent-only retries for rare zero-candidate and schema-invalid responses,
+without letting deterministic fallback count as evidence.
+
+Evidence:
+
+- `docs/validation/reports/2026-07-06-pr33-review-burden-pruning-summary.md`
+- `reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run1/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run2/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run3/relation_feasibility_report.json`
+- `reports/relation_feasibility_readiness/2026-07-06-pr33-review-burden-postadversarial3-runs1-3/relation_feasibility_readiness_report.json`
+- `reports/relation_feasibility_failure_analysis/2026-07-06-pr33-review-burden-postadversarial3-runs1-3/relation_feasibility_failure_analysis_report.json`
+
+Final three-run strict live-agent metrics:
+
+| Metric | Worst | Mean |
+|---|---:|---:|
+| Trusted readiness | READY | READY |
+| Completed-agent precision | 1.0000 | 1.0000 |
+| Completed-agent recall | 1.0000 | 1.0000 |
+| Completed-agent valuable rate | 0.5333 | 0.5333 |
+| High-value recall | 1.0000 | 1.0000 |
+| Trusted candidate precision | 1.0000 | 1.0000 |
+| Trusted candidate valuable rate | 1.0000 | 1.0000 |
+| Trusted candidate generic rate | 0.0000 | 0.0000 |
+| Trusted-eligible high-value recall | 1.0000 | 1.0000 |
+| Trusted-eligible CURIE endpoint rate | 1.0000 | 1.0000 |
+| Entailment checked rate | 1.0000 | 1.0000 |
+| Verified CURIE match rate | 0.7250 | 0.7250 |
+
+Failure attribution:
+
+- missed gold relations: `0`
+- repeated false positives: `0`
+- fallback cases: `0`
+- invalid agent cases: `0`
+- negative-control leakage: `0`
+- weak-claim trusted leakage: `0`
+- review-only gold trusted leakage: `0`
+- wrong verified CURIE links: `0`
+- CURIE gaps: `35`, mostly review-only endpoint decisions and unverified model
+  hints that remain outside trusted promotion
+
+Validation:
+
+- Focused PR33 relation/retry suite: `80 passed in 0.87s`
+- Quality-filter suite: `47 passed in 0.16s`
+- Touched-file Ruff: `All checks passed!`
+- `make relation-feasibility-quality-gate`: passed
+- `make service-checks`: passed with coverage `87.03%`
+- Post-adversarial3 strict live-agent runs1-3: all `GREEN`
+- Adversarial review fixes: invalid target siblings can no longer shadow valid
+  pathway evidence, and raw-but-unusable model relations no longer suppress the
+  zero-candidate agent retry. The post-review schema failure is now covered by
+  RED/GREEN schema-repair retry regressions, including schema-to-zero retry
+  chaining, weak-pass candidate preservation, and unknown-only candidate retry.
+- Readiness aggregate:
+  `reports/relation_feasibility_readiness/2026-07-06-pr33-review-burden-postadversarial3-runs1-3/relation_feasibility_readiness_report.md`
+- Failure analysis:
+  `reports/relation_feasibility_failure_analysis/2026-07-06-pr33-review-burden-postadversarial3-runs1-3/relation_feasibility_failure_analysis_report.md`
 
 ### 2026-07-06 - PR-29 V3 CURIE Recovery And Rare-Disease Recall
 

--- a/docs/validation/reports/2026-07-06-pr33-review-burden-pruning-summary.md
+++ b/docs/validation/reports/2026-07-06-pr33-review-burden-pruning-summary.md
@@ -1,0 +1,236 @@
+# PR33 Review Burden Pruning Summary
+
+## Run Context
+
+- Branch: `alvaro/evidence-pr33-review-burden-pruning`
+- Base branch: `alvaro/evidence-pr32-weak-review-recovery`
+- Commit: PR branch head
+- Fixture path:
+  `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json`
+- Model label: live agent configured by `.env.postgres`
+
+## Goal
+
+Reduce repeated low-value relation noise from the live-agent path while
+preserving trusted-graph readiness. This PR keeps deterministic fallback out of
+the evidence path and uses bounded agent retries only.
+
+The repeated review-burden targets were:
+
+- `PAH pathogenic variants ASSOCIATED_WITH elevated phenylalanine`
+- `Vemurafenib INHIBITS MAPK signaling`
+- `BRAF V600E DOWNSTREAM_OF MAPK signaling`
+- `JAK-STAT ACTIVATES macrophages`
+- `Sotorasib TARGETS switch-II pocket`
+
+During validation, live runs also exposed two agent-path robustness failures:
+
+- a zero-usable-candidate response for
+  `Larotrectinib TREATS NTRK fusion solid tumors`
+- schema-invalid output where a canonical `relation_type` was paired with a
+  conflicting `proposed_relation_type`
+
+PR33 therefore adds bounded agent-only retries for zero usable candidates and
+schema repair. Neither retry uses regex or deterministic fallback evidence.
+
+## Code Changes
+
+- Added sibling-aware review-burden pruning for companion biochemical phenotype
+  candidates when a same-sentence disease relation survives.
+- Promoted direct-target shadowing from review-only to filtered for pathway and
+  process companion effects. After adversarial review, target siblings must pass
+  the base quality floor before they can shadow a pathway effect.
+- Added clause-scoped downstream-context pruning so direct mechanism context is
+  filtered only when it belongs to the same claim.
+- Added primary-relation shadowing for cell-context activation candidates such
+  as `JAK-STAT ACTIVATES macrophages` beside `IL6 REGULATES inflammatory
+  signaling`.
+- Added binding-site pruning so `Sotorasib TARGETS switch-II pocket` is
+  filtered when `Sotorasib TARGETS KRAS G12C` survives in the same sentence.
+- Added a bounded agent-only retry for zero converted-candidate extraction when
+  the text contains relation cues. The retry uses prompt-version suffix
+  `zero_candidate_retry.v1` and an explicit instruction to re-read the text
+  without inventing relations or using deterministic fallback.
+- Added a bounded agent-only retry for schema-validation failures. The retry
+  uses prompt-version suffix `schema_retry.v1` and instructs the agent not to
+  set `proposed_relation_type` when `relation_type` is already canonical.
+
+## Artifact Hashes
+
+- `reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run1/relation_feasibility_report.json`:
+  `85e00b39c66485685bdcc3f4c02a5905183c7279940cbeca92376d220a828d5f`
+- `reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run2/relation_feasibility_report.json`:
+  `c0dcbb359d1aeb2cf99668e179729e48a140cb0bab2ef018247718fa904aef2e`
+- `reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run3/relation_feasibility_report.json`:
+  `0be2831735545e7a04ec88d8f98f001ef6b18c10a9a211aba0f261fa8bc267b9`
+- `reports/relation_feasibility_readiness/2026-07-06-pr33-review-burden-postadversarial3-runs1-3/relation_feasibility_readiness_report.json`:
+  `ed00f69d2d8a6d5ef0956b527f7aac8d8cced70d652d7f75b3ba88dff906d97c`
+- `reports/relation_feasibility_failure_analysis/2026-07-06-pr33-review-burden-postadversarial3-runs1-3/relation_feasibility_failure_analysis_report.json`:
+  `999caadcdff5a60aaa512bf1f6a127a00ab413dac6c806accad30ed7dc5808a0`
+
+## Validation
+
+Schema-retry RED/GREEN regression:
+
+```bash
+uv run pytest \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_retries_schema_validation_failure
+```
+
+Result:
+
+- before implementation: failed with escaped Pydantic `ValidationError`
+- after implementation: `1 passed in 0.19s`
+
+Focused PR33 suite:
+
+```bash
+uv run pytest \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_filters_pathway_target_sibling \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_retries_zero_candidate_agent_pass \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_retries_zero_converted_candidates \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_retries_schema_validation_failure \
+  services/artana_evidence_api/tests/unit/test_review_only_candidate_policy.py \
+  services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_uses_agent_review_only_pass \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_scopes_step_key_to_document_payload \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_reads_beyond_first_chunk \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_repairs_weak_met_resistance_object \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py::test_extract_relation_candidates_with_llm_keeps_weak_generic_review_only \
+  services/artana_evidence_api/tests/unit/test_document_extraction_modules.py::test_llm_extraction_prompt_preserves_useful_weak_claims_as_review_only \
+  services/artana_evidence_api/tests/unit/test_document_extraction_modules.py::test_weak_review_prompt_names_repeated_v3_review_misses \
+  services/artana_evidence_api/tests/unit/test_document_extraction_modules.py::test_llm_extraction_schema_ignores_spurious_proposal_on_canonical_relation \
+  services/artana_evidence_api/tests/unit/test_document_extraction_modules.py::test_llm_extraction_schema_rejects_unknown_proposal_on_canonical_relation \
+  services/artana_evidence_api/tests/unit/test_document_extraction_modules.py::test_llm_extraction_schema_rejects_conflicting_proposal_on_canonical_relation
+```
+
+Result: `80 passed in 0.87s`
+
+Focused quality-filter suite:
+
+```bash
+uv run pytest services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py
+```
+
+Result: `47 passed in 0.16s`
+
+Touched-file Ruff:
+
+```bash
+uv run ruff check \
+  services/artana_evidence_api/document_extraction.py \
+  services/artana_evidence_api/document_extraction_support/llm_extraction \
+  services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py \
+  services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py
+```
+
+Result: `All checks passed!`
+
+Quality gate:
+
+```bash
+make relation-feasibility-quality-gate
+```
+
+Result: relation feasibility audit, readiness, model comparison, fixture
+validation, and summary tests passed.
+
+Full service gate:
+
+```bash
+make service-checks
+```
+
+Result: passed with coverage `87.03%` against the `86%` floor.
+
+Strict live-agent runs:
+
+```bash
+set -a; source .env.postgres; set +a; \
+  uv run python scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json \
+  --output-dir reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run1
+
+set -a; source .env.postgres; set +a; \
+  uv run python scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json \
+  --output-dir reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run2
+
+set -a; source .env.postgres; set +a; \
+  uv run python scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json \
+  --output-dir reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run3
+```
+
+Aggregate reports:
+
+```bash
+uv run python scripts/run_relation_feasibility_readiness_gate.py \
+  --report reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run1 \
+  --report reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run2 \
+  --report reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run3 \
+  --min-runs 3 \
+  --output-dir reports/relation_feasibility_readiness/2026-07-06-pr33-review-burden-postadversarial3-runs1-3
+
+uv run python scripts/summarize_relation_readiness_failures.py \
+  --report postadversarial3-run1=reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run1 \
+  --report postadversarial3-run2=reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run2 \
+  --report postadversarial3-run3=reports/relation_feasibility/2026-07-06-pr33-review-burden-postadversarial3-run3 \
+  --output-dir reports/relation_feasibility_failure_analysis/2026-07-06-pr33-review-burden-postadversarial3-runs1-3
+```
+
+## Three-Run Readiness Result
+
+Trusted graph readiness is **READY** for the measured v3 live-agent trusted
+lane.
+
+| Metric | Worst | Mean |
+|---|---:|---:|
+| Completed-agent precision | 1.0000 | 1.0000 |
+| Completed-agent recall | 1.0000 | 1.0000 |
+| Completed-agent valuable candidate rate | 0.5333 | 0.5333 |
+| High-value recall | 1.0000 | 1.0000 |
+| Trusted candidate precision | 1.0000 | 1.0000 |
+| Trusted candidate valuable rate | 1.0000 | 1.0000 |
+| Trusted candidate generic relation rate | 0.0000 | 0.0000 |
+| Trusted-eligible high-value recall | 1.0000 | 1.0000 |
+| Trusted-eligible CURIE endpoint rate | 1.0000 | 1.0000 |
+| Entailment checked rate | 1.0000 | 1.0000 |
+| All-candidate generic relation rate | 0.3000 | 0.3000 |
+| Verified CURIE match rate | 0.7250 | 0.7250 |
+
+Hard failures across post-adversarial3 runs1-3:
+
+- fallback case count: `0`
+- invalid agent case count: `0`
+- negative control leakage count: `0`
+- raw unknown relation type count: `0`
+- raw unknown relation type surface count: `0`
+- wrong verified CURIE link count: `0`
+- weak claim trusted leakage count: `0`
+- review-only gold trusted leakage count: `0`
+
+Failure attribution after PR33:
+
+- missed gold relations: `none`
+- repeated false positives: `none`
+- CURIE gaps: `35`, mostly review-only endpoint decisions, missing low-value
+  review endpoints, and unverified model hints
+
+## Interpretation
+
+PR33 converts repeated live-agent review noise into code-enforced pruning and
+adds bounded agent-only recovery passes for two observed live-path robustness
+failures: zero usable candidates and schema-invalid canonical/proposal output.
+
+The trusted lane is ready in the three-run post-adversarial3 batch: no blocking
+readiness reasons, trusted precision `1.0000`, trusted valuable rate `1.0000`,
+trusted generic relation rate `0.0000`, and hard safety failures all `0`.
+
+The all-candidate lane still shows useful follow-up work. CURIE gaps remain for
+review-only or low-value evidence. Those are not trusted auto-promotion blockers
+for PR33, but they should continue feeding the next remediation loop.

--- a/services/artana_evidence_api/document_extraction.py
+++ b/services/artana_evidence_api/document_extraction.py
@@ -65,16 +65,13 @@ from artana_evidence_api.document_extraction_review import (
 from artana_evidence_api.document_extraction_support.full_text_chunking import (
     build_relation_extraction_text_chunks,
 )
+from artana_evidence_api.document_extraction_support.llm_extraction.runner import (
+    run_llm_relation_extraction_with_zero_retry,
+)
 from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
-    LLM_EXTRACTION_PROMPT_VERSION,
-    LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
-    build_llm_extraction_prompt,
-    build_llm_weak_review_extraction_prompt,
     fingerprinted_step_key,
     llm_extraction_document_fingerprint,
-    llm_extraction_step_key,
     merge_duplicate_relation_candidates,
-    run_llm_relation_extraction_pass,
 )
 from artana_evidence_api.document_extraction_support.relation_candidate_quality_filter import (
     RelationCandidateQualityFilterResult,
@@ -113,7 +110,6 @@ _MAX_AI_ENTITY_PRE_RESOLUTION_LABELS = 4
 _AI_ENTITY_PRE_RESOLUTION_TIMEOUT_SECONDS = 2.0
 _LLM_CANDIDATE_EXTRACTION_TIMEOUT_SECONDS = 5.0
 _LLM_PROPOSAL_REVIEW_TIMEOUT_SECONDS = 5.0
-_WEAK_REVIEW_AGENT_PASS_REASON = "weak_review_agent_pass"
 _RELATION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
         re.compile(
@@ -515,60 +511,21 @@ async def extract_relation_candidates_with_llm(
             model_port=LiteLLMAdapter(timeout_seconds=60.0),
         )
         client = SingleStepModelClient(kernel=kernel)
-        candidates: list[ExtractedRelationCandidate] = []
-        unknown_relation_types: set[str] = set()
-        raw_relation_count = 0
-        for chunk in chunks:
-            extraction_passes = (
-                (
-                    LLM_EXTRACTION_PROMPT_VERSION,
-                    build_llm_extraction_prompt(
-                        chunk=chunk,
-                        total_chunks=len(chunks),
-                        document_fingerprint=document_fingerprint,
-                    ),
-                    output_schema,
-                    (),
-                ),
-                (
-                    LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
-                    build_llm_weak_review_extraction_prompt(
-                        chunk=chunk,
-                        total_chunks=len(chunks),
-                        document_fingerprint=document_fingerprint,
-                    ),
-                    weak_review_output_schema,
-                    (_WEAK_REVIEW_AGENT_PASS_REASON,),
-                ),
-            )
-            for prompt_version, prompt, pass_output_schema, force_review_only_reason_codes in (
-                extraction_passes
-            ):
-                chunk_candidates, chunk_unknown_relation_types, chunk_raw_count = (
-                    await run_llm_relation_extraction_pass(
-                        step_runner=run_single_step_with_policy,
-                        client=client,
-                        tenant=tenant,
-                        model_id=model_id,
-                        prompt=prompt,
-                        output_schema=pass_output_schema,
-                        step_key=llm_extraction_step_key(
-                            text=chunk.text,
-                            max_relations=max_relations,
-                            model_id=model_id,
-                            prompt_version=prompt_version,
-                            chunk_index=chunk.index,
-                            total_chunks=len(chunks),
-                            document_fingerprint=document_fingerprint,
-                        ),
-                        force_review_only_reason_codes=(
-                            force_review_only_reason_codes
-                        ),
-                    )
-                )
-                raw_relation_count += chunk_raw_count
-                candidates.extend(chunk_candidates)
-                unknown_relation_types.update(chunk_unknown_relation_types)
+        extraction_attempt = await run_llm_relation_extraction_with_zero_retry(
+            normalized_text=normalized_text,
+            chunks=chunks,
+            max_relations=max_relations,
+            document_fingerprint=document_fingerprint,
+            output_schema=output_schema,
+            weak_review_output_schema=weak_review_output_schema,
+            client=client,
+            tenant=tenant,
+            model_id=model_id,
+            step_runner=run_single_step_with_policy,
+        )
+        raw_relation_count = extraction_attempt.raw_relation_count
+        candidates = extraction_attempt.candidates
+        unknown_relation_types = extraction_attempt.unknown_relation_types
 
         candidates = await _resolve_unknown_llm_relation_types(
             candidates=candidates,

--- a/services/artana_evidence_api/document_extraction_support/llm_extraction/__init__.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_extraction/__init__.py
@@ -1,0 +1,2 @@
+"""LLM extraction orchestration helpers."""
+

--- a/services/artana_evidence_api/document_extraction_support/llm_extraction/runner.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_extraction/runner.py
@@ -1,0 +1,265 @@
+"""LLM relation extraction pass orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from artana_evidence_api.document_extraction_contracts import (
+    ExtractedRelationCandidate,
+)
+from artana_evidence_api.document_extraction_relation_taxonomy import (
+    LLM_VALID_RELATION_TYPES,
+)
+from artana_evidence_api.document_extraction_support.full_text_chunking import (
+    RelationExtractionTextChunk,
+)
+from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+    LLM_EXTRACTION_PROMPT_VERSION,
+    LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+    ModelStepRunner,
+    build_llm_extraction_prompt,
+    build_llm_weak_review_extraction_prompt,
+    llm_extraction_step_key,
+    run_llm_relation_extraction_pass,
+)
+from pydantic import BaseModel, ValidationError
+
+_WEAK_REVIEW_AGENT_PASS_REASON = "weak_review_agent_pass"
+_LLM_ZERO_CANDIDATE_RETRY_PROMPT_SUFFIX = "zero_candidate_retry.v1"
+_LLM_SCHEMA_RETRY_PROMPT_SUFFIX = "schema_retry.v1"
+_LLM_ZERO_CANDIDATE_RETRY_INSTRUCTION = """
+
+ZERO-CANDIDATE RETRY:
+A prior relation extraction attempt returned zero usable relations for this same text.
+Re-read the text carefully. If the text states a direct biomedical relation, return the
+specific relation. If the text truly contains no asserted relation, return an empty relation list.
+Do not invent relations, and do not use deterministic fallback output.
+"""
+_LLM_SCHEMA_RETRY_INSTRUCTION = """
+
+SCHEMA REPAIR RETRY:
+A prior relation extraction attempt failed schema validation for this same text.
+Return the same evidence only if it is directly asserted, but repair the JSON so it
+passes the schema. Do not set proposed_relation_type when relation_type is already
+one of the canonical allowed relation types. Only use proposed_relation_type when
+relation_type is UNKNOWN_RELATION_TYPE.
+"""
+
+
+@dataclass(slots=True)
+class LLMRelationExtractionAttempt:
+    candidates: list[ExtractedRelationCandidate]
+    unknown_relation_types: set[str]
+    raw_relation_count: int
+
+
+def _should_retry_zero_candidate_agent_extraction(normalized_text: str) -> bool:
+    return normalized_text.strip() != ""
+
+
+def _has_usable_relation_candidate(
+    candidates: list[ExtractedRelationCandidate],
+) -> bool:
+    return any(
+        candidate.relation_type in LLM_VALID_RELATION_TYPES for candidate in candidates
+    )
+
+
+def _prompt_with_retry_instruction(prompt: str, retry_prompt_instruction: str) -> str:
+    return f"{prompt}{retry_prompt_instruction}"
+
+
+async def _run_llm_relation_extraction_attempt(
+    *,
+    chunks: tuple[RelationExtractionTextChunk, ...],
+    max_relations: int,
+    document_fingerprint: str,
+    output_schema: type[BaseModel],
+    weak_review_output_schema: type[BaseModel],
+    client: object,
+    tenant: object,
+    model_id: str,
+    step_runner: ModelStepRunner,
+    retry_prompt_suffix: str | None = None,
+    retry_prompt_instruction: str = "",
+) -> LLMRelationExtractionAttempt:
+    candidates: list[ExtractedRelationCandidate] = []
+    unknown_relation_types: set[str] = set()
+    raw_relation_count = 0
+    for chunk in chunks:
+        extraction_passes = (
+            (
+                LLM_EXTRACTION_PROMPT_VERSION,
+                build_llm_extraction_prompt(
+                    chunk=chunk,
+                    total_chunks=len(chunks),
+                    document_fingerprint=document_fingerprint,
+                ),
+                output_schema,
+                (),
+            ),
+            (
+                LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+                build_llm_weak_review_extraction_prompt(
+                    chunk=chunk,
+                    total_chunks=len(chunks),
+                    document_fingerprint=document_fingerprint,
+                ),
+                weak_review_output_schema,
+                (_WEAK_REVIEW_AGENT_PASS_REASON,),
+            ),
+        )
+        for prompt_version, prompt, pass_output_schema, force_review_only_reason_codes in (
+            extraction_passes
+        ):
+            effective_prompt = (
+                prompt
+                if retry_prompt_suffix is None
+                else _prompt_with_retry_instruction(prompt, retry_prompt_instruction)
+            )
+            effective_prompt_version = (
+                prompt_version
+                if retry_prompt_suffix is None
+                else f"{prompt_version}.{retry_prompt_suffix}"
+            )
+            effective_step_key = llm_extraction_step_key(
+                text=chunk.text,
+                max_relations=max_relations,
+                model_id=model_id,
+                prompt_version=effective_prompt_version,
+                chunk_index=chunk.index,
+                total_chunks=len(chunks),
+                document_fingerprint=document_fingerprint,
+            )
+            schema_retry_prompt_version = (
+                f"{effective_prompt_version}.{_LLM_SCHEMA_RETRY_PROMPT_SUFFIX}"
+            )
+            schema_retry_step_key = llm_extraction_step_key(
+                text=chunk.text,
+                max_relations=max_relations,
+                model_id=model_id,
+                prompt_version=schema_retry_prompt_version,
+                chunk_index=chunk.index,
+                total_chunks=len(chunks),
+                document_fingerprint=document_fingerprint,
+            )
+            chunk_candidates, chunk_unknown_relation_types, chunk_raw_count = (
+                await _run_llm_relation_extraction_pass_with_schema_retry(
+                    step_runner=step_runner,
+                    client=client,
+                    tenant=tenant,
+                    model_id=model_id,
+                    prompt=effective_prompt,
+                    output_schema=pass_output_schema,
+                    step_key=effective_step_key,
+                    schema_retry_prompt=_prompt_with_retry_instruction(
+                        effective_prompt,
+                        _LLM_SCHEMA_RETRY_INSTRUCTION,
+                    ),
+                    schema_retry_step_key=schema_retry_step_key,
+                    force_review_only_reason_codes=force_review_only_reason_codes,
+                )
+            )
+            raw_relation_count += chunk_raw_count
+            candidates.extend(chunk_candidates)
+            unknown_relation_types.update(chunk_unknown_relation_types)
+    return LLMRelationExtractionAttempt(
+        candidates=candidates,
+        unknown_relation_types=unknown_relation_types,
+        raw_relation_count=raw_relation_count,
+    )
+
+
+async def _run_llm_relation_extraction_pass_with_schema_retry(
+    *,
+    step_runner: ModelStepRunner,
+    client: object,
+    tenant: object,
+    model_id: str,
+    prompt: str,
+    output_schema: type[BaseModel],
+    step_key: str,
+    schema_retry_prompt: str,
+    schema_retry_step_key: str,
+    force_review_only_reason_codes: tuple[str, ...],
+) -> tuple[list[ExtractedRelationCandidate], set[str], int]:
+    try:
+        return await run_llm_relation_extraction_pass(
+            step_runner=step_runner,
+            client=client,
+            tenant=tenant,
+            model_id=model_id,
+            prompt=prompt,
+            output_schema=output_schema,
+            step_key=step_key,
+            force_review_only_reason_codes=force_review_only_reason_codes,
+        )
+    except ValidationError:
+        return await run_llm_relation_extraction_pass(
+            step_runner=step_runner,
+            client=client,
+            tenant=tenant,
+            model_id=model_id,
+            prompt=schema_retry_prompt,
+            output_schema=output_schema,
+            step_key=schema_retry_step_key,
+            force_review_only_reason_codes=force_review_only_reason_codes,
+        )
+
+
+async def run_llm_relation_extraction_with_zero_retry(
+    *,
+    normalized_text: str,
+    chunks: tuple[RelationExtractionTextChunk, ...],
+    max_relations: int,
+    document_fingerprint: str,
+    output_schema: type[BaseModel],
+    weak_review_output_schema: type[BaseModel],
+    client: object,
+    tenant: object,
+    model_id: str,
+    step_runner: ModelStepRunner,
+) -> LLMRelationExtractionAttempt:
+    extraction_attempt = await _run_llm_relation_extraction_attempt(
+        chunks=chunks,
+        max_relations=max_relations,
+        document_fingerprint=document_fingerprint,
+        output_schema=output_schema,
+        weak_review_output_schema=weak_review_output_schema,
+        client=client,
+        tenant=tenant,
+        model_id=model_id,
+        step_runner=step_runner,
+    )
+    if (
+        _has_usable_relation_candidate(extraction_attempt.candidates)
+        or not _should_retry_zero_candidate_agent_extraction(normalized_text)
+    ):
+        return extraction_attempt
+
+    retry_attempt = await _run_llm_relation_extraction_attempt(
+        chunks=chunks,
+        max_relations=max_relations,
+        document_fingerprint=document_fingerprint,
+        output_schema=output_schema,
+        weak_review_output_schema=weak_review_output_schema,
+        client=client,
+        tenant=tenant,
+        model_id=model_id,
+        step_runner=step_runner,
+        retry_prompt_suffix=_LLM_ZERO_CANDIDATE_RETRY_PROMPT_SUFFIX,
+        retry_prompt_instruction=_LLM_ZERO_CANDIDATE_RETRY_INSTRUCTION,
+    )
+    return LLMRelationExtractionAttempt(
+        candidates=retry_attempt.candidates,
+        unknown_relation_types=retry_attempt.unknown_relation_types,
+        raw_relation_count=(
+            extraction_attempt.raw_relation_count + retry_attempt.raw_relation_count
+        ),
+    )
+
+
+__all__ = [
+    "LLMRelationExtractionAttempt",
+    "run_llm_relation_extraction_with_zero_retry",
+]

--- a/services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py
+++ b/services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py
@@ -26,6 +26,7 @@ from artana_evidence_api.document_extraction_support.review_policy.review_only_c
 )
 
 RelationCandidateQualityFilterReason = Literal[
+    "binding_site_shadowed_by_molecular_target",
     "companion_phenotype_shadowed_by_disease",
     "context_relation_shadowed_by_direct_mechanism",
     "dropped_object_modifier",
@@ -79,6 +80,7 @@ _DISEASE_CONTEXT_TOKENS = frozenset(
         "melanoma",
         "neoplasm",
         "neoplasms",
+        "phenylketonuria",
         "polyposis",
         "syndrome",
         "tumor",
@@ -116,6 +118,12 @@ _CELL_CONTEXT_TOKENS = frozenset(
         "macrophages",
     },
 )
+_BINDING_SITE_CONTEXT_TOKENS = frozenset(
+    {
+        "pocket",
+        "site",
+    },
+)
 _RESISTANCE_OBJECT_BOUNDARY_AFTER_PATTERN = (
     "after|although|among|and|are|because|before|but|cases|cells|cohort|"
     "despite|did|do|does|during|for|however|in|is|patients|samples|show|"
@@ -144,6 +152,8 @@ _UNCERTAIN_RELATION_CUE_RE = re.compile(
     r")\b",
     re.IGNORECASE,
 )
+_MOLECULAR_TARGET_TOKEN_RE = re.compile(r"^[A-Z][A-Z0-9.-]{1,}$")
+_VARIANT_TOKEN_RE = re.compile(r"^[A-Z][0-9]+[A-Z*]$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -202,6 +212,18 @@ def filter_low_value_relation_candidates(
                 continue
             reason = sibling_decision.reason
         if reason is None and _is_cell_context_object(candidate):
+            if _cell_context_shadowed_by_primary_relation(
+                candidate=candidate,
+                candidates=repaired_candidates,
+            ):
+                filtered_candidates.append(
+                    QualityFilteredRelationCandidate(
+                        candidate_index=candidate_index,
+                        candidate=candidate,
+                        reason="cell_context_object",
+                    ),
+                )
+                continue
             kept_candidates.append(
                 _with_review_only_reason(candidate, "cell_context_object"),
             )
@@ -477,6 +499,13 @@ def _sibling_shadow_decision(
             "pathway_effect_shadowed_by_direct_target",
         ),
         (
+            _binding_site_shadow_action(
+                candidate=candidate,
+                candidates=candidates,
+            ),
+            "binding_site_shadowed_by_molecular_target",
+        ),
+        (
             _process_effect_shadow_action(
                 candidate=candidate,
                 candidates=candidates,
@@ -602,11 +631,64 @@ def _pathway_effect_shadow_action(
         and canonicalize_extraction_relation_type(sibling.relation_type) == "TARGETS"
         and _normalize_entity_label(sibling.subject_label) == candidate_subject
         and _normalize_sentence(sibling.sentence) == candidate_sentence
+        and _sibling_shares_claim_scope(candidate, sibling)
+        and _is_specific_molecular_target_object(sibling.object_label)
+        and _quality_filter_reason(sibling) is None
         for sibling in candidates
     )
     if not shadowed_by_direct_target:
         return None
-    return "filter" if not _candidate_relation_cue_present(candidate) else "review_only"
+    return "filter"
+
+
+def _binding_site_shadow_action(
+    *,
+    candidate: ExtractedRelationCandidate,
+    candidates: tuple[ExtractedRelationCandidate, ...],
+) -> _SiblingShadowAction | None:
+    canonical_relation = canonicalize_extraction_relation_type(candidate.relation_type)
+    if canonical_relation != "TARGETS":
+        return None
+    if not _is_binding_site_context_object(candidate):
+        return None
+    candidate_subject = _normalize_entity_label(candidate.subject_label)
+    candidate_object = _normalize_entity_label(candidate.object_label)
+    candidate_sentence = _normalize_sentence(candidate.sentence)
+    has_surviving_molecular_target_sibling = any(
+        sibling is not candidate
+        and canonicalize_extraction_relation_type(sibling.relation_type) == "TARGETS"
+        and _normalize_entity_label(sibling.subject_label) == candidate_subject
+        and _normalize_sentence(sibling.sentence) == candidate_sentence
+        and _normalize_entity_label(sibling.object_label) != candidate_object
+        and _sibling_shares_claim_scope(candidate, sibling)
+        and _is_specific_molecular_target_object(sibling.object_label)
+        and not _has_binding_site_context_token(sibling.object_label)
+        and _quality_filter_reason(sibling) is None
+        for sibling in candidates
+    )
+    return "filter" if has_surviving_molecular_target_sibling else None
+
+
+def _is_binding_site_context_object(candidate: ExtractedRelationCandidate) -> bool:
+    candidate_object = _normalize_entity_label(candidate.object_label)
+    if not _has_binding_site_context_token(candidate_object):
+        return False
+    object_pattern = _phrase_pattern(candidate_object)
+    if object_pattern == "":
+        return False
+    return (
+        re.search(
+            rf"\b(?:bind|binds|binding|bound)\b"
+            rf".{{0,80}}\b{object_pattern}\b",
+            _normalize_entity_label(candidate.sentence),
+        )
+        is not None
+    )
+
+
+def _has_binding_site_context_token(label: str) -> bool:
+    normalized_label = _normalize_entity_label(label)
+    return bool(_BINDING_SITE_CONTEXT_TOKENS.intersection(normalized_label.split()))
 
 
 def _process_effect_shadow_action(
@@ -627,13 +709,14 @@ def _process_effect_shadow_action(
         in {"ACTIVATES", "INHIBITS", "REGULATES"}
         and _normalize_entity_label(sibling.subject_label) == candidate_subject
         and _normalize_sentence(sibling.sentence) == candidate_sentence
+        and _sibling_shares_claim_scope(candidate, sibling)
         and _has_broad_pathway_effect_object(sibling.object_label)
         and _quality_filter_reason(sibling) is None
         for sibling in candidates
     )
     if not shadowed_by_pathway_mechanism:
         return None
-    return "review_only"
+    return "filter"
 
 
 def _is_cell_context_object(candidate: ExtractedRelationCandidate) -> bool:
@@ -658,6 +741,31 @@ def _is_cell_context_object(candidate: ExtractedRelationCandidate) -> bool:
     )
 
 
+def _cell_context_shadowed_by_primary_relation(
+    *,
+    candidate: ExtractedRelationCandidate,
+    candidates: tuple[ExtractedRelationCandidate, ...],
+) -> bool:
+    candidate_sentence = _normalize_sentence(candidate.sentence)
+    for sibling in candidates:
+        if sibling is candidate:
+            continue
+        if _normalize_sentence(sibling.sentence) != candidate_sentence:
+            continue
+        if _quality_filter_reason(sibling) is not None:
+            continue
+        if not _sibling_shares_claim_scope(candidate, sibling):
+            continue
+        sibling_relation = canonicalize_extraction_relation_type(sibling.relation_type)
+        if sibling_relation not in {"ACTIVATES", "REGULATES"}:
+            continue
+        if _has_broad_pathway_effect_object(
+            sibling.object_label,
+        ) or _has_broad_process_effect_object(sibling.object_label):
+            return True
+    return False
+
+
 def _has_broad_pathway_effect_object(label: str) -> bool:
     normalized_label = _normalize_entity_label(label)
     return bool(_BROAD_PATHWAY_EFFECT_TOKENS.intersection(normalized_label.split()))
@@ -666,6 +774,19 @@ def _has_broad_pathway_effect_object(label: str) -> bool:
 def _has_broad_process_effect_object(label: str) -> bool:
     normalized_label = _normalize_entity_label(label)
     return bool(_BROAD_PROCESS_EFFECT_TOKENS.intersection(normalized_label.split()))
+
+
+def _is_specific_molecular_target_object(label: str) -> bool:
+    if _has_broad_pathway_effect_object(label) or _has_disease_context_token(
+        _normalize_entity_label(label),
+    ):
+        return False
+    tokens = re.findall(r"[A-Za-z0-9.*-]+", label)
+    return any(
+        _MOLECULAR_TARGET_TOKEN_RE.fullmatch(token) is not None
+        or _VARIANT_TOKEN_RE.fullmatch(token) is not None
+        for token in tokens
+    )
 
 
 def _is_specific_biomarker_response_object(label: str) -> bool:
@@ -762,6 +883,19 @@ def _candidate_claim_scope(candidate: ExtractedRelationCandidate) -> str:
     return " ".join(clauses)
 
 
+def _sibling_shares_claim_scope(
+    candidate: ExtractedRelationCandidate,
+    sibling: ExtractedRelationCandidate,
+) -> bool:
+    candidate_scope = _candidate_claim_scope(candidate)
+    sibling_scope = _candidate_claim_scope(sibling)
+    return (
+        candidate_scope != ""
+        and sibling_scope != ""
+        and candidate_scope == sibling_scope
+    )
+
+
 def _split_candidate_clauses(sentence: str) -> tuple[str, ...]:
     return tuple(
         normalized_clause
@@ -803,11 +937,20 @@ def _context_edge_is_direct_mechanism_modifier(
     pattern = re.compile(
         rf"\b{re.escape(direct_subject)}\b"
         rf".{{0,80}}\b(?:{direct_cue_pattern})\b"
-        rf".{{0,80}}\b{re.escape(context_subject)}\b"
+        rf"[^.;,]{{0,80}}\b{re.escape(context_subject)}\b"
         rf"\s+(?:{context_cue_pattern})\s+"
         rf"\b{re.escape(context_object)}\b",
     )
-    return pattern.search(sentence) is not None
+    if pattern.search(sentence) is not None:
+        return True
+    direct_target_context_pattern = re.compile(
+        rf"\b{re.escape(direct_subject)}\b"
+        rf".{{0,80}}\b(?:{direct_cue_pattern})\b"
+        rf"[^.;,]{{0,80}}\b{re.escape(context_subject)}\b"
+        rf"[^.;,]{{0,80}}\b(?:{context_cue_pattern})\s+"
+        rf"\b{re.escape(context_object)}\b",
+    )
+    return direct_target_context_pattern.search(sentence) is not None
 
 
 def _phrase_alternation(phrases: tuple[str, ...]) -> str:

--- a/services/artana_evidence_api/tests/unit/test_document_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction.py
@@ -34,6 +34,9 @@ from artana_evidence_api.document_extraction_prompting import (
 )
 from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
     LLM_EXTRACTION_PROMPT_VERSION,
+    LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+    ModelStepRunner,
+    llm_extraction_step_key,
 )
 from artana_evidence_api.document_extraction_support.strict_relation_discovery import (
     discover_relation_candidates_strict,
@@ -44,6 +47,7 @@ from artana_evidence_api.types.graph_contracts import (
     KernelEntityListResponse,
     KernelEntityResponse,
 )
+from pydantic import ValidationError
 
 
 class _EmptyGraphApiGateway:
@@ -142,6 +146,35 @@ class _FakeKernel:
 class _FakeSingleStepClient:
     def __init__(self, *, kernel) -> None:
         self.kernel = kernel
+
+
+def _configure_llm_extraction_test_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    step_runner: ModelStepRunner,
+) -> None:
+    monkeypatch.setattr(runtime_support, "has_configured_openai_api_key", lambda: True)
+    monkeypatch.setattr(
+        runtime_support,
+        "get_model_registry",
+        lambda: SimpleNamespace(
+            get_default_model=lambda _capability: SimpleNamespace(
+                model_id="openai:gpt-5.4-mini",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "normalize_litellm_model_id",
+        lambda model_id: model_id,
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "create_artana_postgres_store",
+        lambda: _FakeKernelStore(),
+    )
+    monkeypatch.setattr("artana.kernel.ArtanaKernel", _FakeKernel)
+    monkeypatch.setattr("artana.agent.SingleStepModelClient", _FakeSingleStepClient)
+    monkeypatch.setattr(document_extraction, "run_single_step_with_policy", step_runner)
 
 
 def test_llm_extraction_prompt_covers_rare_disease_gene_variant_associations() -> None:
@@ -830,7 +863,590 @@ async def test_extract_relation_candidates_with_llm_uses_agent_review_only_pass(
 
 
 @pytest.mark.asyncio
-async def test_extract_relation_candidates_with_llm_demotes_pathway_target_sibling(
+async def test_extract_relation_candidates_with_llm_retries_zero_candidate_agent_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_prompts: list[str] = []
+    captured_step_keys: list[str] = []
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        captured_prompts.append(str(kwargs["prompt"]))
+        captured_step_keys.append(kwargs["step_key"])
+        if len(captured_step_keys) <= 2:
+            return SimpleNamespace(output={"relations": []})
+        if "WEAK REVIEW-ONLY EXTRACTION PASS" in str(kwargs["prompt"]):
+            return SimpleNamespace(output={"relations": []})
+        return SimpleNamespace(
+            output={
+                "relations": [
+                    {
+                        "subject": "Larotrectinib",
+                        "relation_type": "TREATS",
+                        "object": "NTRK fusion solid tumors",
+                        "sentence": (
+                            "Larotrectinib treats solid tumors harboring "
+                            "NTRK gene fusions regardless of tissue origin."
+                        ),
+                    },
+                ],
+            },
+        )
+
+    monkeypatch.setattr(runtime_support, "has_configured_openai_api_key", lambda: True)
+    monkeypatch.setattr(
+        runtime_support,
+        "get_model_registry",
+        lambda: SimpleNamespace(
+            get_default_model=lambda _capability: SimpleNamespace(
+                model_id="openai:gpt-5.4-mini",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "normalize_litellm_model_id",
+        lambda model_id: model_id,
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "create_artana_postgres_store",
+        lambda: _FakeKernelStore(),
+    )
+    monkeypatch.setattr("artana.kernel.ArtanaKernel", _FakeKernel)
+    monkeypatch.setattr("artana.agent.SingleStepModelClient", _FakeSingleStepClient)
+    monkeypatch.setattr(
+        document_extraction,
+        "run_single_step_with_policy",
+        _fake_run_single_step_with_policy,
+    )
+
+    text = (
+        "Larotrectinib treats solid tumors harboring NTRK gene fusions "
+        "regardless of tissue origin."
+    )
+    candidates = await extract_relation_candidates_with_llm(text)
+
+    assert len(candidates) == 1
+    assert candidates[0].subject_label == "Larotrectinib"
+    assert candidates[0].relation_type == "TREATS"
+    assert candidates[0].object_label == "NTRK fusion solid tumors"
+    assert captured_step_keys == [
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=(
+                f"{LLM_EXTRACTION_PROMPT_VERSION}."
+                "zero_candidate_retry.v1"
+            ),
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=(
+                f"{LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION}."
+                "zero_candidate_retry.v1"
+            ),
+        ),
+    ]
+    assert "A prior relation extraction attempt returned zero usable relations" in (
+        captured_prompts[2]
+    )
+    assert "return an empty relation list" in captured_prompts[3]
+
+
+@pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_retries_zero_converted_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_step_keys: list[str] = []
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        captured_step_keys.append(kwargs["step_key"])
+        if len(captured_step_keys) == 1:
+            return SimpleNamespace(
+                output={
+                    "relations": [
+                        {
+                            "subject": "a",
+                            "relation_type": "TREATS",
+                            "object": "NTRK fusion solid tumors",
+                            "sentence": (
+                                "Larotrectinib treats solid tumors harboring "
+                                "NTRK gene fusions regardless of tissue origin."
+                            ),
+                        },
+                    ],
+                },
+            )
+        if len(captured_step_keys) == 2 or "WEAK REVIEW-ONLY EXTRACTION PASS" in str(
+            kwargs["prompt"],
+        ):
+            return SimpleNamespace(output={"relations": []})
+        return SimpleNamespace(
+            output={
+                "relations": [
+                    {
+                        "subject": "Larotrectinib",
+                        "relation_type": "TREATS",
+                        "object": "NTRK fusion solid tumors",
+                        "sentence": (
+                            "Larotrectinib treats solid tumors harboring "
+                            "NTRK gene fusions regardless of tissue origin."
+                        ),
+                    },
+                ],
+            },
+        )
+
+    monkeypatch.setattr(runtime_support, "has_configured_openai_api_key", lambda: True)
+    monkeypatch.setattr(
+        runtime_support,
+        "get_model_registry",
+        lambda: SimpleNamespace(
+            get_default_model=lambda _capability: SimpleNamespace(
+                model_id="openai:gpt-5.4-mini",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "normalize_litellm_model_id",
+        lambda model_id: model_id,
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "create_artana_postgres_store",
+        lambda: _FakeKernelStore(),
+    )
+    monkeypatch.setattr("artana.kernel.ArtanaKernel", _FakeKernel)
+    monkeypatch.setattr("artana.agent.SingleStepModelClient", _FakeSingleStepClient)
+    monkeypatch.setattr(
+        document_extraction,
+        "run_single_step_with_policy",
+        _fake_run_single_step_with_policy,
+    )
+
+    candidates = await extract_relation_candidates_with_llm(
+        "Larotrectinib treats solid tumors harboring NTRK gene fusions "
+        "regardless of tissue origin.",
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].subject_label == "Larotrectinib"
+    assert candidates[0].relation_type == "TREATS"
+    assert candidates[0].object_label == "NTRK fusion solid tumors"
+    assert len(captured_step_keys) == 4
+
+
+@pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_retries_zero_causes_candidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_step_keys: list[str] = []
+    text = "SMN1 loss causes spinal muscular atrophy."
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        captured_step_keys.append(kwargs["step_key"])
+        if len(captured_step_keys) <= 2:
+            return SimpleNamespace(output={"relations": []})
+        if "WEAK REVIEW-ONLY EXTRACTION PASS" in str(kwargs["prompt"]):
+            return SimpleNamespace(output={"relations": []})
+        return SimpleNamespace(
+            output={
+                "relations": [
+                    {
+                        "subject": "SMN1 loss",
+                        "relation_type": "CAUSES",
+                        "object": "spinal muscular atrophy",
+                        "sentence": text,
+                    },
+                ],
+            },
+        )
+
+    _configure_llm_extraction_test_runtime(
+        monkeypatch,
+        _fake_run_single_step_with_policy,
+    )
+
+    candidates = await extract_relation_candidates_with_llm(text)
+
+    assert len(candidates) == 1
+    assert candidates[0].subject_label == "SMN1 loss"
+    assert candidates[0].relation_type == "CAUSES"
+    assert candidates[0].object_label == "spinal muscular atrophy"
+    assert captured_step_keys == [
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=(
+                f"{LLM_EXTRACTION_PROMPT_VERSION}."
+                "zero_candidate_retry.v1"
+            ),
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=(
+                f"{LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION}."
+                "zero_candidate_retry.v1"
+            ),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_retries_schema_validation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_prompts: list[str] = []
+    captured_step_keys: list[str] = []
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        captured_prompts.append(str(kwargs["prompt"]))
+        captured_step_keys.append(kwargs["step_key"])
+        if len(captured_step_keys) == 1:
+            kwargs["output_schema"].model_validate(
+                {
+                    "relations": [
+                        {
+                            "subject": "MSI-high status",
+                            "relation_type": "BIOMARKER_FOR",
+                            "proposed_relation_type": "PREDICTS_RESPONSE_TO",
+                            "object": "immune checkpoint inhibitor response",
+                            "sentence": (
+                                "MSI-high status is a biomarker for immune "
+                                "checkpoint inhibitor response."
+                            ),
+                        },
+                    ],
+                },
+            )
+        if "WEAK REVIEW-ONLY EXTRACTION PASS" in str(kwargs["prompt"]):
+            return SimpleNamespace(output={"relations": []})
+        return SimpleNamespace(
+            output={
+                "relations": [
+                    {
+                        "subject": "MSI-high status",
+                        "relation_type": "BIOMARKER_FOR",
+                        "object": "immune checkpoint inhibitor response",
+                        "sentence": (
+                            "MSI-high status is a biomarker for immune "
+                            "checkpoint inhibitor response."
+                        ),
+                    },
+                ],
+            },
+        )
+
+    monkeypatch.setattr(runtime_support, "has_configured_openai_api_key", lambda: True)
+    monkeypatch.setattr(
+        runtime_support,
+        "get_model_registry",
+        lambda: SimpleNamespace(
+            get_default_model=lambda _capability: SimpleNamespace(
+                model_id="openai:gpt-5.4-mini",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "normalize_litellm_model_id",
+        lambda model_id: model_id,
+    )
+    monkeypatch.setattr(
+        runtime_support,
+        "create_artana_postgres_store",
+        lambda: _FakeKernelStore(),
+    )
+    monkeypatch.setattr("artana.kernel.ArtanaKernel", _FakeKernel)
+    monkeypatch.setattr("artana.agent.SingleStepModelClient", _FakeSingleStepClient)
+    monkeypatch.setattr(
+        document_extraction,
+        "run_single_step_with_policy",
+        _fake_run_single_step_with_policy,
+    )
+
+    candidates = await extract_relation_candidates_with_llm(
+        "MSI-high status is a biomarker for immune checkpoint inhibitor response.",
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].subject_label == "MSI-high status"
+    assert candidates[0].relation_type == "BIOMARKER_FOR"
+    assert candidates[0].object_label == "immune checkpoint inhibitor response"
+    assert len(captured_step_keys) == 3
+    assert captured_step_keys[1] == llm_extraction_step_key(
+        text=(
+            "MSI-high status is a biomarker for immune checkpoint inhibitor "
+            "response."
+        ),
+        max_relations=10,
+        model_id="openai:gpt-5.4-mini",
+        prompt_version=f"{LLM_EXTRACTION_PROMPT_VERSION}.schema_retry.v1",
+    )
+    assert "failed schema validation" in captured_prompts[1]
+    assert "Do not set proposed_relation_type" in captured_prompts[1]
+
+
+@pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_chains_schema_retry_to_zero_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_step_keys: list[str] = []
+    text = "MSI-high status is a biomarker for immune checkpoint inhibitor response."
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        prompt = str(kwargs["prompt"])
+        captured_step_keys.append(kwargs["step_key"])
+        if len(captured_step_keys) == 1:
+            kwargs["output_schema"].model_validate(
+                {
+                    "relations": [
+                        {
+                            "subject": "MSI-high status",
+                            "relation_type": "BIOMARKER_FOR",
+                            "proposed_relation_type": "PREDICTS_RESPONSE_TO",
+                            "object": "immune checkpoint inhibitor response",
+                            "sentence": text,
+                        },
+                    ],
+                },
+            )
+        if "ZERO-CANDIDATE RETRY" in prompt and (
+            "WEAK REVIEW-ONLY EXTRACTION PASS" not in prompt
+        ):
+            return SimpleNamespace(
+                output={
+                    "relations": [
+                        {
+                            "subject": "MSI-high status",
+                            "relation_type": "BIOMARKER_FOR",
+                            "object": "immune checkpoint inhibitor response",
+                            "sentence": text,
+                        },
+                    ],
+                },
+            )
+        if "SCHEMA REPAIR RETRY" in prompt and (
+            "WEAK REVIEW-ONLY EXTRACTION PASS" not in prompt
+        ):
+            return SimpleNamespace(
+                output={
+                    "relations": [
+                        {
+                            "subject": "a",
+                            "relation_type": "BIOMARKER_FOR",
+                            "object": "immune checkpoint inhibitor response",
+                            "sentence": text,
+                        },
+                    ],
+                },
+            )
+        return SimpleNamespace(output={"relations": []})
+
+    _configure_llm_extraction_test_runtime(
+        monkeypatch,
+        _fake_run_single_step_with_policy,
+    )
+
+    candidates = await extract_relation_candidates_with_llm(text)
+
+    assert len(candidates) == 1
+    assert candidates[0].subject_label == "MSI-high status"
+    assert candidates[0].relation_type == "BIOMARKER_FOR"
+    assert candidates[0].object_label == "immune checkpoint inhibitor response"
+    assert captured_step_keys == [
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=f"{LLM_EXTRACTION_PROMPT_VERSION}.schema_retry.v1",
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=(
+                f"{LLM_EXTRACTION_PROMPT_VERSION}."
+                "zero_candidate_retry.v1"
+            ),
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=(
+                f"{LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION}."
+                "zero_candidate_retry.v1"
+            ),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_preserves_primary_after_weak_schema_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_step_keys: list[str] = []
+    text = (
+        "BRCA1 truncating variants are associated with hereditary breast and "
+        "ovarian cancer."
+    )
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        captured_step_keys.append(kwargs["step_key"])
+        if len(captured_step_keys) == 1:
+            return SimpleNamespace(
+                output={
+                    "relations": [
+                        {
+                            "subject": "BRCA1 truncating variants",
+                            "relation_type": "ASSOCIATED_WITH",
+                            "object": "hereditary breast and ovarian cancer",
+                            "sentence": text,
+                        },
+                    ],
+                },
+            )
+        if len(captured_step_keys) == 2:
+            kwargs["output_schema"].model_validate(
+                {
+                    "relations": [
+                        {
+                            "subject": "BRCA1 truncating variants",
+                            "relation_type": "ASSOCIATED_WITH",
+                            "proposed_relation_type": "CAUSES",
+                            "object": "hereditary breast and ovarian cancer",
+                            "sentence": text,
+                        },
+                    ],
+                },
+            )
+        return SimpleNamespace(output={"relations": []})
+
+    _configure_llm_extraction_test_runtime(
+        monkeypatch,
+        _fake_run_single_step_with_policy,
+    )
+
+    candidates = await extract_relation_candidates_with_llm(text)
+
+    assert len(candidates) == 1
+    assert candidates[0].subject_label == "BRCA1 truncating variants"
+    assert candidates[0].relation_type == "ASSOCIATED_WITH"
+    assert candidates[0].object_label == "hereditary breast and ovarian cancer"
+    assert captured_step_keys == [
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+        ),
+        llm_extraction_step_key(
+            text=text,
+            max_relations=10,
+            model_id="openai:gpt-5.4-mini",
+            prompt_version=(
+                f"{LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION}.schema_retry.v1"
+            ),
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_propagates_invalid_schema_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    text = "MSI-high status is a biomarker for immune checkpoint inhibitor response."
+
+    async def _fake_run_single_step_with_policy(*_args, **kwargs):
+        kwargs["output_schema"].model_validate(
+            {
+                "relations": [
+                    {
+                        "subject": "MSI-high status",
+                        "relation_type": "BIOMARKER_FOR",
+                        "proposed_relation_type": "PREDICTS_RESPONSE_TO",
+                        "object": "immune checkpoint inhibitor response",
+                        "sentence": text,
+                    },
+                ],
+            },
+        )
+
+    _configure_llm_extraction_test_runtime(
+        monkeypatch,
+        _fake_run_single_step_with_policy,
+    )
+
+    with pytest.raises(ValidationError):
+        await extract_relation_candidates_with_llm(text)
+
+
+@pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_propagates_runtime_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_run_single_step_with_policy(*_args, **_kwargs):
+        raise RuntimeError("model transport failed")
+
+    _configure_llm_extraction_test_runtime(
+        monkeypatch,
+        _fake_run_single_step_with_policy,
+    )
+
+    with pytest.raises(RuntimeError, match="model transport failed"):
+        await extract_relation_candidates_with_llm(
+            "MSI-high status is a biomarker for immune checkpoint inhibitor response.",
+        )
+
+
+@pytest.mark.asyncio
+async def test_extract_relation_candidates_with_llm_filters_pathway_target_sibling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     async def _fake_run_single_step_with_policy(*_args, **kwargs):
@@ -894,15 +1510,9 @@ async def test_extract_relation_candidates_with_llm_demotes_pathway_target_sibli
         "Vemurafenib targets BRAF V600E and inhibits MAPK signaling.",
     )
 
-    assert len(candidates) == 2
+    assert len(candidates) == 1
     assert candidates[0].relation_type == "TARGETS"
     assert candidates[0].trusted_evidence_eligible is True
-    assert candidates[1].relation_type == "INHIBITS"
-    assert candidates[1].review_status == "review_only"
-    assert candidates[1].review_reason_codes == (
-        "pathway_effect_shadowed_by_direct_target",
-    )
-    assert candidates[1].trusted_evidence_eligible is False
 
 
 @pytest.mark.asyncio
@@ -964,7 +1574,9 @@ async def test_extract_relation_candidates_with_llm_drops_invalid_weak_pass_type
         "MED13 may be linked to congenital heart disease in a subset of families.",
     )
 
-    assert len(prompts) == 2
+    assert len(prompts) == 4
+    assert "ZERO-CANDIDATE RETRY" in prompts[2]
+    assert "ZERO-CANDIDATE RETRY" in prompts[3]
     assert candidates == []
 
 
@@ -1029,7 +1641,9 @@ async def test_extract_relation_candidates_with_llm_drops_invalid_primary_pass_t
         "MED13 cases included congenital heart disease.",
     )
 
-    assert len(prompts) == 2
+    assert len(prompts) == 4
+    assert "ZERO-CANDIDATE RETRY" in prompts[2]
+    assert "ZERO-CANDIDATE RETRY" in prompts[3]
     assert candidates == []
 
 
@@ -1236,7 +1850,9 @@ async def test_weak_pass_drops_structured_relation_type_proposals(
         "MED13 may be linked to congenital heart disease.",
     )
 
-    assert len(prompts) == 2
+    assert len(prompts) == 4
+    assert "ZERO-CANDIDATE RETRY" in prompts[2]
+    assert "ZERO-CANDIDATE RETRY" in prompts[3]
     assert candidates == []
 
 
@@ -1633,11 +2249,11 @@ def test_llm_extraction_step_key_uses_full_text_beyond_prefix() -> None:
     second_text = f"{shared_prefix} MED13 regulates cardiomyopathy."
 
     assert first_text[:4000] == second_text[:4000]
-    assert document_extraction.llm_extraction_step_key(
+    assert llm_extraction_step_key(
         text=first_text,
         max_relations=10,
         model_id="openai/gpt-5.4-mini",
-    ) != document_extraction.llm_extraction_step_key(
+    ) != llm_extraction_step_key(
         text=second_text,
         max_relations=10,
         model_id="openai/gpt-5.4-mini",
@@ -1770,38 +2386,38 @@ async def test_extract_relation_candidates_with_llm_scopes_step_key_to_document_
     await extract_relation_candidates_with_llm(second_text)
 
     assert captured_step_keys == [
-        document_extraction.llm_extraction_step_key(
+        llm_extraction_step_key(
             text=first_text,
             max_relations=10,
             model_id="openai:gpt-5.4-mini",
         ),
-        document_extraction.llm_extraction_step_key(
+        llm_extraction_step_key(
             text=first_text,
             max_relations=10,
             model_id="openai:gpt-5.4-mini",
-            prompt_version=document_extraction.LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+            prompt_version=LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
         ),
-        document_extraction.llm_extraction_step_key(
+        llm_extraction_step_key(
             text=first_text,
             max_relations=10,
             model_id="openai:gpt-5.4-mini",
         ),
-        document_extraction.llm_extraction_step_key(
+        llm_extraction_step_key(
             text=first_text,
             max_relations=10,
             model_id="openai:gpt-5.4-mini",
-            prompt_version=document_extraction.LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+            prompt_version=LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
         ),
-        document_extraction.llm_extraction_step_key(
+        llm_extraction_step_key(
             text=second_text,
             max_relations=10,
             model_id="openai:gpt-5.4-mini",
         ),
-        document_extraction.llm_extraction_step_key(
+        llm_extraction_step_key(
             text=second_text,
             max_relations=10,
             model_id="openai:gpt-5.4-mini",
-            prompt_version=document_extraction.LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
+            prompt_version=LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION,
         ),
     ]
     assert captured_step_keys[0] == captured_step_keys[2]

--- a/services/artana_evidence_api/tests/unit/test_llm_fallback_observability.py
+++ b/services/artana_evidence_api/tests/unit/test_llm_fallback_observability.py
@@ -591,7 +591,7 @@ async def test_llm_extraction_logs_debug_for_filtered_candidates(
     ]
     assert records
     record = records[-1]
-    assert record.raw_relation_count == 2
+    assert record.raw_relation_count == 4
     assert record.usable_candidate_count == 0
 
 

--- a/services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py
+++ b/services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py
@@ -148,6 +148,37 @@ def test_quality_filter_marks_single_biochemical_companion_phenotype_review_only
     assert result.filtered_candidates == ()
 
 
+def test_quality_filter_removes_biochemical_companion_when_disease_sibling_exists() -> None:
+    disease_candidate = ExtractedRelationCandidate(
+        subject_label="PAH pathogenic variants",
+        relation_type="ASSOCIATED_WITH",
+        object_label="phenylketonuria",
+        sentence=(
+            "PAH pathogenic variants are associated with phenylketonuria and "
+            "elevated phenylalanine."
+        ),
+    )
+    phenotype_candidate = ExtractedRelationCandidate(
+        subject_label="PAH pathogenic variants",
+        relation_type="ASSOCIATED_WITH",
+        object_label="elevated phenylalanine",
+        sentence=(
+            "PAH pathogenic variants are associated with phenylketonuria and "
+            "elevated phenylalanine."
+        ),
+    )
+
+    result = filter_low_value_relation_candidates(
+        (disease_candidate, phenotype_candidate),
+    )
+
+    assert result.candidates == (disease_candidate,)
+    assert result.filtered_candidates[0].candidate == phenotype_candidate
+    assert result.filtered_candidates[0].reason == (
+        "companion_phenotype_shadowed_by_disease"
+    )
+
+
 def test_quality_filter_keeps_correlated_only_specific_relation_review_only() -> None:
     candidate = ExtractedRelationCandidate(
         subject_label="MET amplification",
@@ -411,7 +442,7 @@ def test_quality_filter_marks_single_nested_biomarker_context_review_only() -> N
     assert result.filtered_candidates == ()
 
 
-def test_quality_filter_marks_explicit_pathway_effect_with_direct_target_review_only() -> None:
+def test_quality_filter_removes_explicit_pathway_effect_with_direct_target() -> None:
     target_candidate = ExtractedRelationCandidate(
         subject_label="Vemurafenib",
         relation_type="TARGETS",
@@ -429,15 +460,155 @@ def test_quality_filter_marks_explicit_pathway_effect_with_direct_target_review_
         (target_candidate, pathway_candidate),
     )
 
-    assert result.candidates[0] == target_candidate
-    assert result.candidates[1].review_status == "review_only"
-    assert "pathway_effect_shadowed_by_direct_target" in (
-        result.candidates[1].review_reason_codes
+    assert result.candidates == (target_candidate,)
+    assert result.filtered_candidates[0].candidate == pathway_candidate
+    assert result.filtered_candidates[0].reason == (
+        "pathway_effect_shadowed_by_direct_target"
     )
-    assert result.filtered_candidates == ()
 
 
-def test_quality_filter_marks_proliferation_effect_with_pathway_sibling_review_only() -> None:
+def test_quality_filter_keeps_pathway_effect_when_target_sibling_is_invalid() -> None:
+    invalid_target_candidate = ExtractedRelationCandidate(
+        subject_label="Vemurafenib",
+        relation_type="TARGETS",
+        object_label="BRAF V600E",
+        sentence="Vemurafenib inhibits MAPK signaling in melanoma.",
+    )
+    pathway_candidate = ExtractedRelationCandidate(
+        subject_label="Vemurafenib",
+        relation_type="INHIBITS",
+        object_label="MAPK signaling",
+        sentence="Vemurafenib inhibits MAPK signaling in melanoma.",
+    )
+
+    result = filter_low_value_relation_candidates(
+        (invalid_target_candidate, pathway_candidate),
+    )
+
+    assert result.candidates == (pathway_candidate,)
+    assert result.filtered_candidates[0].candidate == invalid_target_candidate
+    assert result.filtered_candidates[0].reason == "missing_relation_arguments"
+
+
+def test_quality_filter_keeps_pathway_effect_when_target_sibling_is_not_molecular() -> None:
+    disease_target_candidate = ExtractedRelationCandidate(
+        subject_label="Vemurafenib",
+        relation_type="TARGETS",
+        object_label="melanoma",
+        sentence="Vemurafenib targets melanoma and inhibits MAPK signaling.",
+    )
+    pathway_candidate = ExtractedRelationCandidate(
+        subject_label="Vemurafenib",
+        relation_type="INHIBITS",
+        object_label="MAPK signaling",
+        sentence="Vemurafenib targets melanoma and inhibits MAPK signaling.",
+    )
+
+    result = filter_low_value_relation_candidates(
+        (disease_target_candidate, pathway_candidate),
+    )
+
+    assert pathway_candidate in result.candidates
+    assert all(
+        filtered.candidate != pathway_candidate
+        for filtered in result.filtered_candidates
+    )
+
+
+def test_quality_filter_removes_binding_site_target_with_molecular_target_sibling() -> None:
+    target_candidate = ExtractedRelationCandidate(
+        subject_label="Sotorasib",
+        relation_type="TARGETS",
+        object_label="KRAS G12C",
+        sentence=(
+            "Sotorasib targets KRAS G12C by binding the switch-II pocket in "
+            "mutant lung cancer."
+        ),
+    )
+    binding_site_candidate = ExtractedRelationCandidate(
+        subject_label="Sotorasib",
+        relation_type="TARGETS",
+        object_label="switch-II pocket",
+        sentence=(
+            "Sotorasib targets KRAS G12C by binding the switch-II pocket in "
+            "mutant lung cancer."
+        ),
+    )
+
+    result = filter_low_value_relation_candidates(
+        (target_candidate, binding_site_candidate),
+    )
+
+    assert result.candidates == (target_candidate,)
+    assert result.filtered_candidates[0].candidate == binding_site_candidate
+    assert result.filtered_candidates[0].reason == (
+        "binding_site_shadowed_by_molecular_target"
+    )
+
+
+def test_quality_filter_keeps_binding_site_target_without_molecular_target_sibling() -> None:
+    pathway_target_candidate = ExtractedRelationCandidate(
+        subject_label="SHP099",
+        relation_type="TARGETS",
+        object_label="ERK signaling",
+        sentence=(
+            "SHP099 binds the SHP2 allosteric site and targets ERK signaling "
+            "in tumor cells."
+        ),
+    )
+    binding_site_candidate = ExtractedRelationCandidate(
+        subject_label="SHP099",
+        relation_type="TARGETS",
+        object_label="SHP2 allosteric site",
+        sentence=(
+            "SHP099 binds the SHP2 allosteric site and targets ERK signaling "
+            "in tumor cells."
+        ),
+    )
+
+    result = filter_low_value_relation_candidates(
+        (pathway_target_candidate, binding_site_candidate),
+    )
+
+    assert binding_site_candidate in result.candidates
+    assert all(
+        filtered.candidate != binding_site_candidate
+        for filtered in result.filtered_candidates
+    )
+
+
+def test_quality_filter_removes_downstream_pathway_context_with_direct_target() -> None:
+    target_candidate = ExtractedRelationCandidate(
+        subject_label="Vemurafenib",
+        relation_type="TARGETS",
+        object_label="BRAF V600E",
+        sentence=(
+            "Vemurafenib targets BRAF V600E and suppresses downstream MAPK "
+            "signaling in melanoma."
+        ),
+    )
+    pathway_context_candidate = ExtractedRelationCandidate(
+        subject_label="BRAF V600E",
+        relation_type="DOWNSTREAM_OF",
+        object_label="MAPK signaling",
+        sentence=(
+            "Vemurafenib targets BRAF V600E and suppresses downstream MAPK "
+            "signaling in melanoma."
+        ),
+    )
+
+    result = filter_low_value_relation_candidates(
+        (target_candidate, pathway_context_candidate),
+    )
+
+    assert result.candidates == (target_candidate,)
+    assert result.filtered_candidates[0].candidate == pathway_context_candidate
+    assert result.filtered_candidates[0].reason == (
+        "context_relation_shadowed_by_direct_mechanism"
+    )
+
+
+def test_quality_filter_removes_proliferation_effect_with_pathway_sibling() -> None:
     pathway_candidate = ExtractedRelationCandidate(
         subject_label="KRAS G12D",
         relation_type="ACTIVATES",
@@ -461,12 +632,42 @@ def test_quality_filter_marks_proliferation_effect_with_pathway_sibling_review_o
         (pathway_candidate, proliferation_candidate),
     )
 
-    assert result.candidates[0] == pathway_candidate
-    assert result.candidates[1].review_status == "review_only"
-    assert "process_effect_shadowed_by_pathway_mechanism" in (
-        result.candidates[1].review_reason_codes
+    assert result.candidates == (pathway_candidate,)
+    assert result.filtered_candidates[0].candidate == proliferation_candidate
+    assert result.filtered_candidates[0].reason == (
+        "process_effect_shadowed_by_pathway_mechanism"
     )
-    assert result.filtered_candidates == ()
+
+
+def test_quality_filter_keeps_independent_process_effect_clause() -> None:
+    pathway_candidate = ExtractedRelationCandidate(
+        subject_label="KRAS G12D",
+        relation_type="ACTIVATES",
+        object_label="MAPK signaling",
+        sentence=(
+            "KRAS G12D activates MAPK signaling, and KRAS G12D increases "
+            "pancreatic cancer cell proliferation through MYC."
+        ),
+    )
+    proliferation_candidate = ExtractedRelationCandidate(
+        subject_label="KRAS G12D",
+        relation_type="ACTIVATES",
+        object_label="pancreatic cancer cell proliferation",
+        sentence=(
+            "KRAS G12D activates MAPK signaling, and KRAS G12D increases "
+            "pancreatic cancer cell proliferation through MYC."
+        ),
+    )
+
+    result = filter_low_value_relation_candidates(
+        (pathway_candidate, proliferation_candidate),
+    )
+
+    assert proliferation_candidate in result.candidates
+    assert all(
+        filtered.candidate != proliferation_candidate
+        for filtered in result.filtered_candidates
+    )
 
 
 def test_quality_filter_marks_cell_context_activation_review_only() -> None:
@@ -486,6 +687,68 @@ def test_quality_filter_marks_cell_context_activation_review_only() -> None:
     assert result.candidates[0].review_status == "review_only"
     assert "cell_context_object" in result.candidates[0].review_reason_codes
     assert result.filtered_candidates == ()
+
+
+def test_quality_filter_removes_cell_context_activation_when_primary_relation_exists() -> None:
+    primary_candidate = ExtractedRelationCandidate(
+        subject_label="IL6",
+        relation_type="REGULATES",
+        object_label="inflammatory signaling",
+        sentence=(
+            "IL6 regulates inflammatory signaling through JAK-STAT activation "
+            "in macrophages."
+        ),
+    )
+    context_candidate = ExtractedRelationCandidate(
+        subject_label="JAK-STAT",
+        relation_type="ACTIVATES",
+        object_label="macrophages",
+        sentence=(
+            "IL6 regulates inflammatory signaling through JAK-STAT activation "
+            "in macrophages."
+        ),
+    )
+
+    result = filter_low_value_relation_candidates(
+        (primary_candidate, context_candidate),
+    )
+
+    assert result.candidates == (primary_candidate,)
+    assert result.filtered_candidates[0].candidate == context_candidate
+    assert result.filtered_candidates[0].reason == "cell_context_object"
+
+
+def test_quality_filter_keeps_independent_cell_context_clause_as_review_only() -> None:
+    primary_candidate = ExtractedRelationCandidate(
+        subject_label="IL6",
+        relation_type="REGULATES",
+        object_label="inflammatory signaling",
+        sentence=(
+            "IL6 regulates inflammatory signaling in macrophages, and "
+            "JAK-STAT activation was measured in macrophages."
+        ),
+    )
+    context_candidate = ExtractedRelationCandidate(
+        subject_label="JAK-STAT",
+        relation_type="ACTIVATES",
+        object_label="macrophages",
+        sentence=(
+            "IL6 regulates inflammatory signaling in macrophages, and "
+            "JAK-STAT activation was measured in macrophages."
+        ),
+    )
+
+    result = filter_low_value_relation_candidates(
+        (primary_candidate, context_candidate),
+    )
+
+    assert len(result.candidates) == 2
+    assert result.candidates[1].review_status == "review_only"
+    assert "cell_context_object" in result.candidates[1].review_reason_codes
+    assert all(
+        filtered.candidate != context_candidate
+        for filtered in result.filtered_candidates
+    )
 
 
 def test_quality_filter_removes_candidate_that_drops_subject_modifier() -> None:


### PR DESCRIPTION
## Summary

PR33 reduces repeated low-value review burden in the live-agent extraction path and hardens agent-only retries without letting deterministic fallback count as evidence.

Changes:
- Adds sibling-aware pruning for companion phenotype, pathway/process, downstream context, cell-context, and binding-site noise.
- Splits LLM extraction pass orchestration into `document_extraction_support/llm_extraction/runner.py`.
- Adds bounded agent-only zero-candidate and schema-repair retries with distinct replay keys.
- Fixes adversarially found issues: invalid sibling shadowing, raw/unusable retry suppression, schema-retry ordering, weak-pass candidate loss, unknown-only candidate suppression, and over-broad pruning.
- Updates the evidence tracker and PR33 validation summary with final post-adversarial3 artifacts.

## Validation

- Focused PR33/retry/observability suite: `80 passed in 0.87s`
- Quality-filter suite: `47 passed in 0.16s`
- Touched-file Ruff: passed
- `make relation-feasibility-quality-gate`: passed
- Three strict live-agent runs: GREEN x3
- Readiness aggregate: READY, blockers 0
- Failure analysis: missed 0, false positives 0, CURIE gaps 35
- `make service-checks`: passed, coverage `87.03%` against `86%` floor
- Adversarial re-review: prior retry/pruning blockers addressed; only packaging/service-gate items remained, both handled here

## Artifact Summary

- PR33 report: `docs/validation/reports/2026-07-06-pr33-review-burden-pruning-summary.md`
- Readiness artifact: `reports/relation_feasibility_readiness/2026-07-06-pr33-review-burden-postadversarial3-runs1-3/relation_feasibility_readiness_report.json`
- Failure analysis artifact: `reports/relation_feasibility_failure_analysis/2026-07-06-pr33-review-burden-postadversarial3-runs1-3/relation_feasibility_failure_analysis_report.json`

Note: `uv.lock` is intentionally not included.
