### PR TITLE
PR34: prove live model comparison fail-closed

### DIFF
--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -152,6 +152,7 @@ Status values:
 | 20 | PR-31 | `alvaro/evidence-pr31-context-precision-guards` | Draft PR #114 open; three-run readiness READY; GitHub checks clean | Demote pathway, process, and cell-context candidates from trusted auto-promotion when they are useful review context but not curated trusted graph evidence. | Three strict v3 live-agent runs report trusted graph readiness ready with worst trusted precision, trusted high-value recall, trusted valuable rate, trusted endpoint recovery, and entailment checked rate all at 1.0000. | Added RED/GREEN quality-filter tests for Vemurafenib/MAPK pathway shadowing, KRAS/proliferation process shadowing, and JAK-STAT/macrophage cell-context activation; added fake-LLM extraction regression proving review-only metadata survives the agent path; ran focused tests, touched-file Ruff, `make relation-feasibility-quality-gate`, strict v3 live runs1-3, readiness aggregate READY, and failure analysis. Hard failures are all 0: fallback, invalid agent, negative leakage, raw unknown relation/surface, wrong verified CURIE links, weak trusted leakage, and review-only gold trusted leakage. Remaining work is review-lane usefulness, not trusted auto-promotion: weak EGFR/MET review misses and all-candidate review burden remain. Summary: `docs/validation/reports/2026-07-06-pr31-context-precision-guards-summary.md`. |
 | 21 | PR-32 | `alvaro/evidence-pr32-weak-review-recovery` | Implemented locally; post-adversarial three-run readiness READY; final gates pass | Recover weak EGFR trend-response and MET correlated-resistance evidence as review-only candidates while preserving trusted-lane safety. | Low-value review recall is 1.0000 across three strict v3 live-agent runs, weak trusted leakage remains 0, and trusted readiness remains READY. | Added weak-review prompt examples, weak-pass prompt reinforcement, `trended with` detection, trend-response relation repair, correlated-resistance object repair, post-repair duplicate merging, and schema recovery for canonical relations with spurious proposal fields. Adversarial review then tightened schema recovery to reject unknown/conflicting proposals, clear stale object CURIE metadata after object repair, and scope repair cues to the candidate claim; re-review then closed bare-`and` claim-boundary leakage. Focused tests pass (`55 passed`), touched-file Ruff passes, `make relation-feasibility-quality-gate` passes, `make service-checks` passes with coverage 87.03%, strict live runs12-14 are GREEN with low-value review recall 1.0000, fallback 0, invalid agent 0, weak trusted leakage 0, and readiness aggregate READY. Summary: `docs/validation/reports/2026-07-06-pr32-weak-review-recovery-summary.md`. |
 | 22 | PR-33 | `alvaro/evidence-pr33-review-burden-pruning` | Implemented locally; final gates pass; three-run readiness READY | Remove repeated review-burden false positives and recover rare zero-candidate/schema-invalid agent responses without deterministic fallback. | Trusted readiness remains READY, hard safety failures stay 0, and missed gold and repeated false positives are 0 across three post-adversarial strict v3 live-agent runs. | Added companion phenotype, pathway/process, downstream context, cell-context, and binding-site sibling pruning; added agent-only zero-candidate and schema-repair retries with retry-specific prompts and distinct replay keys; adversarial review and service-gate failures fixed invalid-sibling shadowing, raw-but-unusable retry suppression, schema-retry ordering, weak-pass candidate loss, partial zero-retry cue coverage, unknown-only candidate retry suppression, and over-broad pruning; focused tests pass (`80 passed`), quality-filter suite passes (`47 passed`), touched-file Ruff passes, `make relation-feasibility-quality-gate` passes, `make service-checks` passes with coverage `87.03%`, and strict post-adversarial3 live runs1-3 aggregate to READY with worst completed-agent precision 1.0000, worst recall 1.0000, worst high-value recall 1.0000, trusted precision 1.0000, trusted valuable rate 1.0000, trusted endpoint rate 1.0000, missed gold 0, false positives 0, fallback 0, invalid agent 0, negative leakage 0, weak trusted leakage 0, and wrong verified CURIE links 0. Summary: `docs/validation/reports/2026-07-06-pr33-review-burden-pruning-summary.md`. |
