### PR TITLE
PR36: Harden v4 live-agent trusted readiness

### DIFF
--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -154,6 +154,7 @@ Status values:
 | 22 | PR-33 | `alvaro/evidence-pr33-review-burden-pruning` | Implemented locally; final gates pass; three-run readiness READY | Remove repeated review-burden false positives and recover rare zero-candidate/schema-invalid agent responses without deterministic fallback. | Trusted readiness remains READY, hard safety failures stay 0, and missed gold and repeated false positives are 0 across three post-adversarial strict v3 live-agent runs. | Added companion phenotype, pathway/process, downstream context, cell-context, and binding-site sibling pruning; added agent-only zero-candidate and schema-repair retries with retry-specific prompts and distinct replay keys; adversarial review and service-gate failures fixed invalid-sibling shadowing, raw-but-unusable retry suppression, schema-retry ordering, weak-pass candidate loss, partial zero-retry cue coverage, unknown-only candidate retry suppression, and over-broad pruning; focused tests pass (`80 passed`), quality-filter suite passes (`47 passed`), touched-file Ruff passes, `make relation-feasibility-quality-gate` passes, `make service-checks` passes with coverage `87.03%`, and strict post-adversarial3 live runs1-3 aggregate to READY with worst completed-agent precision 1.0000, worst recall 1.0000, worst high-value recall 1.0000, trusted precision 1.0000, trusted valuable rate 1.0000, trusted endpoint rate 1.0000, missed gold 0, false positives 0, fallback 0, invalid agent 0, negative leakage 0, weak trusted leakage 0, and wrong verified CURIE links 0. Summary: `docs/validation/reports/2026-07-06-pr33-review-burden-pruning-summary.md`. |
 | 23 | PR-34 | `alvaro/evidence-pr34-live-model-ab-proof` | Implemented locally; live A/B proof complete; final gates pass | Close the stronger-model question with a fail-closed live model comparison on the v3 benchmark. | Candidate model adoption requires three completed runs, zero hard safety failures, and no trusted endpoint regression. | Added fixture pinning to `scripts/run_relation_model_comparison.py`, made failed audit subprocesses produce a `KEEP_CURRENT` report with `audit_failures`, and added Markdown audit-failure rendering. Current `openai:gpt-5.4-mini` completed 3/3 strict v3 live runs with trusted readiness READY and hard failures 0; candidate `openai:gpt-5` completed only 1/3 runs and failed run2 preflight with a LiteLLM timeout, so the comparison decision is KEEP_CURRENT. Focused model-comparison tests pass (`13 passed`), `make relation-feasibility-quality-gate` passes, `make service-checks` passes with coverage `87.03%`, and adversarial review found no blockers after symmetric failed-current-run coverage and doc wording cleanup. Summary: `docs/validation/reports/2026-07-06-pr34-live-model-ab-proof-summary.md`. |
 | 24 | PR-35 | `alvaro/evidence-pr35-benchmark-v4-100-case-proof` | Implemented locally; final local gates pass; adversarial re-review PASS | Make the Definition-of-Green benchmark scale requirement executable with a 100-case v4 fixture. | CI fails if the trusted-readiness benchmark fixture is below 100 cases, lacks balanced high-value/true-low-value/negative/long-document/near-miss coverage, pads scale with duplicate relation signatures, or adds new broad v4 pathway/gene rows as trusted gold. | Added `biomedical_relation_goldset_v4.json` by preserving the 40-case v3 seed and adding 60 labeled synthetic cases: 50 strong-specific, 25 weak review-only, and 25 negative-control cases overall. Added v4 validation coverage requiring at least 100 cases, 50 high-value specific cases, 25 true low-value review cases, 25 negative controls, at least five long-document cases, at least five adversarial negated near-misses, at least 74 unique gold relation signatures, and at most one repeated signature for the inherited v3 IL6 strong/weak contrast. RED test failed on the missing v4 fixture; adversarial review then found the low-value count mixed high-value review-only rows and that some v4 rows duplicated v3 or used broad trusted endpoints, so PR35 added `true_low_value_review_case_count`, signature-diversity counters, and a v4 trusted-context guard. GREEN focused fixture validation passes (`7 passed`) with validator issue count 0, touched-file Ruff passes, `make relation-feasibility-quality-gate` passes, `make service-checks` passes with coverage `87.03%`, and final adversarial re-review reports PASS. Summary: `docs/validation/reports/2026-07-06-pr35-benchmark-v4-100-case-proof-summary.md`. |
+| 25 | PR-36 | `alvaro/evidence-pr36-v4-live-readiness` | Implemented locally; final gates pass; post-adversarial three-run v4 readiness READY | Run strict live-agent readiness against the 100-case v4 fixture and close trusted-lane blockers without relying on deterministic fallback. | Three strict v4 live-agent runs pass the repeated-run readiness gate with trusted precision, trusted valuable rate, trusted generic rate, trusted-eligible high-value recall, and trusted endpoint recovery all at target while hard failures stay 0. | Added a trusted-promotion safety policy for strong-but-unsafe relation shapes, wired it into relation quality filtering, fixed hyphenated modifier-loss pruning, aligned v3/v4 gold rows with promotion policy, and added fixture validation so trusted gold cannot violate the same safety policy. Adversarial review then exposed `CAUSES`/gene-state association leaks, `growth` over-demotion, reason-code loss, a live `JAK2 activity` endpoint repair gap, and a `growth factor-independent proliferation` phrase gap; PR36 added RED/GREEN regressions and fixes for all. Strict v4 postreview2 runs1-3 aggregate to READY: worst trusted precision 1.0000, trusted valuable rate 1.0000, trusted generic rate 0.0000, trusted-eligible high-value recall 1.0000, trusted-eligible endpoint rate 1.0000, fallback 0, invalid agent 0, negative leakage 0, review-only trusted leakage 0, weak trusted leakage 0, and wrong verified CURIE links 0. Focused tests pass, touched-file Ruff passes, `make relation-feasibility-quality-gate` passes, final adversarial re-review is PASS, and `make service-checks` passes with coverage `87.03%`. Summary: `docs/validation/reports/2026-07-06-pr36-v4-live-readiness-summary.md`. |
 
 ## PR Evidence Packet
 
@@ -214,6 +215,91 @@ Run only the service checks relevant to the changed boundary, then run the
 aggregate gate before merge when the PR is ready.
 
 ## Evidence Log
+
+### 2026-07-07 - PR-36 V4 Live-Agent Trusted Readiness
+
+PR: PR-36 v4 live-agent trusted readiness
+
+Branch: `alvaro/evidence-pr36-v4-live-readiness`
+
+Goal: Run the strict live-agent readiness loop against the 100-case v4 fixture
+and prevent broad or structurally under-grounded review evidence from leaking
+into trusted graph auto-promotion.
+
+Evidence:
+
+- `docs/validation/reports/2026-07-06-pr36-v4-live-readiness-summary.md`
+- `reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run1/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run2/relation_feasibility_report.json`
+- `reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run3/relation_feasibility_report.json`
+- `reports/relation_feasibility_readiness/2026-07-07-pr36-v4-live-readiness-postreview2/relation_feasibility_readiness_report.json`
+- `services/artana_evidence_api/document_extraction_support/review_policy/trusted_promotion_safety_policy.py`
+
+Final three-run strict live-agent trusted-lane metrics:
+
+| Metric | Worst | Mean |
+|---|---:|---:|
+| Trusted readiness | READY | READY |
+| Completed-agent precision | 0.9861 | 0.9908 |
+| Completed-agent recall | 0.9467 | 0.9600 |
+| Completed-agent valuable rate | 0.5694 | 0.5733 |
+| High-value recall | 0.9600 | 0.9733 |
+| Trusted candidate precision | 1.0000 | 1.0000 |
+| Trusted candidate valuable rate | 1.0000 | 1.0000 |
+| Trusted candidate generic rate | 0.0000 | 0.0000 |
+| Trusted-eligible high-value recall | 1.0000 | 1.0000 |
+| Trusted-eligible CURIE endpoint rate | 1.0000 | 1.0000 |
+| Entailment checked rate | 1.0000 | 1.0000 |
+| Verified CURIE match rate | 0.8161 | 0.8314 |
+| All-candidate generic relation rate | 0.3288 | 0.3211 |
+
+Hard failures:
+
+- fallback cases: `0`
+- invalid agent cases: `0`
+- negative-control leakage: `0`
+- raw unknown relation types: `0`
+- raw unknown relation type surfaces: `0`
+- review-only gold trusted leakage: `0`
+- weak-claim trusted leakage: `0`
+- wrong verified CURIE links: `0`
+
+Validation:
+
+- Quality-filter suite: `62 passed`
+- Focused regression bundle: passed
+- Touched-file Ruff: `All checks passed!`
+- `make relation-feasibility-quality-gate`: passed
+- Strict v4 postreview2 live-agent runs1-3: all `GREEN`
+- Repeated-run readiness gate with `--fail-on-not-ready`: `READY`
+- Final adversarial re-review: PASS
+- `make service-checks`: passed with coverage `87.03%`
+
+Adversarial review fixes:
+
+- Added `CAUSES` and non-dictionary gene-state association regressions so
+  bare-gene/gene-state disease claims cannot bypass promotion safety.
+- Prevented `growth` inside molecular target names such as epidermal growth
+  factor receptor from being treated as a composite growth process.
+- Merged weak-review and trusted-promotion safety reason codes so audit trails
+  do not lose either reason family.
+- Added the `Ruxolitinib INHIBITS JAK2 activity` conversion regression and
+  repair so a verified direct target is recovered instead of trusting a
+  model-only process endpoint.
+- Added the `growth factor-independent proliferation` regression so target-like
+  tokens inside process labels do not bypass composite-process review-only
+  safety; the v4 fixture and postreview2 live reports do not contain this phrase,
+  so the live-readiness metrics above remain the authoritative postreview2
+  batch.
+
+Interpretation:
+
+PR36 makes the v4 trusted lane ready under the current repeated strict
+live-agent gate. The change is not a fallback or benchmark-only shortcut: it
+adds code-level trusted-promotion safety rules and applies the same policy to
+fixture validation. Remaining all-candidate generic noise and review-only CURIE
+gaps stay visible as follow-up review-lane work, not trusted auto-promotion
+blockers.
 
 ### 2026-07-06 - PR-34 Live Model A/B Proof
 

--- a/docs/validation/reports/2026-07-06-pr36-v4-live-readiness-summary.md
+++ b/docs/validation/reports/2026-07-06-pr36-v4-live-readiness-summary.md
@@ -1,0 +1,258 @@
+# PR36 V4 Live-Agent Trusted Readiness Summary
+
+## Run Context
+
+- Branch: `alvaro/evidence-pr36-v4-live-readiness`
+- Base branch: `alvaro/evidence-pr35-benchmark-v4-100-case-proof`
+- Fixture path:
+  `scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v4.json`
+- Model label: live agent configured by `.env.postgres`
+
+## Goal
+
+Run the strict live-agent readiness loop against the 100-case v4 benchmark and
+close any blockers that prevent trusted graph auto-promotion from being safe.
+The target is the live-agent path, not deterministic fallback.
+
+## Root Cause
+
+The first v4 live-agent readiness runs were RED even though the agent completed
+all cases and fallback stayed at zero. The failure was trusted-promotion policy:
+strong-looking but unsafe relation shapes could still enter the trusted lane.
+
+The unsafe shapes were not useless evidence. They were useful review items whose
+endpoint semantics were too broad or too composite for automatic trusted graph
+promotion:
+
+- bare-gene disease/phenotype associations without variant-state grounding,
+- gene-state predisposition labels that need structured grounding,
+- broad pathway endpoints such as `MAPK signaling`,
+- composite treatment-response labels,
+- molecular-subtype disease labels,
+- composite process endpoints such as cancer-cell proliferation,
+- process-context relations such as DNA repair regulating a disease subtype.
+
+The benchmark also had a few over-trusted gold rows inherited from v3/v4. Those
+rows overstated what the sentence supported and therefore taught the scorecard
+to reward unsafe promotion.
+
+Adversarial review then found two additional safety gaps:
+
+- `CAUSES` and non-dictionary gene-state `ASSOCIATED_WITH` claims could still
+  bypass the variant/state grounding guard.
+- direct target activity tails such as `JAK2 activity` could survive as trusted
+  candidates with model-only process CURIE hints instead of being repaired to
+  the verified target endpoint.
+
+## Code And Data Changes
+
+- Added a single-responsibility trusted-promotion safety policy:
+  `services/artana_evidence_api/document_extraction_support/review_policy/trusted_promotion_safety_policy.py`.
+- Wired the policy into the relation candidate quality filter so unsafe strong
+  candidates remain visible as `review_only` instead of entering trusted graph
+  auto-promotion.
+- Added review reason codes for each unsafe trusted-promotion shape.
+- Tightened specificity pruning for hyphenated modifier loss, so
+  `BRCA-mutated ovarian cancer` cannot be shortened to `BRCA` without being
+  rejected.
+- Updated fixture validation so trusted high/medium gold rows fail if they
+  violate the same trusted-promotion safety policy used by extraction.
+- Corrected v3/v4 gold rows that were too broad for trusted auto-promotion:
+  BRAF/KRAS activation of `MAPK signaling` and Bevacizumab inhibition of
+  `VEGF-A signaling` are now review-only gold.
+- After adversarial review, expanded the gene/phenotype guard to cover `CAUSES`
+  and gene-state `ASSOCIATED_WITH` surfaces, kept receptor labels containing
+  `growth` out of the composite-process demotion rule, and merged weak-review
+  plus promotion-safety reason codes into one audit trail.
+- Added direct-mechanism object repair for verified one-token target activity
+  labels, so `Ruxolitinib INHIBITS JAK2 activity` becomes a verified `JAK2`
+  endpoint instead of a trusted model-only `JAK2 activity` process endpoint.
+
+## Artifact Hashes
+
+- `reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run1/relation_feasibility_report.json`:
+  `f8f3a576dbee94982bafeffc56e0a7a37b7ade7233681c38b3e7d1a4207dc1a7`
+- `reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run2/relation_feasibility_report.json`:
+  `feddb311cd6e7422ef4bbb790366fe788868c6a7de377640e2b62ff0c8dd5dd4`
+- `reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run3/relation_feasibility_report.json`:
+  `fc7da9f804deb04eb9e57c7b6ef3690872e493ec47429cf2027ee0d91d6230db`
+- `reports/relation_feasibility_readiness/2026-07-07-pr36-v4-live-readiness-postreview2/relation_feasibility_readiness_report.json`:
+  `d10b91519d0c6e0b0452bfce520f35a23da2271fb3a97f8b0b34fe54630bbbac`
+
+## Validation
+
+Focused quality-filter suite:
+
+```bash
+uv run pytest services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py -q
+```
+
+Result: `62 passed`.
+
+Focused regression bundle:
+
+```bash
+uv run pytest \
+  services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py \
+  services/artana_evidence_api/tests/unit/test_document_extraction_modules.py \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py \
+  tests/unit/test_relation_feasibility_audit.py \
+  tests/unit/test_relation_feasibility_fixture_validation.py -q
+```
+
+Result: passed.
+
+Touched-file Ruff:
+
+```bash
+uv run ruff check \
+  services/artana_evidence_api/document_extraction_support/review_policy/trusted_promotion_safety_policy.py \
+  services/artana_evidence_api/document_extraction_support/llm_fulltext_extraction.py \
+  services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py \
+  services/artana_evidence_api/document_extraction_support/relation_specificity_pruning.py \
+  services/artana_evidence_api/tests/unit/test_document_extraction_modules.py \
+  services/artana_evidence_api/tests/unit/test_document_extraction.py \
+  services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py \
+  scripts/validation/relation_feasibility/fixture_checks/validation.py \
+  tests/unit/test_relation_feasibility_fixture_validation.py
+```
+
+Result: `All checks passed!`
+
+Relation-feasibility quality gate:
+
+```bash
+make relation-feasibility-quality-gate
+```
+
+Result: passed.
+
+Aggregate service gate:
+
+```bash
+make service-checks
+```
+
+Result: passed with coverage `87.03%`.
+
+Final adversarial re-review:
+
+- Result: PASS.
+- Prior blockers fixed: `CAUSES` and non-dictionary gene-state association
+  leaks, `growth` receptor over-demotion, reason-code loss, direct target
+  activity-tail repair, and the later `growth factor-independent proliferation`
+  composite-process gap.
+
+Strict v4 live-agent runs:
+
+```bash
+set -a; source .env.postgres; set +a; \
+  uv run python scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v4.json \
+  --output-dir reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run1
+
+set -a; source .env.postgres; set +a; \
+  uv run python scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v4.json \
+  --output-dir reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run2
+
+set -a; source .env.postgres; set +a; \
+  uv run python scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --cases scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v4.json \
+  --output-dir reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run3
+```
+
+Readiness aggregate:
+
+```bash
+uv run python scripts/run_relation_feasibility_readiness_gate.py \
+  --report reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run1 \
+  --report reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run2 \
+  --report reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run3 \
+  --min-runs 3 \
+  --output-dir reports/relation_feasibility_readiness/2026-07-07-pr36-v4-live-readiness-postreview2 \
+  --fail-on-not-ready
+```
+
+Result:
+
+- `relation_feasibility_readiness status=ready`
+- runs evaluated: `3 / 3`
+- blocking reasons: `0`
+
+## Three-Run Readiness Result
+
+Trusted graph readiness is **READY** for the measured v4 strict live-agent
+trusted lane.
+
+| Metric | Worst | Mean |
+|---|---:|---:|
+| Completed-agent precision | 0.9861 | 0.9908 |
+| Completed-agent recall | 0.9467 | 0.9600 |
+| Completed-agent valuable rate | 0.5694 | 0.5733 |
+| High-value recall | 0.9600 | 0.9733 |
+| Trusted candidate precision | 1.0000 | 1.0000 |
+| Trusted candidate valuable rate | 1.0000 | 1.0000 |
+| Trusted candidate generic rate | 0.0000 | 0.0000 |
+| Trusted-eligible high-value recall | 1.0000 | 1.0000 |
+| Trusted-eligible CURIE endpoint rate | 1.0000 | 1.0000 |
+| Entailment checked rate | 1.0000 | 1.0000 |
+| Verified CURIE match rate | 0.8161 | 0.8314 |
+| All-candidate generic relation rate | 0.3288 | 0.3211 |
+
+Hard failures across v4 postreview2 runs1-3:
+
+- fallback case count: `0`
+- invalid agent case count: `0`
+- negative-control leakage count: `0`
+- raw unknown relation type count: `0`
+- raw unknown relation type surface count: `0`
+- review-only gold trusted leakage count: `0`
+- weak-claim trusted leakage count: `0`
+- wrong verified CURIE link count: `0`
+
+Run-level trusted-lane metrics:
+
+| Run | Trusted candidates | Trusted precision | Trusted valuable | Trusted generic | Trusted-eligible high-value recall | Trusted endpoint rate | Review-only leakage |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| postreview2-run1 | 10 | 1.0000 | 1.0000 | 0.0000 | 1.0000 | 1.0000 | 0 |
+| postreview2-run2 | 10 | 1.0000 | 1.0000 | 0.0000 | 1.0000 | 1.0000 | 0 |
+| postreview2-run3 | 10 | 1.0000 | 1.0000 | 0.0000 | 1.0000 | 1.0000 | 0 |
+
+## Prior RED Runs
+
+Earlier strict live-agent runs were intentionally kept as part of the loop
+evidence. They are superseded by the postreview2 batch above, but they explain
+why PR36 changed code instead of only rerunning the model.
+
+| Run | Verdict | Main blocker | Trusted precision | Trusted-eligible high-value recall | Trusted endpoint rate | Review-only leakage |
+|---|---|---|---:|---:|---:|---:|
+| 2026-07-06 run1 | RED | 15 review-only gold rows leaked into trusted candidates, with low trusted precision. | 0.4138 | 0.9231 | 0.9231 | 15 |
+| 2026-07-06 run2 | RED | One trusted leakage case survived after the first safety pass. | 0.8333 | 1.0000 | 1.0000 | 1 |
+| 2026-07-06 run3 | RED | One process-context trusted leakage case survived. | 0.9091 | 1.0000 | 1.0000 | 1 |
+| 2026-07-07 postreview-run2 | RED | `Ruxolitinib INHIBITS JAK2 activity` used a trusted model-only process endpoint and missed verified `JAK2`. | 0.9000 | 0.9000 | 0.9000 | 0 |
+
+## Interpretation
+
+PR36 is the first v4 loop where the 100-case strict live-agent benchmark passes
+the repeated-run trusted-readiness gate. The improvement is code-level and
+policy-level: the system no longer treats broad or structurally under-grounded
+review evidence as trusted graph evidence.
+
+This does not mean every future biomedical document is globally safe for
+automatic graph promotion. It means the measured v4 trusted lane is ready under
+the current strict live-agent readiness gate. The all-candidate lane still shows
+useful review-lane work: verified CURIE match rate is below the trusted-lane
+endpoint rate because many review-only and low-value candidates still lack
+trusted endpoints, and all-candidate generic relation rate remains high. Those
+are review usefulness and benchmark-expansion issues, not trusted auto-promotion
+blockers for PR36.
+
+The final phrase-aware composite-process hardening for
+`growth factor-independent proliferation` was validated by focused tests and
+adversarial re-review. That phrase does not appear in the v4 fixture or the
+postreview2 live reports, so it does not change the postreview2 live-readiness
+metrics above.