+| 23 | PR-34 | `alvaro/evidence-pr34-live-model-ab-proof` | Implemented locally; live A/B proof complete; final gates pass | Close the stronger-model question with a fail-closed live model comparison on the v3 benchmark. | Candidate model adoption requires three completed runs, zero hard safety failures, and no trusted endpoint regression. | Added fixture pinning to `scripts/run_relation_model_comparison.py`, made failed audit subprocesses produce a `KEEP_CURRENT` report with `audit_failures`, and added Markdown audit-failure rendering. Current `openai:gpt-5.4-mini` completed 3/3 strict v3 live runs with trusted readiness READY and hard failures 0; candidate `openai:gpt-5` completed only 1/3 runs and failed run2 preflight with a LiteLLM timeout, so the comparison decision is KEEP_CURRENT. Focused model-comparison tests pass (`13 passed`), `make relation-feasibility-quality-gate` passes, `make service-checks` passes with coverage `87.03%`, and adversarial review found no blockers after symmetric failed-current-run coverage and doc wording cleanup. Summary: `docs/validation/reports/2026-07-06-pr34-live-model-ab-proof-summary.md`. |
 
 ## PR Evidence Packet
 
@@ -212,6 +213,86 @@ Run only the service checks relevant to the changed boundary, then run the
 aggregate gate before merge when the PR is ready.
 
 ## Evidence Log
+
+### 2026-07-06 - PR-34 Live Model A/B Proof
+
+PR: PR-34 live model A/B proof
+
+Branch: `alvaro/evidence-pr34-live-model-ab-proof`
+
+Goal: Prove whether a stronger extraction model should replace the current
+configured model for trusted-readiness evaluation, using the same v3 fixture and
+fail-closed adoption rules.
+
+Evidence:
+
+- `docs/validation/reports/2026-07-06-pr34-live-model-ab-proof-summary.md`
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/relation_model_comparison_report.json`
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/relation_model_comparison_report.md`
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/runs/current/run1/relation_feasibility_report.json`
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/runs/current/run2/relation_feasibility_report.json`
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/runs/current/run3/relation_feasibility_report.json`
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/runs/candidate/run1/relation_feasibility_report.json`
+
+Model comparison decision:
+
+- current model: `openai:gpt-5.4-mini`
+- candidate model: `openai:gpt-5`
+- decision: `KEEP_CURRENT`
+- candidate adoption blocker: candidate audit run failed
+- candidate completed reports: `1/3`
+- candidate failed run: run2 exited `2` after live-agent preflight timed out
+
+Current model worst-run metrics across v3 runs1-3:
+
+| Metric | Worst |
+|---|---:|
+| Trusted readiness | READY |
+| Completed-agent precision | 1.0000 |
+| Completed-agent recall | 1.0000 |
+| Completed-agent valuable rate | 0.5333 |
+| High-value recall | 1.0000 |
+| Trusted candidate precision | 1.0000 |
+| Trusted candidate valuable rate | 1.0000 |
+| Trusted candidate generic rate | 0.0000 |
+| Trusted-eligible high-value recall | 1.0000 |
+| Trusted-eligible CURIE endpoint rate | 1.0000 |
+| Entailment checked rate | 1.0000 |
+| Verified CURIE match rate | 0.7250 |
+
+Candidate completed run1 metrics:
+
+| Metric | Value |
+|---|---:|
+| Verdict | GREEN |
+| Completed-agent precision | 1.0000 |
+| Completed-agent recall | 0.9667 |
+| High-value recall | 0.9500 |
+| Trusted candidate precision | 1.0000 |
+| Trusted-eligible high-value recall | 1.0000 |
+| Trusted-eligible CURIE endpoint rate | 1.0000 |
+| Fallback cases | 0 |
+| Invalid agent cases | 0 |
+| Wrong verified CURIE links | 0 |
+
+Validation:
+
+- RED/GREEN fixture-pinning regression passed.
+- RED/GREEN failed-candidate-audit reporting regression passed.
+- Symmetric failed-current-run regression passed.
+- Focused model-comparison suite: `13 passed`.
+- `make relation-feasibility-quality-gate`: passed.
+- `make service-checks`: passed with coverage `87.03%`.
+- Corrected live A/B command used
+  `--cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json`.
+
+Interpretation:
+
+Do not switch the default extraction model to `openai:gpt-5` from this evidence.
+The current model is repeatably READY on the trusted lane, while the stronger
+candidate did not complete the required three-run gate and its only completed
+run was worse on completed-agent recall, high-value recall, and valuable
+candidate rate.
 
 ### 2026-07-06 - PR-33 Review Burden Pruning And Agent Retry Hardening
 