--- a/scripts/validation/relation_feasibility/fixture_checks/validation.py
+++ b/scripts/validation/relation_feasibility/fixture_checks/validation.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from artana_evidence_api.document_extraction_support.entity_grounding.verified_dictionary import (
     review_only_record_for_label,
 )
+from artana_evidence_api.document_extraction_support.review_policy.trusted_promotion_safety_policy import (
+    classify_trusted_promotion_safety,
+)
 
 JSONObject = dict[str, object]
 _LONG_DOCUMENT_MIN_CHARACTERS = 600
@@ -284,6 +287,7 @@ def _relation_issues(
         and _string_field(raw_relation, "review_status") != "review_only"
     ):
         issues.extend(_trusted_relation_review_only_endpoint_issues(raw_relation, case_id))
+        issues.extend(_trusted_relation_promotion_safety_issues(raw_relation, case_id))
     return tuple(issues)
 
 
@@ -334,6 +338,36 @@ def _trusted_relation_review_only_endpoint_issues(
             ),
         )
     return tuple(issues)
+
+
+def _trusted_relation_promotion_safety_issues(
+    raw_relation: Mapping[str, object],
+    case_id: str | None,
+) -> tuple[FixtureValidationIssue, ...]:
+    subject = _string_field(raw_relation, "subject")
+    relation_type = _string_field(raw_relation, "relation_type")
+    object_label = _string_field(raw_relation, "object")
+    if subject is None or relation_type is None or object_label is None:
+        return ()
+    decision = classify_trusted_promotion_safety(
+        relation_type=relation_type,
+        subject_label=subject,
+        object_label=object_label,
+    )
+    if not decision.review_only:
+        return ()
+    return (
+        FixtureValidationIssue(
+            code="trusted_gold_violates_promotion_safety_policy",
+            message=(
+                "Trusted high/medium gold rows must not use relation shapes "
+                "that trusted-promotion policy keeps review-only: "
+                f"{subject} {relation_type} {object_label} "
+                f"({', '.join(decision.reason_codes)})"
+            ),
+            case_id=case_id,
+        ),
+    )
 
 
 def _topic_issues(

--- a/scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json
+++ b/scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v3.json
@@ -265,9 +265,10 @@
           "object": "MAPK signaling",
           "support_sentence": "BRAF V600E activates MAPK signaling in melanoma cells with constitutive kinase output.",
           "value_level": "high",
-          "rationale": "Specific variant-to-pathway activation relation.",
+          "review_status": "review_only",
+          "rationale": "Specific variant-to-pathway activation relation with a broad pathway endpoint that must remain review-only.",
           "subject_curie": "ClinVar:BRAF_V600E",
-          "object_curie": "GO:0000165",
+          "object_curie": null,
           "requires_entailment": true
         }
       ]
@@ -327,9 +328,10 @@
           "object": "MAPK signaling",
           "support_sentence": "KRAS G12D activates MAPK signaling and increases pancreatic cancer cell proliferation.",
           "value_level": "high",
-          "rationale": "Specific variant-to-pathway activation relation.",
+          "review_status": "review_only",
+          "rationale": "Specific variant-to-pathway activation relation with a broad pathway endpoint that must remain review-only.",
           "subject_curie": "ClinVar:KRAS_G12D",
-          "object_curie": "GO:0000165",
+          "object_curie": null,
           "requires_entailment": true
         }
       ]

--- a/scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v4.json
+++ b/scripts/validation/relation_feasibility/fixtures/biomedical_relation_goldset_v4.json
@@ -294,9 +294,10 @@
           "object": "MAPK signaling",
           "support_sentence": "BRAF V600E activates MAPK signaling in melanoma cells with constitutive kinase output.",
           "value_level": "high",
-          "rationale": "Specific variant-to-pathway activation relation.",
+          "review_status": "review_only",
+          "rationale": "Specific variant-to-pathway activation relation with a broad pathway endpoint that must remain review-only.",
           "subject_curie": "ClinVar:BRAF_V600E",
-          "object_curie": "GO:0000165",
+          "object_curie": null,
           "requires_entailment": true
         }
       ]
@@ -363,9 +364,10 @@
           "object": "MAPK signaling",
           "support_sentence": "KRAS G12D activates MAPK signaling and increases pancreatic cancer cell proliferation.",
           "value_level": "high",
-          "rationale": "Specific variant-to-pathway activation relation.",
+          "review_status": "review_only",
+          "rationale": "Specific variant-to-pathway activation relation with a broad pathway endpoint that must remain review-only.",
           "subject_curie": "ClinVar:KRAS_G12D",
-          "object_curie": "GO:0000165",
+          "object_curie": null,
           "requires_entailment": true
         }
       ]
@@ -840,7 +842,7 @@
     },
     {
       "case_id": "v4_bevacizumab_inhibits_vegfa",
-      "title": "Bevacizumab inhibits VEGF-A",
+      "title": "Bevacizumab inhibits VEGF-A signaling",
       "category": "strong_specific",
       "topics": [
         "pathway_regulation",
@@ -851,12 +853,13 @@
         {
           "subject": "Bevacizumab",
           "relation_type": "INHIBITS",
-          "object": "VEGF-A",
+          "object": "VEGF-A signaling",
           "support_sentence": "Bevacizumab inhibits VEGF-A signaling in angiogenesis-focused tumor models.",
           "value_level": "high",
-          "rationale": "Direct drug-to-target inhibition relation.",
+          "review_status": "review_only",
+          "rationale": "Drug-to-broad-pathway inhibition relation that must remain review-only rather than overclaiming direct target inhibition.",
           "subject_curie": "DrugBank:DB00112",
-          "object_curie": "HGNC:12680",
+          "object_curie": null,
           "requires_entailment": true
         }
       ]

--- a/services/artana_evidence_api/document_extraction_support/llm_fulltext_extraction.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_fulltext_extraction.py
@@ -31,6 +31,9 @@ from artana_evidence_api.document_extraction_support.entity_curie_linking import
     EntityCurieLink,
     normalize_entity_curie,
 )
+from artana_evidence_api.document_extraction_support.entity_grounding.verified_dictionary import (
+    verified_record_for_label,
+)
 from artana_evidence_api.document_extraction_support.evidence_grounding import (
     tumor_agnostic_fusion_surfaces,
 )
@@ -54,6 +57,19 @@ LLM_WEAK_REVIEW_EXTRACTION_PROMPT_VERSION = (
     "document_extraction.weak_review_extraction.v2"
 )
 _MIN_ENTITY_LABEL_LENGTH = 2