--- a/docs/validation/reports/2026-07-06-pr34-live-model-ab-proof-summary.md
+++ b/docs/validation/reports/2026-07-06-pr34-live-model-ab-proof-summary.md
@@ -1,0 +1,213 @@
+# PR34 Live Model A/B Proof Summary
+
+## Run Context
+
+- Branch: `alvaro/evidence-pr34-live-model-ab-proof`
+- Base branch: `alvaro/evidence-pr33-review-burden-pruning`
+- Commit: PR branch head
+- Fixture path:
+  `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json`
+- Current model: `openai:gpt-5.4-mini`
+- Candidate model: `openai:gpt-5`
+
+## Goal
+
+Close the pending stronger-model question with live evidence instead of model
+intuition. A candidate model can be recommended only when it completes the same
+repeatability gate as the current model, has zero hard safety failures, and does
+not regress trusted endpoint recovery.
+
+## Code Changes
+
+- Added `--cases` to `scripts/run_relation_model_comparison.py` so repeated
+  model A/B audits can pin the same benchmark fixture used by trusted-readiness
+  runs.
+- Made run-mode model comparison fail closed when a live audit subprocess exits
+  nonzero. The CLI now writes a comparison report with `KEEP_CURRENT`,
+  `audit_failures`, blocking reasons, and safety failures instead of crashing
+  without an artifact.
+- Added Markdown rendering for audit failures so reviewers do not need to open
+  JSON to see why a candidate model was rejected.
+
+## Artifact Hashes
+
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/relation_model_comparison_report.json`:
+  `ba9e7fffcf24dce3cf730933f4d1a27aac7c56f17e9e33b9b1a85d388b5c968b`
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/runs/current/run1/relation_feasibility_report.json`:
+  `552f0bf5f7dbab09075a3fc74a91811d00f4b4debd45f807f0c4490eaa6d4070`
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/runs/current/run2/relation_feasibility_report.json`:
+  `16f09f98b6c208b6fd3d539f90e7c79f62c49da1c161d1f01aa8f651854bcf97`
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/runs/current/run3/relation_feasibility_report.json`:
+  `5ba655a0873072403e3344c2936b68b87430161a3b694e14ddebbce2f488e972`
+- `reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof/runs/candidate/run1/relation_feasibility_report.json`:
+  `cdad70287950b4db7c2f4e58e2d960637a6696801d3c00d5344b302f050bccf8`
+
+## Validation
+
+RED/GREEN regression for fixture pinning:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  tests/unit/test_relation_feasibility_model_comparison.py::test_model_comparison_cli_passes_cases_to_repeated_audit_runs \
+  -q
+```
+
+Result:
+
+- before implementation: failed because `--cases` was not recognized
+- after implementation: passed
+
+RED/GREEN regression for failed candidate audit reporting:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  tests/unit/test_relation_feasibility_model_comparison.py::test_model_comparison_cli_writes_fail_closed_report_for_failed_candidate_run \
+  -q
+```
+
+Result:
+
+- before implementation: failed with escaped `CalledProcessError`
+- after implementation: passed and wrote `audit_failures`
+
+Symmetric current-model failure regression:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  tests/unit/test_relation_feasibility_model_comparison.py::test_model_comparison_cli_writes_fail_closed_report_for_failed_current_run \
+  -q
+```
+
+Result: passed after adversarial review.
+
+Focused model-comparison suite:
+
+```bash
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 -m pytest \
+  tests/unit/test_relation_feasibility_model_comparison.py \
+  -q
+```
+
+Result: `13 passed`
+
+Quality gate:
+
+```bash
+make relation-feasibility-quality-gate
+```
+
+Result: passed.
+
+Full service gate:
+
+```bash
+make service-checks
+```
+
+Result: passed with coverage `87.03%` against the `86%` floor.
+
+Live model A/B command:
+
+```bash
+set -a; source .env.postgres; \
+export ARTANA_STRONGER_MODEL_CANDIDATE=openai:gpt-5; set +a; \
+PYTHONPATH="$(pwd)/services:$(pwd)" \
+  .venv/bin/python3 scripts/run_relation_model_comparison.py \
+  --current-model-label openai:gpt-5.4-mini \
+  --candidate-model-label openai:gpt-5 \
+  --runs-per-model 3 \
+  --run-audits \
+  --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json \
+  --output-dir reports/relation_model_comparison/2026-07-06-pr34-live-model-ab-proof
+```
+
+Result:
+
+- current model completed three strict v3 live-agent runs
+- candidate model completed one strict v3 live-agent run
+- candidate model run2 failed preflight with `LiteLLM timed out after 1 attempts`
+- comparison report decision: `KEEP_CURRENT`
+
+## Model Comparison Result
+
+| Model | Completed runs | Decision status |
+|---|---:|---|
+| `openai:gpt-5.4-mini` | 3/3 | READY current baseline |
+| `openai:gpt-5` | 1/3 | Not adoptable |
+
+Current model worst-run readiness:
+
+| Metric | Worst |
+|---|---:|
+| Trusted graph readiness | READY |
+| Completed-agent precision | 1.0000 |
+| Completed-agent recall | 1.0000 |
+| Completed-agent valuable candidate rate | 0.5333 |
+| High-value recall | 1.0000 |
+| Trusted candidate precision | 1.0000 |
+| Trusted candidate valuable rate | 1.0000 |
+| Trusted candidate generic rate | 0.0000 |
+| Trusted-eligible high-value recall | 1.0000 |
+| Trusted-eligible CURIE endpoint rate | 1.0000 |
+| Entailment checked rate | 1.0000 |
+| Verified CURIE match rate | 0.7250 |
+
+Current model hard failures across runs1-3:
+
+- fallback case count: `0`
+- invalid agent case count: `0`
+- negative control leakage count: `0`
+- raw unknown relation type count: `0`
+- raw unknown relation type surface count: `0`
+- wrong verified CURIE link count: `0`
+- weak claim trusted leakage count: `0`
+- review-only gold trusted leakage count: `0`
+
+Candidate completed run1:
+
+| Metric | Value |
+|---|---:|
+| Verdict | GREEN |
+| Completed-agent precision | 1.0000 |
+| Completed-agent recall | 0.9667 |
+| Completed-agent valuable candidate rate | 0.5172 |
+| High-value recall | 0.9500 |
+| Trusted candidate precision | 1.0000 |
+| Trusted-eligible high-value recall | 1.0000 |
+| Trusted-eligible CURIE endpoint rate | 1.0000 |
+| Fallback cases | 0 |
+| Invalid agent cases | 0 |
+| Wrong verified CURIE links | 0 |
+
+Fail-closed comparison decision:
+
+- adopted model label: `null`
+- blocking reasons:
+  - `candidate audit run failed.`
+  - `candidate report count must match --runs-per-model; expected 3, got 1.`
+- safety failures:
+  - `candidate run2 exited 2`
+
+## Interpretation
+
+PR34 answers the stronger-model question for the current trusted-readiness
+stack: do not switch the default extraction model to `openai:gpt-5` from this
+evidence.
+
+The current configured model is already repeatably READY on the v3 trusted
+lane. The stronger candidate did not complete the three-run gate reliably, and
+its single completed run had lower completed-agent recall, high-value recall,
+and valuable candidate rate than the current model.
+
+The useful follow-up is not to rely on a stronger model as a shortcut. Future
+model work should first add explicit latency/cost fields and then retry a
+candidate only if it can pass the same three-run gate without preflight
+timeouts or safety regressions.
+
+Adversarial review found no blockers. It identified two improvements, both
+applied here: symmetric failed-current-run coverage and softer wording around
+candidate latency because explicit latency/cost fields are not yet recorded.

--- a/scripts/run_relation_model_comparison.py
+++ b/scripts/run_relation_model_comparison.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -22,8 +23,25 @@ from scripts.validation.relation_feasibility.model_comparison import (  # noqa: 
     build_model_comparison_report,
     write_model_comparison_report,
 )
+from scripts.validation.relation_feasibility.readiness import (  # noqa: E402
+    build_readiness_report,
+)
 
 _DEFAULT_REPORT_ROOT = _REPO_ROOT / "reports" / "relation_model_comparison"
+
+
+@dataclass(frozen=True, slots=True)
+class _AuditRunFailure:
+    model_label: str
+    run_index: int
+    exit_code: int
+    command: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _AuditGroupResult:
+    report_paths: tuple[Path, ...]
+    failures: tuple[_AuditRunFailure, ...]
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -73,6 +91,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--cases",
+        type=Path,
+        default=None,
+        help=(
+            "Benchmark JSON file to pass to each live audit when --run-audits is "
+            "used. When omitted, the audit script uses its own default fixture."
+        ),
+    )
+    parser.add_argument(
         "--candidate-model-env-var",
         default="ARTANA_STRONGER_MODEL_CANDIDATE",
         help="Environment variable containing the candidate extraction model id.",
@@ -106,33 +133,50 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     output_dir = args.output_dir or _timestamped_output_dir()
     if args.run_audits:
-        current_reports, candidate_reports = _run_audit_group_reports(
+        current_group, candidate_group = _run_audit_group_reports(
             output_dir=output_dir,
             runs_per_model=args.runs_per_model,
             candidate_model_env_var=args.candidate_model_env_var,
+            cases_path=args.cases,
         )
+        current_reports = current_group.report_paths
+        candidate_reports = candidate_group.report_paths
+        audit_failures = current_group.failures + candidate_group.failures
     else:
         current_reports = tuple(args.current_report or ())
         candidate_reports = tuple(args.candidate_report or ())
-    _validate_report_count(
-        label="current",
-        report_paths=current_reports,
-        runs_per_model=args.runs_per_model,
+        audit_failures = ()
+    resolved_current_reports = tuple(_resolve_report_path(path) for path in current_reports)
+    resolved_candidate_reports = tuple(
+        _resolve_report_path(path) for path in candidate_reports
     )
-    _validate_report_count(
-        label="candidate",
-        report_paths=candidate_reports,
-        runs_per_model=args.runs_per_model,
-    )
-    report = build_model_comparison_report(
-        current_model_label=args.current_model_label,
-        candidate_model_label=args.candidate_model_label,
-        current_report_paths=tuple(_resolve_report_path(path) for path in current_reports),
-        candidate_report_paths=tuple(
-            _resolve_report_path(path) for path in candidate_reports
-        ),
-        min_runs=args.runs_per_model,
-    )
+    if audit_failures:
+        report = _build_failed_audit_comparison_report(
+            current_model_label=args.current_model_label,
+            candidate_model_label=args.candidate_model_label,
+            current_report_paths=resolved_current_reports,
+            candidate_report_paths=resolved_candidate_reports,
+            audit_failures=audit_failures,
+            min_runs=args.runs_per_model,
+        )
+    else:
+        _validate_report_count(
+            label="current",
+            report_paths=resolved_current_reports,
+            runs_per_model=args.runs_per_model,
+        )
+        _validate_report_count(
+            label="candidate",
+            report_paths=resolved_candidate_reports,
+            runs_per_model=args.runs_per_model,
+        )
+        report = build_model_comparison_report(
+            current_model_label=args.current_model_label,
+            candidate_model_label=args.candidate_model_label,
+            current_report_paths=resolved_current_reports,
+            candidate_report_paths=resolved_candidate_reports,
+            min_runs=args.runs_per_model,
+        )
     manifest = write_model_comparison_report(report=report, output_dir=output_dir)
     decision = report["decision"]
     adopted_model_label = (
@@ -159,32 +203,40 @@ def _run_audit_group_reports(
     output_dir: Path,
     runs_per_model: int,
     candidate_model_env_var: str,
-) -> tuple[tuple[Path, ...], tuple[Path, ...]]:
+    cases_path: Path | None,
+) -> tuple[_AuditGroupResult, _AuditGroupResult]:
     candidate_model = os.environ.get(candidate_model_env_var)
     if not candidate_model:
         msg = f"{candidate_model_env_var} must be set when --run-audits is used"
         raise SystemExit(msg)
     original_model = os.environ.get("ARTANA_AI_EVIDENCE_EXTRACTION_MODEL")
     current_reports = _run_model_audits(
+        model_label="current",
         output_dir=output_dir / "runs" / "current",
         runs_per_model=runs_per_model,
         model_id=original_model,
+        cases_path=cases_path,
     )
     candidate_reports = _run_model_audits(
+        model_label="candidate",
         output_dir=output_dir / "runs" / "candidate",
         runs_per_model=runs_per_model,
         model_id=candidate_model,
+        cases_path=cases_path,
     )
     return current_reports, candidate_reports
 
 
 def _run_model_audits(
     *,
+    model_label: str,
     output_dir: Path,
     runs_per_model: int,
     model_id: str | None,
-) -> tuple[Path, ...]:
+    cases_path: Path | None,
+) -> _AuditGroupResult:
     reports: list[Path] = []
+    failures: list[_AuditRunFailure] = []
     for run_index in range(1, runs_per_model + 1):
         run_dir = output_dir / f"run{run_index}"
         run_dir.mkdir(parents=True, exist_ok=True)
@@ -193,12 +245,31 @@ def _run_model_audits(
             env["ARTANA_AI_EVIDENCE_EXTRACTION_MODEL"] = model_id
         else:
             env.pop("ARTANA_AI_EVIDENCE_EXTRACTION_MODEL", None)
-        _run_single_audit(output_dir=run_dir, env=env)
+        try:
+            if cases_path is None:
+                _run_single_audit(output_dir=run_dir, env=env)
+            else:
+                _run_single_audit(output_dir=run_dir, env=env, cases_path=cases_path)
+        except subprocess.CalledProcessError as exc:
+            failures.append(
+                _AuditRunFailure(
+                    model_label=model_label,
+                    run_index=run_index,
+                    exit_code=exc.returncode,
+                    command=tuple(str(part) for part in exc.cmd),
+                ),
+            )
+            break
         reports.append(run_dir / "relation_feasibility_report.json")
-    return tuple(reports)
+    return _AuditGroupResult(report_paths=tuple(reports), failures=tuple(failures))
 
 
-def _run_single_audit(*, output_dir: Path, env: Mapping[str, str]) -> None:
+def _run_single_audit(
+    *,
+    output_dir: Path,
+    env: Mapping[str, str],
+    cases_path: Path | None = None,
+) -> None:
     command = [
         sys.executable,
         str(_REPO_ROOT / "scripts" / "run_relation_feasibility_audit.py"),
@@ -207,6 +278,8 @@ def _run_single_audit(*, output_dir: Path, env: Mapping[str, str]) -> None:
         "--output-dir",
         str(output_dir),
     ]
+    if cases_path is not None:
+        command.extend(("--cases", str(cases_path)))
     subprocess.run(  # noqa: S603
         command,
         cwd=_REPO_ROOT,
@@ -233,6 +306,117 @@ def _resolve_report_path(path: Path) -> Path:
     if path.is_dir():
         return path / "relation_feasibility_report.json"
     return path
+
+
+def _build_failed_audit_comparison_report(  # noqa: PLR0913
+    *,
+    current_model_label: str,
+    candidate_model_label: str,
+    current_report_paths: Sequence[Path],
+    candidate_report_paths: Sequence[Path],
+    audit_failures: Sequence[_AuditRunFailure],
+    min_runs: int,
+) -> dict[str, object]:
+    return {
+        "current_model_label": current_model_label,
+        "candidate_model_label": candidate_model_label,
+        "current_readiness": _readiness_or_incomplete_placeholder(
+            label="current",
+            report_paths=current_report_paths,
+            min_runs=min_runs,
+        ),
+        "candidate_readiness": _readiness_or_incomplete_placeholder(
+            label="candidate",
+            report_paths=candidate_report_paths,
+            min_runs=min_runs,
+        ),
+        "audit_failures": [_audit_failure_to_json(failure) for failure in audit_failures],
+        "decision": {
+            "adopted_model_label": None,
+            "blocking_reasons": _audit_failure_blocking_reasons(
+                current_report_count=len(current_report_paths),
+                candidate_report_count=len(candidate_report_paths),
+                audit_failures=audit_failures,
+                min_runs=min_runs,
+            ),
+            "metric_deltas": {},
+            "safety_failures": [
+                (
+                    f"{failure.model_label} run{failure.run_index} "
+                    f"exited {failure.exit_code}"
+                )
+                for failure in audit_failures
+            ],
+        },
+    }
+
+
+def _readiness_or_incomplete_placeholder(
+    *,
+    label: str,
+    report_paths: Sequence[Path],
+    min_runs: int,
+) -> dict[str, object]:
+    if len(report_paths) >= min_runs:
+        return build_readiness_report(report_paths=report_paths, min_runs=min_runs)
+    return {
+        "readiness_status": "not_ready",
+        "trusted_graph_ready": False,
+        "blocking_reasons": [
+            _report_count_reason(
+                label=label,
+                report_count=len(report_paths),
+                min_runs=min_runs,
+            ),
+        ],
+        "worst_metrics": {},
+        "hard_failure_counts": {},
+    }
+
+
+def _audit_failure_blocking_reasons(
+    *,
+    current_report_count: int,
+    candidate_report_count: int,
+    audit_failures: Sequence[_AuditRunFailure],
+    min_runs: int,
+) -> list[str]:
+    reasons: list[str] = []
+    failed_labels = {failure.model_label for failure in audit_failures}
+    reasons.extend(f"{label} audit run failed." for label in sorted(failed_labels))
+    if current_report_count != min_runs:
+        reasons.append(
+            _report_count_reason(
+                label="current",
+                report_count=current_report_count,
+                min_runs=min_runs,
+            ),
+        )
+    if candidate_report_count != min_runs:
+        reasons.append(
+            _report_count_reason(
+                label="candidate",
+                report_count=candidate_report_count,
+                min_runs=min_runs,
+            ),
+        )
+    return reasons
+
+
+def _report_count_reason(*, label: str, report_count: int, min_runs: int) -> str:
+    return (
+        f"{label} report count must match --runs-per-model; "
+        f"expected {min_runs}, got {report_count}."
+    )
+
+
+def _audit_failure_to_json(failure: _AuditRunFailure) -> dict[str, object]:
+    return {
+        "model_label": failure.model_label,
+        "run_index": failure.run_index,
+        "exit_code": failure.exit_code,
+        "command": " ".join(failure.command),
+    }
 
 
 def _decision_count(decision: object, key: str) -> int:

--- a/scripts/validation/relation_feasibility/model_comparison.py
+++ b/scripts/validation/relation_feasibility/model_comparison.py
@@ -142,6 +142,8 @@ def render_model_comparison_markdown(report: JSONObject) -> str:
         lines.extend(f"- {failure}" for failure in safety_failures)
     else:
         lines.append("- none")
+    lines.extend(["", "## Audit Failures", ""])
+    lines.extend(_audit_failure_lines(report.get("audit_failures")))
     lines.extend(["", "## Metric Deltas", ""])
     lines.extend(_metric_lines(decision.get("metric_deltas")))
     lines.extend(["", "## Current Worst Metrics", ""])
@@ -291,6 +293,23 @@ def _metric_lines(value: object) -> list[str]:
     if not metrics:
         return ["- none"]
     return [f"- {key}: {metric_value}" for key, metric_value in sorted(metrics.items())]
+
+
+def _audit_failure_lines(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return ["- none"]
+    lines: list[str] = []
+    for item in value:
+        failure = _object_dict(item)
+        model_label = _optional_string(failure.get("model_label")) or "unknown"
+        run_index = _int_value(failure.get("run_index"))
+        exit_code = _int_value(failure.get("exit_code"))
+        command = _optional_string(failure.get("command"))
+        line = f"- {model_label} run{run_index} exited {exit_code}"
+        if command is not None:
+            line = f"{line}: `{command}`"
+        lines.append(line)
+    return lines or ["- none"]
 
 
 def _object_dict(value: object) -> JSONObject:

--- a/tests/unit/test_relation_feasibility_model_comparison.py
+++ b/tests/unit/test_relation_feasibility_model_comparison.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -453,3 +454,169 @@ def test_model_comparison_cli_orchestrates_repeated_audit_runs(
         (Path("runs/candidate/run3"), "openai:gpt-5.5"),
     ]
     assert (output_dir / "relation_model_comparison_report.json").exists()
+
+
+def test_model_comparison_cli_passes_cases_to_repeated_audit_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_cases: list[Path | None] = []
+    cases_path = tmp_path / "benchmark_v3.json"
+    cases_path.write_text("[]\n")
+    monkeypatch.setenv("ARTANA_STRONGER_MODEL_CANDIDATE", "openai:gpt-5.5")
+
+    def _fake_run_audit(
+        *,
+        output_dir: Path,
+        env: Mapping[str, str],
+        cases_path: Path | None = None,
+    ) -> None:
+        run_cases.append(cases_path)
+        _write_report(
+            output_dir,
+            "relation_feasibility_report",
+            model_label="candidate"
+            if env.get("ARTANA_AI_EVIDENCE_EXTRACTION_MODEL") == "openai:gpt-5.5"
+            else "current",
+        )
+
+    monkeypatch.setattr(comparison_script, "_run_single_audit", _fake_run_audit)
+
+    exit_code = comparison_main(
+        [
+            "--current-model-label",
+            "current",
+            "--candidate-model-label",
+            "candidate",
+            "--runs-per-model",
+            "3",
+            "--run-audits",
+            "--cases",
+            str(cases_path),
+            "--output-dir",
+            str(tmp_path / "comparison"),
+        ],
+    )
+
+    assert exit_code == 0
+    assert run_cases == [cases_path] * 6
+
+
+def test_model_comparison_cli_writes_fail_closed_report_for_failed_candidate_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARTANA_STRONGER_MODEL_CANDIDATE", "openai:gpt-5.5")
+
+    def _fake_run_audit(*, output_dir: Path, env: Mapping[str, str]) -> None:
+        relative_output = output_dir.relative_to(tmp_path / "comparison")
+        if relative_output == Path("runs/candidate/run2"):
+            raise subprocess.CalledProcessError(
+                returncode=2,
+                cmd=("run_relation_feasibility_audit.py", "--extractor", "agent"),
+            )
+        _write_report(
+            output_dir,
+            "relation_feasibility_report",
+            model_label="candidate"
+            if env.get("ARTANA_AI_EVIDENCE_EXTRACTION_MODEL") == "openai:gpt-5.5"
+            else "current",
+        )
+
+    monkeypatch.setattr(comparison_script, "_run_single_audit", _fake_run_audit)
+    output_dir = tmp_path / "comparison"
+
+    exit_code = comparison_main(
+        [
+            "--current-model-label",
+            "current",
+            "--candidate-model-label",
+            "candidate",
+            "--runs-per-model",
+            "3",
+            "--run-audits",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    report = json.loads(
+        (output_dir / "relation_model_comparison_report.json").read_text(),
+    )
+    markdown = (output_dir / "relation_model_comparison_report.md").read_text()
+
+    assert exit_code == 0
+    assert report["decision"]["adopted_model_label"] is None
+    assert "candidate audit run failed." in report["decision"]["blocking_reasons"]
+    assert report["audit_failures"] == [
+        {
+            "model_label": "candidate",
+            "run_index": 2,
+            "exit_code": 2,
+            "command": "run_relation_feasibility_audit.py --extractor agent",
+        },
+    ]
+    assert "## Audit Failures" in markdown
+    assert "- candidate run2 exited 2" in markdown
+
+
+def test_model_comparison_cli_writes_fail_closed_report_for_failed_current_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARTANA_STRONGER_MODEL_CANDIDATE", "openai:gpt-5.5")
+
+    def _fake_run_audit(*, output_dir: Path, env: Mapping[str, str]) -> None:
+        relative_output = output_dir.relative_to(tmp_path / "comparison")
+        if relative_output == Path("runs/current/run2"):
+            raise subprocess.CalledProcessError(
+                returncode=2,
+                cmd=("run_relation_feasibility_audit.py", "--extractor", "agent"),
+            )
+        _write_report(
+            output_dir,
+            "relation_feasibility_report",
+            model_label="candidate"
+            if env.get("ARTANA_AI_EVIDENCE_EXTRACTION_MODEL") == "openai:gpt-5.5"
+            else "current",
+        )
+
+    monkeypatch.setattr(comparison_script, "_run_single_audit", _fake_run_audit)
+    output_dir = tmp_path / "comparison"
+
+    exit_code = comparison_main(
+        [
+            "--current-model-label",
+            "current",
+            "--candidate-model-label",
+            "candidate",
+            "--runs-per-model",
+            "3",
+            "--run-audits",
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+
+    report = json.loads(
+        (output_dir / "relation_model_comparison_report.json").read_text(),
+    )
+    markdown = (output_dir / "relation_model_comparison_report.md").read_text()
+
+    assert exit_code == 0
+    assert report["decision"]["adopted_model_label"] is None
+    assert "current audit run failed." in report["decision"]["blocking_reasons"]
+    assert report["decision"]["blocking_reasons"] == [
+        "current audit run failed.",
+        "current report count must match --runs-per-model; expected 3, got 1.",
+    ]
+    assert report["audit_failures"] == [
+        {
+            "model_label": "current",
+            "run_index": 2,
+            "exit_code": 2,
+            "command": "run_relation_feasibility_audit.py --extractor agent",
+        },
+    ]
+    assert report["candidate_readiness"]["readiness_status"] == "ready"
+    assert "- current run2 exited 2" in markdown


### PR DESCRIPTION
## Summary

- Add `--cases` to `scripts/run_relation_model_comparison.py` so repeated live model A/B audits can pin the same benchmark fixture as trusted-readiness runs.
- Make failed live audit subprocesses produce a fail-closed `KEEP_CURRENT` model-comparison report with `audit_failures` instead of crashing without an artifact.
- Record the PR34 live current-vs-`openai:gpt-5` result in the tracker and merge-visible summary.

## Live A/B Result

Decision: `KEEP_CURRENT`.

- Current model `openai:gpt-5.4-mini`: completed 3/3 strict v3 live-agent runs; trusted readiness READY; hard failures 0.
- Candidate model `openai:gpt-5`: completed 1/3 strict v3 live-agent runs; run2 failed live-agent preflight with a LiteLLM timeout.
- Candidate run1 was GREEN but lower than current on completed-agent recall (`0.9667` vs `1.0000`), high-value recall (`0.9500` vs `1.0000`), and valuable candidate rate (`0.5172` vs `0.5333`).

## Validation

- `PYTHONPATH="$PWD/services:$PWD" .venv/bin/python3 -m pytest tests/unit/test_relation_feasibility_model_comparison.py -q` -> `13 passed`
- `uv run ruff check scripts/run_relation_model_comparison.py scripts/validation/relation_feasibility/model_comparison.py tests/unit/test_relation_feasibility_model_comparison.py` -> passed
- `make relation-feasibility-quality-gate` -> passed
- `make service-checks` -> passed, coverage `87.03%` against `86%` floor
- Adversarial review: no blockers; followed up by adding symmetric failed-current-run coverage and softer latency wording

## Evidence

- `docs/validation/reports/2026-07-06-pr34-live-model-ab-proof-summary.md`
- `docs/validation/evidence-excellence-progress-tracker.md`