+_DIRECT_TARGET_ACTIVITY_RELATION_TYPES = frozenset(
+    {
+        "ACTIVATES",
+        "INHIBITS",
+        "MODULATES",
+        "REGULATES",
+        "TARGETS",
+    },
+)
+_DIRECT_TARGET_ACTIVITY_OBJECT_RE = re.compile(
+    r"^\s*(?P<target>[A-Za-z][A-Za-z0-9.-]{1,15})\s+activity\s*$",
+    re.IGNORECASE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -356,13 +372,44 @@ def _repair_relation_object_label(
     object_label: str,
     sentence: str,
 ) -> str:
-    if relation_type != "TREATS" or object_label == "":
+    if object_label == "":
         return object_label
-    repaired = _repair_tumor_agnostic_fusion_treatment_object(
+    if relation_type == "TREATS":
+        repaired = _repair_tumor_agnostic_fusion_treatment_object(
+            object_label=object_label,
+            sentence=sentence,
+        )
+        if repaired is not None:
+            return repaired
+    return _repair_direct_target_activity_object(
+        relation_type=relation_type,
         object_label=object_label,
         sentence=sentence,
-    )
-    return repaired or object_label
+    ) or object_label
+
+
+def _repair_direct_target_activity_object(
+    *,
+    relation_type: str,
+    object_label: str,
+    sentence: str,
+) -> str | None:
+    if relation_type not in _DIRECT_TARGET_ACTIVITY_RELATION_TYPES:
+        return None
+    match = _DIRECT_TARGET_ACTIVITY_OBJECT_RE.fullmatch(object_label)
+    if match is None:
+        return None
+    target_label = match.group("target")
+    record = verified_record_for_label(target_label)
+    if record is None:
+        return None
+    if not re.search(
+        rf"\b{re.escape(target_label)}\s+activity\b",
+        sentence,
+        flags=re.IGNORECASE,
+    ):
+        return None
+    return record.label
 
 
 def _repair_tumor_agnostic_fusion_treatment_object(

--- a/services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py
+++ b/services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py
@@ -24,6 +24,9 @@ from artana_evidence_api.document_extraction_support.relation_specificity_prunin
 from artana_evidence_api.document_extraction_support.review_policy.review_only_candidate_policy import (
     classify_review_only_candidate,
 )
+from artana_evidence_api.document_extraction_support.review_policy.trusted_promotion_safety_policy import (
+    classify_trusted_promotion_safety,
+)
 
 RelationCandidateQualityFilterReason = Literal[
     "binding_site_shadowed_by_molecular_target",
@@ -228,12 +231,12 @@ def filter_low_value_relation_candidates(
                 _with_review_only_reason(candidate, "cell_context_object"),
             )
             continue
-        review_only_candidate = _review_only_candidate(candidate)
-        if review_only_candidate is not None and reason in {
+        review_lane_candidate = _review_lane_candidate(candidate)
+        if review_lane_candidate is not None and reason in {
             None,
             "uncertain_relation_claim",
         }:
-            kept_candidates.append(review_only_candidate)
+            kept_candidates.append(review_lane_candidate)
             continue
         if reason is None:
             kept_candidates.append(candidate)
@@ -299,24 +302,34 @@ def _merge_duplicate_kept_candidates(
     return tuple(merged_by_key[key] for key in ordered_keys)
 
 
-def _review_only_candidate(
+def _review_lane_candidate(
     candidate: ExtractedRelationCandidate,
 ) -> ExtractedRelationCandidate | None:
-    if candidate.review_status == "review_only":
-        return candidate
+    review_only = candidate.review_status == "review_only"
+    review_reason_codes = list(candidate.review_reason_codes)
+
     decision = classify_review_only_candidate(
         relation_type=candidate.relation_type,
         support_sentence=candidate.sentence,
         subject_label=candidate.subject_label,
         object_label=candidate.object_label,
     )
-    if not decision.review_only:
-        return None
-    return replace(
-        candidate,
-        review_status="review_only",
-        review_reason_codes=decision.reason_codes,
+    if decision.review_only:
+        review_only = True
+        review_reason_codes.extend(decision.reason_codes)
+
+    safety_decision = classify_trusted_promotion_safety(
+        relation_type=candidate.relation_type,
+        subject_label=candidate.subject_label,
+        object_label=candidate.object_label,
     )
+    if safety_decision.review_only:
+        review_only = True
+        review_reason_codes.extend(safety_decision.reason_codes)
+
+    if not review_only:
+        return None
+    return _with_review_only_reasons(candidate, tuple(review_reason_codes))
 
 
 def _repair_weak_review_candidate(
@@ -820,11 +833,18 @@ def _with_review_only_reason(
     candidate: ExtractedRelationCandidate,
     reason_code: str,
 ) -> ExtractedRelationCandidate:
+    return _with_review_only_reasons(candidate, (reason_code,))
+
+
+def _with_review_only_reasons(
+    candidate: ExtractedRelationCandidate,
+    reason_codes: tuple[str, ...],
+) -> ExtractedRelationCandidate:
     return replace(
         candidate,
         review_status="review_only",
         review_reason_codes=tuple(
-            dict.fromkeys((*candidate.review_reason_codes, reason_code)),
+            dict.fromkeys((*candidate.review_reason_codes, *reason_codes)),
         ),
     )
 

--- a/services/artana_evidence_api/document_extraction_support/relation_specificity_pruning.py
+++ b/services/artana_evidence_api/document_extraction_support/relation_specificity_pruning.py
@@ -41,6 +41,7 @@ _ENTITY_MODIFIER_TERMS = (
     "silencing",
     "suppression",
     "truncating",
+    "mutated",
     "upregulation",
     "mutation",
     "variant",
@@ -422,7 +423,7 @@ def _has_post_modifier(*, label_pattern: str, sentence: str) -> bool:
     )
     return (
         re.search(
-            rf"\b{label_pattern}\s+(?:{modifier_pattern})\b",
+            rf"\b{label_pattern}(?:\s+|-)(?:{modifier_pattern})\b",
             sentence,
             flags=re.IGNORECASE,
         )

--- a/services/artana_evidence_api/document_extraction_support/review_policy/trusted_promotion_safety_policy.py
+++ b/services/artana_evidence_api/document_extraction_support/review_policy/trusted_promotion_safety_policy.py
@@ -1,0 +1,251 @@
+"""Review-only safety policy for trusted graph auto-promotion."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from artana_evidence_api.document_extraction_relation_taxonomy import (
+    canonicalize_extraction_relation_type,
+)
+from artana_evidence_api.document_extraction_support.entity_grounding.verified_dictionary import (
+    verified_record_for_label,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedPromotionSafetyDecision:
+    """Decision about whether a strong relation is safe to auto-promote."""
+
+    review_only: bool
+    reason_codes: tuple[str, ...]
+
+
+_BARE_GENE_RE = re.compile(r"^[A-Z][A-Z0-9-]{1,11}$")
+_VARIANT_TOKEN_RE = re.compile(r"^[A-Z][0-9]+[A-Z*]$")
+_GENE_STATE_TOKENS = frozenset(
+    {
+        "activation",
+        "amplification",
+        "deletion",
+        "deficiency",
+        "expression",
+        "loss",
+        "loss-of-function",
+        "mutation",
+        "mutations",
+        "pathogenic",
+        "phosphorylation",
+        "score",
+        "signaling",
+        "status",
+        "truncating",
+        "variant",
+        "variants",
+    },
+)
+_BROAD_PATHWAY_TOKENS = frozenset(
+    {
+        "cascade",
+        "pathway",
+        "pathways",
+        "signaling",
+    },
+)
+_DISEASE_OR_PHENOTYPE_TOKENS = frozenset(
+    {
+        "adenocarcinoma",
+        "cancer",
+        "carcinoma",
+        "delay",
+        "disease",
+        "hypercholesterolemia",
+        "leukemia",
+        "lymphoma",
+        "melanoma",
+        "neoplasm",
+        "neoplasms",
+        "phenotype",
+        "polyposis",
+        "syndrome",
+        "tumor",
+        "tumors",
+    },
+)
+_MOLECULAR_SUBTYPE_TOKENS = frozenset(
+    {
+        "amplification",
+        "deletion",
+        "exon",
+        "fusion",
+        "fusions",
+        "mutant",
+        "mutated",
+        "mutation",
+        "positive",
+    },
+)
+_TREATMENT_RESPONSE_TOKENS = frozenset(
+    {
+        "benefit",
+        "response",
+        "sensitivity",
+    },
+)
+_COMPOSITE_PROCESS_TOKENS = frozenset(
+    {
+        "growth",
+        "proliferation",
+    },
+)
+_COMPOSITE_PROCESS_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"\b(?:cell|cellular|tumor|tumour|cancer|neoplastic|organoid|clonal)\s+"
+        r"(?:growth|proliferation)\b",
+        r"\bgrowth\s+factor(?:\s|-)+independent\s+proliferation\b",
+        r"\b(?:growth|proliferation)\s+"
+        r"(?:advantage|phenotype|program|rate)\b",
+    )
+)
+_PROCESS_CONTEXT_SUBJECT_TOKENS = frozenset(
+    {
+        "development",
+        "phosphorylation",
+        "repair",
+        "response",
+        "signaling",
+    },
+)
+def classify_trusted_promotion_safety(
+    *,
+    relation_type: str,
+    subject_label: str,
+    object_label: str,
+) -> TrustedPromotionSafetyDecision:
+    """Classify strong extracted claims that still require review before trust."""
+
+    canonical_relation = canonicalize_extraction_relation_type(relation_type)
+    if canonical_relation is None:
+        canonical_relation = relation_type.strip().upper()
+
+    reason_codes: list[str] = []
+    if canonical_relation == "PREDISPOSES_TO":
+        reason_codes.extend(_predisposition_review_reasons(subject_label))
+    if canonical_relation in {"ASSOCIATED_WITH", "CAUSES"} and (
+        _is_disease_or_phenotype_label(object_label)
+    ):
+        reason_codes.extend(_gene_phenotype_review_reasons(subject_label))
+    if canonical_relation == "BIOMARKER_FOR" and _is_treatment_response_label(
+        object_label,
+    ):
+        reason_codes.append("composite_treatment_response_label")
+    if canonical_relation == "TREATS" and _is_unstructured_molecular_subtype_disease(
+        object_label,
+    ):
+        reason_codes.append("molecular_subtype_requires_structured_grounding")
+    if _is_composite_process_label(object_label):
+        reason_codes.append("composite_process_endpoint_requires_review")
+    if canonical_relation in {"ACTIVATES", "REGULATES"} and (
+        _is_process_context_label(subject_label)
+        and _is_disease_or_phenotype_label(object_label)
+    ):
+        reason_codes.append("process_context_relation_requires_review")
+    if canonical_relation in {"ACTIVATES", "INHIBITS", "REGULATES"} and (
+        _is_broad_pathway_label(object_label)
+    ):
+        reason_codes.append("broad_pathway_endpoint_requires_review")
+
+    deduped_reason_codes = tuple(dict.fromkeys(reason_codes))
+    return TrustedPromotionSafetyDecision(
+        review_only=bool(deduped_reason_codes),
+        reason_codes=deduped_reason_codes,
+    )
+
+
+def _predisposition_review_reasons(subject_label: str) -> tuple[str, ...]:
+    if _has_gene_state_label(subject_label):
+        return ("gene_state_subject_requires_structured_grounding",)
+    if _is_bare_gene_label(subject_label):
+        return ("gene_level_predisposition_requires_variant_state",)
+    return ()
+
+
+def _gene_phenotype_review_reasons(subject_label: str) -> tuple[str, ...]:
+    if _has_gene_state_label(subject_label):
+        return ("gene_state_subject_requires_structured_grounding",)
+    if _is_bare_gene_label(subject_label):
+        return ("gene_phenotype_association_requires_variant_state",)
+    return ()
+
+
+def _has_gene_state_label(label: str) -> bool:
+    tokens = set(_normalized_tokens(label))
+    return bool(tokens.intersection(_GENE_STATE_TOKENS))
+
+
+def _is_bare_gene_label(label: str) -> bool:
+    record = verified_record_for_label(label)
+    if record is not None:
+        return record.curie.upper().startswith("HGNC:")
+    tokens = label.strip().split()
+    return len(tokens) == 1 and _BARE_GENE_RE.fullmatch(tokens[0]) is not None
+
+
+def _is_broad_pathway_label(label: str) -> bool:
+    return bool(set(_normalized_tokens(label)).intersection(_BROAD_PATHWAY_TOKENS))
+
+
+def _is_treatment_response_label(label: str) -> bool:
+    return bool(set(_normalized_tokens(label)).intersection(_TREATMENT_RESPONSE_TOKENS))
+
+
+def _is_unstructured_molecular_subtype_disease(label: str) -> bool:
+    if verified_record_for_label(label) is not None:
+        return False
+    tokens = set(_normalized_tokens(label))
+    has_subtype_token = bool(tokens.intersection(_MOLECULAR_SUBTYPE_TOKENS)) or any(
+        _VARIANT_TOKEN_RE.fullmatch(token.upper()) is not None for token in tokens
+    )
+    return has_subtype_token and _is_disease_or_phenotype_label(label)
+
+
+def _is_composite_process_label(label: str) -> bool:
+    normalized_tokens = _normalized_tokens(label)
+    tokens = set(normalized_tokens)
+    if not tokens.intersection(_COMPOSITE_PROCESS_TOKENS):
+        return False
+    normalized_label = " ".join(normalized_tokens)
+    return any(
+        pattern.search(normalized_label) is not None
+        for pattern in _COMPOSITE_PROCESS_PATTERNS
+    )
+
+
+def _is_process_context_label(label: str) -> bool:
+    return bool(
+        set(_normalized_tokens(label)).intersection(_PROCESS_CONTEXT_SUBJECT_TOKENS),
+    )
+
+
+def _is_disease_or_phenotype_label(label: str) -> bool:
+    record = verified_record_for_label(label)
+    if record is not None:
+        prefix = record.curie.partition(":")[0].upper()
+        if prefix in {"HP", "MONDO", "NCIT"} and not _is_broad_pathway_label(label):
+            return True
+    return bool(set(_normalized_tokens(label)).intersection(_DISEASE_OR_PHENOTYPE_TOKENS))
+
+
+def _normalized_tokens(label: str) -> tuple[str, ...]:
+    return tuple(
+        token
+        for token in re.split(r"[^A-Za-z0-9*-]+", label.casefold())
+        if token != ""
+    )
+
+
+__all__ = [
+    "TrustedPromotionSafetyDecision",
+    "classify_trusted_promotion_safety",
+]

--- a/services/artana_evidence_api/tests/unit/test_document_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction.py
@@ -854,11 +854,12 @@ async def test_extract_relation_candidates_with_llm_uses_agent_review_only_pass(
     assert candidates[0].subject_label == "MED13"
     assert candidates[0].object_label == "congenital heart disease"
     assert candidates[0].review_status == "review_only"
-    assert candidates[0].review_reason_codes == (
+    assert set(candidates[0].review_reason_codes) >= {
         "hedged_language",
         "may_link",
         "weak_review_agent_pass",
-    )
+        "gene_phenotype_association_requires_variant_state",
+    }
     assert candidates[0].trusted_evidence_eligible is False
 
 

--- a/services/artana_evidence_api/tests/unit/test_document_extraction_modules.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction_modules.py
@@ -945,6 +945,33 @@ def test_llm_conversion_verifies_model_curie_hints_against_dictionary() -> None:
     assert candidates[0].object_curie_source == "verified_linker"
 
 
+def test_llm_conversion_repairs_direct_target_activity_object() -> None:
+    parsed = SimpleNamespace(
+        relations=[
+            SimpleNamespace(
+                subject="Ruxolitinib",
+                subject_curie="DRUGBANK:DB08877",
+                relation_type="INHIBITS",
+                proposed_relation_type=None,
+                new_relation_type_rationale=None,
+                object="JAK2 activity",
+                object_curie="NCIT:C114453",
+                sentence="Ruxolitinib inhibits JAK2 activity in cytokine-stimulated cells.",
+            ),
+        ],
+    )
+
+    candidates, unknown_relation_types = llm_relations_to_candidates(parsed)
+
+    assert unknown_relation_types == set()
+    assert len(candidates) == 1
+    assert candidates[0].object_label == "JAK2"
+    assert candidates[0].object_curie == "HGNC:6192"
+    assert candidates[0].object_curie_source == "verified_linker"
+    assert candidates[0].review_status == "candidate"
+    assert candidates[0].trusted_evidence_eligible is True
+
+
 @pytest.mark.parametrize(
     (
         "subject",

--- a/services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py
+++ b/services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py
@@ -11,7 +11,7 @@ from artana_evidence_api.document_extraction_support.relation_candidate_quality_
 )
 
 
-def test_quality_filter_keeps_entailed_specific_candidate() -> None:
+def test_quality_filter_keeps_entailed_specific_candidate_as_review_only() -> None:
     candidate = ExtractedRelationCandidate(
         subject_label="RET p.Arg1174*",
         relation_type="ACTIVATES",
@@ -21,7 +21,12 @@ def test_quality_filter_keeps_entailed_specific_candidate() -> None:
 
     result = filter_low_value_relation_candidates((candidate,))
 
-    assert result.candidates == (candidate,)
+    assert len(result.candidates) == 1
+    assert result.candidates[0].review_status == "review_only"
+    assert "broad_pathway_endpoint_requires_review" in (
+        result.candidates[0].review_reason_codes
+    )
+    assert result.candidates[0].trusted_evidence_eligible is False
     assert result.filtered_candidates == ()
 
 
@@ -55,6 +60,149 @@ def test_quality_filter_keeps_entailed_specific_candidate() -> None:
                 "adenomatous polyposis."
             ),
         ),
+    ],
+)
+def test_quality_filter_keeps_gene_state_predisposition_surfaces_for_review(
+    candidate: ExtractedRelationCandidate,
+) -> None:
+    result = filter_low_value_relation_candidates((candidate,))
+
+    assert len(result.candidates) == 1
+    assert result.candidates[0].review_status == "review_only"
+    assert result.candidates[0].trusted_evidence_eligible is False
+    assert result.filtered_candidates == ()
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected_reason_code"),
+    [
+        (
+            ExtractedRelationCandidate(
+                subject_label="BRCA1",
+                relation_type="PREDISPOSES_TO",
+                object_label="hereditary breast ovarian cancer syndrome",
+                sentence=(
+                    "BRCA1 predisposes to hereditary breast ovarian cancer "
+                    "syndrome in families with pathogenic variants."
+                ),
+            ),
+            "gene_level_predisposition_requires_variant_state",
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="MED13",
+                relation_type="ASSOCIATED_WITH",
+                object_label="developmental delay",
+                sentence="MED13 was associated with developmental delay.",
+            ),
+            "gene_phenotype_association_requires_variant_state",
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="MED13",
+                relation_type="CAUSES",
+                object_label="developmental delay",
+                sentence="MED13 causes developmental delay in affected families.",
+            ),
+            "gene_phenotype_association_requires_variant_state",
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="SOMEGENE pathogenic variants",
+                relation_type="ASSOCIATED_WITH",
+                object_label="developmental delay",
+                sentence=(
+                    "SOMEGENE pathogenic variants were associated with "
+                    "developmental delay."
+                ),
+            ),
+            "gene_state_subject_requires_structured_grounding",
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="Trametinib",
+                relation_type="INHIBITS",
+                object_label="MAPK signaling",
+                sentence=(
+                    "Trametinib inhibits MAPK signaling in melanoma cells "
+                    "with pathway activation."
+                ),
+            ),
+            "broad_pathway_endpoint_requires_review",
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="BRAF V600E",
+                relation_type="BIOMARKER_FOR",
+                object_label="response to vemurafenib",
+                sentence="BRAF V600E is a biomarker for response to vemurafenib.",
+            ),
+            "composite_treatment_response_label",
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="Vemurafenib",
+                relation_type="TREATS",
+                object_label="BRAF V600E melanoma",
+                sentence="Vemurafenib treats BRAF V600E melanoma.",
+            ),
+            "molecular_subtype_requires_structured_grounding",
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="KRAS G12D",
+                relation_type="ASSOCIATED_WITH",
+                object_label="pancreatic cancer cell proliferation",
+                sentence=(
+                    "KRAS G12D was associated with pancreatic cancer cell "
+                    "proliferation in engineered organoid models."
+                ),
+            ),
+            "composite_process_endpoint_requires_review",
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="AKT activation",
+                relation_type="ASSOCIATED_WITH",
+                object_label="growth factor-independent proliferation",
+                sentence=(
+                    "AKT activation was associated with "
+                    "growth factor-independent proliferation in tumor cells."
+                ),
+            ),
+            "composite_process_endpoint_requires_review",
+        ),
+        (
+            ExtractedRelationCandidate(
+                subject_label="Homologous recombination DNA repair",
+                relation_type="REGULATES",
+                object_label="BRCA-mutated ovarian cancer",
+                sentence=(
+                    "Homologous recombination DNA repair regulates "
+                    "BRCA-mutated ovarian cancer sensitivity patterns in "
+                    "repair-deficient tumors."
+                ),
+            ),
+            "process_context_relation_requires_review",
+        ),
+    ],
+)
+def test_quality_filter_marks_trusted_promotion_unsafe_shapes_review_only(
+    candidate: ExtractedRelationCandidate,
+    expected_reason_code: str,
+) -> None:
+    result = filter_low_value_relation_candidates((candidate,))
+
+    assert len(result.candidates) == 1
+    assert result.candidates[0].review_status == "review_only"
+    assert expected_reason_code in result.candidates[0].review_reason_codes
+    assert result.candidates[0].trusted_evidence_eligible is False
+    assert result.filtered_candidates == ()
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
         ExtractedRelationCandidate(
             subject_label="Larotrectinib",
             relation_type="TREATS",
@@ -64,15 +212,63 @@ def test_quality_filter_keeps_entailed_specific_candidate() -> None:
                 "fusions regardless of tissue origin."
             ),
         ),
+        ExtractedRelationCandidate(
+            subject_label="Olaparib",
+            relation_type="TREATS",
+            object_label="BRCA-mutated ovarian cancer",
+            sentence=(
+                "Olaparib treats BRCA-mutated ovarian cancer by exploiting "
+                "homologous recombination deficiency."
+            ),
+        ),
+        ExtractedRelationCandidate(
+            subject_label="EGFR T790M",
+            relation_type="CONFERS_RESISTANCE_TO",
+            object_label="erlotinib",
+            sentence="EGFR T790M confers resistance to erlotinib.",
+        ),
+        ExtractedRelationCandidate(
+            subject_label="Vemurafenib",
+            relation_type="TARGETS",
+            object_label="BRAF V600E",
+            sentence="Vemurafenib targets BRAF V600E.",
+        ),
+        ExtractedRelationCandidate(
+            subject_label="Cetuximab",
+            relation_type="TARGETS",
+            object_label="epidermal growth factor receptor",
+            sentence="Cetuximab targets epidermal growth factor receptor.",
+        ),
     ],
 )
-def test_quality_filter_keeps_specific_v3_relation_surfaces(
+def test_quality_filter_keeps_curated_trusted_promotion_shapes(
     candidate: ExtractedRelationCandidate,
 ) -> None:
     result = filter_low_value_relation_candidates((candidate,))
 
     assert result.candidates == (candidate,)
     assert result.filtered_candidates == ()
+
+
+def test_quality_filter_merges_weak_review_and_promotion_safety_reasons() -> None:
+    candidate = ExtractedRelationCandidate(
+        subject_label="Trametinib",
+        relation_type="REGULATES",
+        object_label="MAPK signaling",
+        sentence="Trametinib may regulate MAPK signaling in melanoma cells.",
+    )
+
+    result = filter_low_value_relation_candidates((candidate,))
+
+    assert len(result.candidates) == 1
+    kept_candidate = result.candidates[0]
+    assert kept_candidate.review_status == "review_only"
+    assert kept_candidate.trusted_evidence_eligible is False
+    assert set(kept_candidate.review_reason_codes) >= {
+        "hedged_language",
+        "may_regulate",
+        "broad_pathway_endpoint_requires_review",
+    }
 
 
 def test_quality_filter_removes_companion_phenotype_when_disease_sibling_exists() -> None:
@@ -99,7 +295,13 @@ def test_quality_filter_removes_companion_phenotype_when_disease_sibling_exists(
         (disease_candidate, phenotype_candidate),
     )
 
-    assert result.candidates == (disease_candidate,)
+    assert len(result.candidates) == 1
+    assert result.candidates[0].subject_label == disease_candidate.subject_label
+    assert result.candidates[0].object_label == disease_candidate.object_label
+    assert result.candidates[0].review_status == "review_only"
+    assert "gene_state_subject_requires_structured_grounding" in (
+        result.candidates[0].review_reason_codes
+    )
     assert result.filtered_candidates[0].candidate == phenotype_candidate
     assert result.filtered_candidates[0].reason == (
         "companion_phenotype_shadowed_by_disease"
@@ -172,7 +374,13 @@ def test_quality_filter_removes_biochemical_companion_when_disease_sibling_exist
         (disease_candidate, phenotype_candidate),
     )
 
-    assert result.candidates == (disease_candidate,)
+    assert len(result.candidates) == 1
+    assert result.candidates[0].subject_label == disease_candidate.subject_label
+    assert result.candidates[0].object_label == disease_candidate.object_label
+    assert result.candidates[0].review_status == "review_only"
+    assert "gene_state_subject_requires_structured_grounding" in (
+        result.candidates[0].review_reason_codes
+    )
     assert result.filtered_candidates[0].candidate == phenotype_candidate
     assert result.filtered_candidates[0].reason == (
         "companion_phenotype_shadowed_by_disease"
@@ -262,7 +470,7 @@ def test_quality_filter_does_not_repair_resistance_object_from_prefix_match() ->
     assert result.candidates[0].review_status == "review_only"
 
 
-def test_quality_filter_does_not_repair_trend_relation_from_unrelated_clause() -> None:
+def test_quality_filter_does_not_repair_unrelated_trend_but_reviews_response() -> None:
     candidate = ExtractedRelationCandidate(
         subject_label="EGFR expression",
         relation_type="BIOMARKER_FOR",
@@ -277,10 +485,13 @@ def test_quality_filter_does_not_repair_trend_relation_from_unrelated_clause() -
 
     assert len(result.candidates) == 1
     assert result.candidates[0].relation_type == "BIOMARKER_FOR"
-    assert result.candidates[0].review_status == "candidate"
+    assert result.candidates[0].review_status == "review_only"
+    assert "composite_treatment_response_label" in (
+        result.candidates[0].review_reason_codes
+    )
 
 
-def test_quality_filter_does_not_repair_trend_relation_from_bare_and_clause() -> None:
+def test_quality_filter_does_not_repair_bare_and_trend_but_reviews_response() -> None:
     candidate = ExtractedRelationCandidate(
         subject_label="EGFR expression",
         relation_type="BIOMARKER_FOR",
@@ -295,7 +506,10 @@ def test_quality_filter_does_not_repair_trend_relation_from_bare_and_clause() ->
 
     assert len(result.candidates) == 1
     assert result.candidates[0].relation_type == "BIOMARKER_FOR"
-    assert result.candidates[0].review_status == "candidate"
+    assert result.candidates[0].review_status == "review_only"
+    assert "composite_treatment_response_label" in (
+        result.candidates[0].review_reason_codes
+    )
 
 
 def test_quality_filter_does_not_repair_resistance_object_from_unrelated_clause() -> None:
@@ -418,7 +632,14 @@ def test_quality_filter_removes_nested_biomarker_context_object() -> None:
         (response_candidate, context_candidate),
     )
 
-    assert result.candidates == (response_candidate,)
+    assert len(result.candidates) == 1
+    assert result.candidates[0].subject_label == response_candidate.subject_label
+    assert result.candidates[0].relation_type == response_candidate.relation_type
+    assert result.candidates[0].object_label == response_candidate.object_label
+    assert result.candidates[0].review_status == "review_only"
+    assert "composite_treatment_response_label" in (
+        result.candidates[0].review_reason_codes
+    )
     assert result.filtered_candidates[0].candidate == context_candidate
     assert result.filtered_candidates[0].reason == "nested_context_object"
 
@@ -485,7 +706,14 @@ def test_quality_filter_keeps_pathway_effect_when_target_sibling_is_invalid() ->
         (invalid_target_candidate, pathway_candidate),
     )
 
-    assert result.candidates == (pathway_candidate,)
+    assert len(result.candidates) == 1
+    assert result.candidates[0].subject_label == pathway_candidate.subject_label
+    assert result.candidates[0].relation_type == pathway_candidate.relation_type
+    assert result.candidates[0].object_label == pathway_candidate.object_label
+    assert result.candidates[0].review_status == "review_only"
+    assert "broad_pathway_endpoint_requires_review" in (
+        result.candidates[0].review_reason_codes
+    )
     assert result.filtered_candidates[0].candidate == invalid_target_candidate
     assert result.filtered_candidates[0].reason == "missing_relation_arguments"
 
@@ -508,7 +736,15 @@ def test_quality_filter_keeps_pathway_effect_when_target_sibling_is_not_molecula
         (disease_target_candidate, pathway_candidate),
     )
 
-    assert pathway_candidate in result.candidates
+    pathway_result = next(
+        candidate
+        for candidate in result.candidates
+        if candidate.object_label == pathway_candidate.object_label
+    )
+    assert pathway_result.review_status == "review_only"
+    assert "broad_pathway_endpoint_requires_review" in (
+        pathway_result.review_reason_codes
+    )
     assert all(
         filtered.candidate != pathway_candidate
         for filtered in result.filtered_candidates
@@ -632,7 +868,14 @@ def test_quality_filter_removes_proliferation_effect_with_pathway_sibling() -> N
         (pathway_candidate, proliferation_candidate),
     )
 
-    assert result.candidates == (pathway_candidate,)
+    assert len(result.candidates) == 1
+    assert result.candidates[0].subject_label == pathway_candidate.subject_label
+    assert result.candidates[0].relation_type == pathway_candidate.relation_type
+    assert result.candidates[0].object_label == pathway_candidate.object_label
+    assert result.candidates[0].review_status == "review_only"
+    assert "broad_pathway_endpoint_requires_review" in (
+        result.candidates[0].review_reason_codes
+    )
     assert result.filtered_candidates[0].candidate == proliferation_candidate
     assert result.filtered_candidates[0].reason == (
         "process_effect_shadowed_by_pathway_mechanism"
@@ -663,7 +906,15 @@ def test_quality_filter_keeps_independent_process_effect_clause() -> None:
         (pathway_candidate, proliferation_candidate),
     )
 
-    assert proliferation_candidate in result.candidates
+    proliferation_result = next(
+        candidate
+        for candidate in result.candidates
+        if candidate.object_label == proliferation_candidate.object_label
+    )
+    assert proliferation_result.review_status == "review_only"
+    assert "composite_process_endpoint_requires_review" in (
+        proliferation_result.review_reason_codes
+    )
     assert all(
         filtered.candidate != proliferation_candidate
         for filtered in result.filtered_candidates
@@ -713,7 +964,14 @@ def test_quality_filter_removes_cell_context_activation_when_primary_relation_ex
         (primary_candidate, context_candidate),
     )
 
-    assert result.candidates == (primary_candidate,)
+    assert len(result.candidates) == 1
+    assert result.candidates[0].subject_label == primary_candidate.subject_label
+    assert result.candidates[0].relation_type == primary_candidate.relation_type
+    assert result.candidates[0].object_label == primary_candidate.object_label
+    assert result.candidates[0].review_status == "review_only"
+    assert "broad_pathway_endpoint_requires_review" in (
+        result.candidates[0].review_reason_codes
+    )
     assert result.filtered_candidates[0].candidate == context_candidate
     assert result.filtered_candidates[0].reason == "cell_context_object"
 
@@ -793,6 +1051,23 @@ def test_quality_filter_removes_candidate_that_drops_common_biomedical_modifier(
     assert {
         filtered.reason for filtered in result.filtered_candidates
     } == {"dropped_subject_modifier"}
+
+
+def test_quality_filter_removes_candidate_that_drops_hyphenated_object_modifier() -> None:
+    candidate = ExtractedRelationCandidate(
+        subject_label="Homologous recombination DNA repair",
+        relation_type="REGULATES",
+        object_label="BRCA",
+        sentence=(
+            "Homologous recombination DNA repair regulates BRCA-mutated "
+            "ovarian cancer sensitivity patterns in repair-deficient tumors."
+        ),
+    )
+
+    result = filter_low_value_relation_candidates((candidate,))
+
+    assert result.candidates == ()
+    assert result.filtered_candidates[0].reason == "dropped_object_modifier"
 
 
 def test_quality_filter_keeps_candidate_that_preserves_subject_modifier() -> None:
@@ -908,10 +1183,11 @@ def test_quality_filter_keeps_uncertain_candidate_as_review_only() -> None:
 
     assert result.filtered_candidates == ()
     assert result.candidates[0].review_status == "review_only"
-    assert result.candidates[0].review_reason_codes == (
+    assert set(result.candidates[0].review_reason_codes) >= {
         "hedged_language",
         "possible_biomarker",
-    )
+        "composite_treatment_response_label",
+    }
     assert result.candidates[0].trusted_evidence_eligible is False
 
 
@@ -955,7 +1231,7 @@ def test_quality_filter_keeps_weak_review_candidates_as_review_only(
 
     assert result.filtered_candidates == ()
     assert result.candidates[0].review_status == "review_only"
-    assert result.candidates[0].review_reason_codes == expected_reason_codes
+    assert set(result.candidates[0].review_reason_codes) >= set(expected_reason_codes)
     assert result.candidates[0].trusted_evidence_eligible is False
 
 
@@ -973,7 +1249,10 @@ def test_quality_filter_keeps_model_review_hint_candidate_as_review_only() -> No
 
     assert result.filtered_candidates == ()
     assert result.candidates[0].review_status == "review_only"
-    assert result.candidates[0].review_reason_codes == ("agent_review_hint",)
+    assert set(result.candidates[0].review_reason_codes) >= {
+        "agent_review_hint",
+        "gene_phenotype_association_requires_variant_state",
+    }
     assert result.candidates[0].trusted_evidence_eligible is False
 
 

--- a/tests/unit/test_relation_feasibility_fixture_validation.py
+++ b/tests/unit/test_relation_feasibility_fixture_validation.py
@@ -180,6 +180,7 @@ def test_fixture_validation_reports_structural_errors() -> None:
         "low_value_case_missing_value_level",
         "trusted_high_value_missing_curie",
         "trusted_gold_uses_review_only_endpoint",
+        "trusted_gold_violates_promotion_safety_policy",
         "invalid_review_status",
         "review_only_endpoint_has_curie",
     }
@@ -421,3 +422,15 @@ def test_v4_new_gold_does_not_add_broad_trusted_context_rows() -> None:
                 offenders.append(case_id)
 
     assert offenders == []
+
+
+def test_v4_fixture_gold_rows_align_with_trusted_promotion_safety_policy() -> None:
+    issues = validate_fixture_payload(
+        json.loads(V4_FIXTURE.read_text(encoding="utf-8")),
+    )
+
+    assert {
+        issue.case_id
+        for issue in issues
+        if issue.code == "trusted_gold_violates_promotion_safety_policy"
+    } == set()


### PR DESCRIPTION
## Summary

- adds a trusted-promotion safety policy for strong-but-unsafe relation shapes and applies it to relation filtering plus fixture validation
- repairs direct target activity tails such as `Ruxolitinib INHIBITS JAK2 activity` to verified target endpoints instead of trusting model-only process CURIEs
- updates v3/v4 gold rows and the validation tracker with post-adversarial v4 live-agent readiness evidence

## Validation

- `uv run pytest services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py services/artana_evidence_api/tests/unit/test_document_extraction_modules.py services/artana_evidence_api/tests/unit/test_document_extraction.py tests/unit/test_relation_feasibility_audit.py tests/unit/test_relation_feasibility_fixture_validation.py -q`
- `uv run ruff check services/artana_evidence_api/document_extraction_support/review_policy/trusted_promotion_safety_policy.py services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py services/artana_evidence_api/document_extraction_support/relation_specificity_pruning.py services/artana_evidence_api/document_extraction_support/llm_fulltext_extraction.py services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py services/artana_evidence_api/tests/unit/test_document_extraction.py services/artana_evidence_api/tests/unit/test_document_extraction_modules.py scripts/validation/relation_feasibility/fixture_checks/validation.py tests/unit/test_relation_feasibility_fixture_validation.py`
- `make relation-feasibility-quality-gate`
- strict v4 live-agent postreview2 runs 1-3: GREEN
- `uv run python scripts/run_relation_feasibility_readiness_gate.py --report reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run1 --report reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run2 --report reports/relation_feasibility/2026-07-07-pr36-v4-live-readiness-postreview2-run3 --min-runs 3 --output-dir reports/relation_feasibility_readiness/2026-07-07-pr36-v4-live-readiness-postreview2 --fail-on-not-ready`
- final adversarial re-review: PASS
- `make service-checks` passed with coverage `87.03%`

## Readiness

The measured v4 strict live-agent trusted lane is READY: worst trusted precision `1.0000`, trusted valuable rate `1.0000`, trusted generic rate `0.0000`, trusted-eligible high-value recall `1.0000`, trusted-eligible endpoint rate `1.0000`, fallback `0`, invalid agent `0`, negative leakage `0`, review-only trusted leakage `0`, weak trusted leakage `0`, and wrong verified CURIE links `0`.

Remaining all-candidate generic noise and review-only CURIE gaps are tracked as review-lane follow-up work, not PR36 trusted auto-promotion blockers.