### PR TITLE
PR38: Add review-ranking calibration telemetry

### DIFF
--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -107,7 +107,7 @@ Evidence:
 | Kept raw relation types | Possible on resolver failure | 0 | 0/30 candidates and 0/30 inventory surfaces | 2026-07-03 PR8 live-agent remediation report | Passing |
 | CURIE-linked gold entities | 0% in extraction path | >= 0.95 | 0.0000 verified CURIE match rate; 0.5690 candidate CURIE present rate; 13 wrong model CURIE hints | 2026-07-03 PR8 live-agent remediation report | Strict gate RED |
 | Auto-created junk nodes | Possible unresolved fallthrough | 0 | Entity-candidate creation requires linked CURIE payloads in PR-6; graph junk-node count not separately audited | PR-6 tests | Ready for review; add graph-count audit later |
-| Score calibration ECE | Uncalibrated | < 0.05 | Trusted candidate support-calibration ECE 0.0000 worst/mean; all-candidate support-calibration ECE 0.0732 worst, 0.0671 mean | PR-37 v4 calibration readiness gate | Trusted lane gated; production review-ranking calibration remains follow-up |
+| Score calibration ECE | Uncalibrated | < 0.05 | Trusted candidate support-calibration ECE 0.0000 worst/mean; all-candidate support-calibration ECE 0.0732 worst, 0.0671 mean; production review-ranking ECE is now measured from decided workspace review outcomes | PR-37 v4 calibration readiness gate; PR-38 workspace review-ranking calibration | Trusted lane gated; production thresholding needs expert/shadow review set |
 | Trusted-tier precision | Not gold-gated | 1.00 | 1.00 on focused hard-floor adversarial suite; live gold run completes but remains RED because verified CURIE match is 0.0000 | PR-8 plus live-agent remediation report | Ready for review |
 | Reproducible extraction | text clipped, temp unset | deterministic and cache-safe | Full-text chunking plus prompt-version/model-aware replay keys | PR-9 blind-spot and key-collision tests | Ready for review |
 | CI quality gate | Not present | blocking | `relation-feasibility-quality-gate` runs in `service-checks` and CI repo-control jobs | PR-10 planner/control tests and final `make service-checks` | Ready for review |
@@ -156,6 +156,7 @@ Status values:
 | 24 | PR-35 | `alvaro/evidence-pr35-benchmark-v4-100-case-proof` | Implemented locally; final local gates pass; adversarial re-review PASS | Make the Definition-of-Green benchmark scale requirement executable with a 100-case v4 fixture. | CI fails if the trusted-readiness benchmark fixture is below 100 cases, lacks balanced high-value/true-low-value/negative/long-document/near-miss coverage, pads scale with duplicate relation signatures, or adds new broad v4 pathway/gene rows as trusted gold. | Added `biomedical_relation_goldset_v4.json` by preserving the 40-case v3 seed and adding 60 labeled synthetic cases: 50 strong-specific, 25 weak review-only, and 25 negative-control cases overall. Added v4 validation coverage requiring at least 100 cases, 50 high-value specific cases, 25 true low-value review cases, 25 negative controls, at least five long-document cases, at least five adversarial negated near-misses, at least 74 unique gold relation signatures, and at most one repeated signature for the inherited v3 IL6 strong/weak contrast. RED test failed on the missing v4 fixture; adversarial review then found the low-value count mixed high-value review-only rows and that some v4 rows duplicated v3 or used broad trusted endpoints, so PR35 added `true_low_value_review_case_count`, signature-diversity counters, and a v4 trusted-context guard. GREEN focused fixture validation passes (`7 passed`) with validator issue count 0, touched-file Ruff passes, `make relation-feasibility-quality-gate` passes, `make service-checks` passes with coverage `87.03%`, and final adversarial re-review reports PASS. Summary: `docs/validation/reports/2026-07-06-pr35-benchmark-v4-100-case-proof-summary.md`. |
 | 25 | PR-36 | `alvaro/evidence-pr36-v4-live-readiness` | Implemented locally; final gates pass; post-adversarial three-run v4 readiness READY | Run strict live-agent readiness against the 100-case v4 fixture and close trusted-lane blockers without relying on deterministic fallback. | Three strict v4 live-agent runs pass the repeated-run readiness gate with trusted precision, trusted valuable rate, trusted generic rate, trusted-eligible high-value recall, and trusted endpoint recovery all at target while hard failures stay 0. | Added a trusted-promotion safety policy for strong-but-unsafe relation shapes, wired it into relation quality filtering, fixed hyphenated modifier-loss pruning, aligned v3/v4 gold rows with promotion policy, and added fixture validation so trusted gold cannot violate the same safety policy. Adversarial review then exposed `CAUSES`/gene-state association leaks, `growth` over-demotion, reason-code loss, a live `JAK2 activity` endpoint repair gap, and a `growth factor-independent proliferation` phrase gap; PR36 added RED/GREEN regressions and fixes for all. Strict v4 postreview2 runs1-3 aggregate to READY: worst trusted precision 1.0000, trusted valuable rate 1.0000, trusted generic rate 0.0000, trusted-eligible high-value recall 1.0000, trusted-eligible endpoint rate 1.0000, fallback 0, invalid agent 0, negative leakage 0, review-only trusted leakage 0, weak trusted leakage 0, and wrong verified CURIE links 0. Focused tests pass, touched-file Ruff passes, `make relation-feasibility-quality-gate` passes, final adversarial re-review is PASS, and `make service-checks` passes with coverage `87.03%`. Summary: `docs/validation/reports/2026-07-06-pr36-v4-live-readiness-summary.md`. |
 | 26 | PR-37 | `alvaro/evidence-pr37-calibration-gate` | Implemented locally; post-adversarial three-run v4 readiness READY with calibration gate | Make audit support calibration measurable and blocking for trusted graph readiness. | Trusted candidate score ECE must be <= 0.0500 and required in every readiness source report. | Added support-calibration metrics, Markdown/JSON report fields, CLI output, readiness-gate thresholding, calibration sample counts, model-comparison calibration deltas, and direct missing/invalid calibration tests. RED tests proved the audit summary lacked calibration and the readiness gate ignored high trusted ECE. Adversarial review then found the first metric was self-fulfilling because it used `is_valuable`; PR37 fixed the metric to score only pre-gold verification signals against gold support and reran strict v4 live postreview runs1-3. The corrected aggregate is READY with trusted candidate score ECE 0.0000 worst/mean, all-candidate score ECE 0.0732 worst and 0.0671 mean, trusted precision 1.0000, trusted valuable rate 1.0000, trusted generic rate 0.0000, trusted endpoint rate 1.0000, and all hard failures 0. Production review-ranking calibration remains separate follow-up. Summary: `docs/validation/reports/2026-07-07-pr37-calibration-gate-summary.md`. |
+| 27 | PR-38 | `alvaro/evidence-pr38-review-ranking-calibration` | Implemented locally; focused tests pass; adversarial fixes applied | Make production review-ranking calibration measurable from real human review outcomes. | Evidence-selection workspace snapshots expose review-ranking sample count, mean score, observed positive rate, and ECE from decided proposals and review items. | Added review-ranking calibration observations and summaries to `services/artana_evidence_api/ranking.py`, wired evidence-selection workspace snapshots to derive positive outcomes from promoted proposals/resolved review items and negative outcomes from rejected proposals/dismissed review items, and ignored pending items. RED tests proved the calibration API was missing; adversarial review then found calibration used capped display lists and lacked resolved-positive coverage, so PR38 now queries decided outcomes separately and tests a promoted proposal outside the display cap. GREEN focused tests pass (`8 passed`) and touched-file Ruff passes. Expert/shadow-mode thresholding remains follow-up. Summary: `docs/validation/reports/2026-07-07-pr38-review-ranking-calibration-summary.md`. |
 
 ## PR Evidence Packet
 
@@ -216,6 +217,45 @@ Run only the service checks relevant to the changed boundary, then run the
 aggregate gate before merge when the PR is ready.
 
 ## Evidence Log
+
+### 2026-07-07 - PR-38 Review-Ranking Calibration
+
+PR: PR-38 review-ranking calibration
+
+Branch: `alvaro/evidence-pr38-review-ranking-calibration`
+
+Goal: Make production review-ranking calibration observable from actual human
+review decisions.
+
+Evidence:
+
+- `docs/validation/reports/2026-07-07-pr38-review-ranking-calibration-summary.md`
+- `services/artana_evidence_api/ranking.py`
+- `services/artana_evidence_api/evidence_selection_workspace_snapshot.py`
+- `services/artana_evidence_api/tests/unit/test_ranking.py`
+- `services/artana_evidence_api/tests/unit/test_evidence_selection_artifact_modules.py`
+
+Result:
+
+- Review-ranking calibration summary includes sample count, mean score,
+  observed positive rate, and expected calibration error.
+- Evidence-selection workspace snapshots now include
+  `review_ranking_calibration`.
+- Positive outcomes are promoted proposals and resolved review items.
+- Negative outcomes are rejected proposals and dismissed review items.
+- Pending items do not affect calibration.
+
+Validation:
+
+- RED focused tests failed on missing calibration API.
+- GREEN focused tests passed: `2 passed`.
+- Expanded focused tests passed after adversarial fixes: `8 passed`.
+- Touched-file Ruff passed.
+
+Known remaining risk:
+
+- Production ranking thresholding still needs a larger expert or shadow-mode
+  review set before setting a hard ECE gate.
 
 ### 2026-07-07 - PR-37 Calibration Gate
 

--- a/docs/validation/reports/2026-07-07-pr38-review-ranking-calibration-summary.md
+++ b/docs/validation/reports/2026-07-07-pr38-review-ranking-calibration-summary.md
@@ -1,0 +1,101 @@
+# PR38 Review-Ranking Calibration Summary
+
+## Run Context
+
+- Branch: `alvaro/evidence-pr38-review-ranking-calibration`
+- Base branch: `alvaro/evidence-pr37-calibration-gate`
+- Scope: Evidence API review-ranking telemetry
+
+## Goal
+
+Make production review-ranking calibration measurable from actual human review
+decisions instead of leaving it as a prose-only follow-up from PR37.
+
+## Root Cause
+
+PR37 made strict relation-feasibility support calibration measurable for the
+trusted auto-promotion lane, but the production review queue still lacked a way
+to compare `ranking_score` against real reviewer outcomes. That meant future
+evidence-selection runs could see prior review decisions without knowing whether
+the ranking score had historically over- or under-predicted useful work.
+
+## Code Changes
+
+- Added `ReviewRankingCalibrationObservation` and
+  `ReviewRankingCalibrationSummary` to `services/artana_evidence_api/ranking.py`.
+- Added `build_review_ranking_calibration_summary(...)` to compute mean score,
+  observed positive rate, and expected calibration error over decided review
+  outcomes.
+- Added review-ranking calibration telemetry to evidence-selection workspace
+  snapshots.
+- Mapped promoted proposals and resolved review items to positive outcomes.
+- Mapped rejected proposals and dismissed review items to negative outcomes.
+- Ignored pending proposals and review items so calibration only reflects real
+  decisions.
+- Computed calibration from status-filtered decided-outcome queries instead of
+  the capped display lists used for snapshot previews.
+
+## Validation
+
+RED tests observed:
+
+```bash
+uv run pytest \
+  services/artana_evidence_api/tests/unit/test_ranking.py::test_review_ranking_calibration_summary_uses_decided_review_outcomes \
+  services/artana_evidence_api/tests/unit/test_evidence_selection_artifact_modules.py::test_workspace_snapshot_captures_prior_state_and_dedup_keys \
+  -q
+```
+
+Initial result: import failure for the missing calibration observation type,
+proving the behavior was absent.
+
+GREEN focused checks:
+
+```bash
+uv run pytest \
+  services/artana_evidence_api/tests/unit/test_ranking.py::test_review_ranking_calibration_summary_uses_decided_review_outcomes \
+  services/artana_evidence_api/tests/unit/test_evidence_selection_artifact_modules.py::test_workspace_snapshot_captures_prior_state_and_dedup_keys \
+  -q
+```
+
+Result: `2 passed`.
+
+Expanded focused checks:
+
+```bash
+uv run pytest \
+  services/artana_evidence_api/tests/unit/test_ranking.py \
+  services/artana_evidence_api/tests/unit/test_evidence_selection_artifact_modules.py \
+  -q
+```
+
+Result: `8 passed`.
+
+Touched-file Ruff:
+
+```bash
+uv run ruff check \
+  services/artana_evidence_api/ranking.py \
+  services/artana_evidence_api/evidence_selection_workspace_snapshot.py \
+  services/artana_evidence_api/tests/unit/test_ranking.py \
+  services/artana_evidence_api/tests/unit/test_evidence_selection_artifact_modules.py
+```
+
+Result: `All checks passed!`
+
+Adversarial review:
+
+- Initial review returned BLOCK because calibration was computed after the
+  workspace snapshot's display cap and the test suite did not prove resolved
+  review items counted as positive outcomes.
+- Fixed by querying decided proposals/review items separately from capped
+  display lists and by adding regression coverage for resolved review items plus
+  a promoted proposal outside the display cap.
+
+## Interpretation
+
+Production review-ranking calibration is now observable whenever prior human
+review decisions exist in the workspace. This does not yet set a merge-blocking
+production ECE threshold, because that threshold should come from a larger
+expert or shadow-mode review set. The important change is that the system now
+captures the measurement needed to tune and govern that threshold.

--- a/services/artana_evidence_api/evidence_selection_workspace_snapshot.py
+++ b/services/artana_evidence_api/evidence_selection_workspace_snapshot.py
@@ -17,6 +17,10 @@ from artana_evidence_api.proposal_store import (
     HarnessProposalRecord,
     HarnessProposalStore,
 )
+from artana_evidence_api.ranking import (
+    ReviewRankingCalibrationObservation,
+    build_review_ranking_calibration_summary,
+)
 from artana_evidence_api.review_item_store import (
     HarnessReviewItemRecord,
     HarnessReviewItemStore,
@@ -26,6 +30,11 @@ from artana_evidence_api.source_document_selection_identity import (
     source_document_dedup_key,
 )
 from artana_evidence_api.types.common import JSONObject, json_object_or_empty
+
+_REVIEW_RANKING_CALIBRATION_BASIS = (
+    "Promoted proposals and resolved review items are positive outcomes; "
+    "rejected proposals and dismissed review items are negative outcomes."
+)
 
 
 def build_evidence_selection_workspace_snapshot(
@@ -50,8 +59,20 @@ def build_evidence_selection_workspace_snapshot(
     ][:20]
     prior_documents = document_store.list_documents(space_id=space_id)[:50]
     prior_proposals = proposal_store.list_proposals(space_id=space_id)[:50]
+    decided_calibration_proposals = [
+        *proposal_store.list_proposals(space_id=space_id, status="promoted"),
+        *proposal_store.list_proposals(space_id=space_id, status="rejected"),
+    ]
     prior_review_items = (
         review_item_store.list_review_items(space_id=space_id)[:50]
+        if review_item_store is not None
+        else []
+    )
+    decided_calibration_review_items = (
+        [
+            *review_item_store.list_review_items(space_id=space_id, status="resolved"),
+            *review_item_store.list_review_items(space_id=space_id, status="dismissed"),
+        ]
         if review_item_store is not None
         else []
     )
@@ -105,6 +126,10 @@ def build_evidence_selection_workspace_snapshot(
         "graph_state_summary": _graph_state_summary(
             proposals=prior_proposals,
             approvals=prior_approvals,
+        ),
+        "review_ranking_calibration": _review_ranking_calibration_snapshot(
+            proposals=decided_calibration_proposals,
+            review_items=decided_calibration_review_items,
         ),
         "deduplication": {
             "source_document_keys": sorted(
@@ -229,6 +254,66 @@ def _graph_state_summary(
             "still read through the graph service."
         ),
     }
+
+
+def _review_ranking_calibration_snapshot(
+    *,
+    proposals: list[HarnessProposalRecord],
+    review_items: list[HarnessReviewItemRecord],
+) -> JSONObject:
+    observations = (
+        *_proposal_ranking_calibration_observations(proposals),
+        *_review_item_ranking_calibration_observations(review_items),
+    )
+    summary = build_review_ranking_calibration_summary(observations)
+    return {
+        **summary.to_json(),
+        "basis": _REVIEW_RANKING_CALIBRATION_BASIS,
+    }
+
+
+def _proposal_ranking_calibration_observations(
+    proposals: list[HarnessProposalRecord],
+) -> tuple[ReviewRankingCalibrationObservation, ...]:
+    observations: list[ReviewRankingCalibrationObservation] = []
+    for proposal in proposals:
+        if proposal.status == "promoted":
+            observations.append(
+                ReviewRankingCalibrationObservation(
+                    ranking_score=proposal.ranking_score,
+                    outcome_positive=True,
+                ),
+            )
+        if proposal.status == "rejected":
+            observations.append(
+                ReviewRankingCalibrationObservation(
+                    ranking_score=proposal.ranking_score,
+                    outcome_positive=False,
+                ),
+            )
+    return tuple(observations)
+
+
+def _review_item_ranking_calibration_observations(
+    review_items: list[HarnessReviewItemRecord],
+) -> tuple[ReviewRankingCalibrationObservation, ...]:
+    observations: list[ReviewRankingCalibrationObservation] = []
+    for review_item in review_items:
+        if review_item.status == "resolved":
+            observations.append(
+                ReviewRankingCalibrationObservation(
+                    ranking_score=review_item.ranking_score,
+                    outcome_positive=True,
+                ),
+            )
+        if review_item.status == "dismissed":
+            observations.append(
+                ReviewRankingCalibrationObservation(
+                    ranking_score=review_item.ranking_score,
+                    outcome_positive=False,
+                ),
+            )
+    return tuple(observations)
 
 
 __all__ = ["build_evidence_selection_workspace_snapshot"]

--- a/services/artana_evidence_api/ranking.py
+++ b/services/artana_evidence_api/ranking.py
@@ -15,6 +15,69 @@ class ProposalRanking:
     metadata: JSONObject
 
 
+@dataclass(frozen=True, slots=True)
+class ReviewRankingCalibrationObservation:
+    """One decided review-ranking observation for calibration accounting."""
+
+    ranking_score: float
+    outcome_positive: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewRankingCalibrationSummary:
+    """Expected calibration error summary for human-review ranking scores."""
+
+    sample_count: int
+    mean_score: float
+    observed_positive_rate: float
+    expected_calibration_error: float
+
+    def to_json(self) -> JSONObject:
+        """Return a stable JSON payload for artifacts and snapshots."""
+        return {
+            "sample_count": self.sample_count,
+            "mean_score": self.mean_score,
+            "observed_positive_rate": self.observed_positive_rate,
+            "expected_calibration_error": self.expected_calibration_error,
+        }
+
+
+def build_review_ranking_calibration_summary(
+    observations: tuple[ReviewRankingCalibrationObservation, ...],
+    *,
+    bin_count: int = 10,
+) -> ReviewRankingCalibrationSummary:
+    """Measure review-ranking calibration against human decision outcomes."""
+    scored_observations = tuple(
+        (
+            _bounded_score(observation.ranking_score),
+            1.0 if observation.outcome_positive else 0.0,
+        )
+        for observation in observations
+    )
+    sample_count = len(scored_observations)
+    if sample_count == 0:
+        return ReviewRankingCalibrationSummary(
+            sample_count=0,
+            mean_score=0.0,
+            observed_positive_rate=0.0,
+            expected_calibration_error=0.0,
+        )
+    return ReviewRankingCalibrationSummary(
+        sample_count=sample_count,
+        mean_score=_round_score(
+            sum(score for score, _outcome in scored_observations) / sample_count,
+        ),
+        observed_positive_rate=_round_score(
+            sum(outcome for _score, outcome in scored_observations) / sample_count,
+        ),
+        expected_calibration_error=_expected_calibration_error(
+            scored_observations=scored_observations,
+            bin_count=bin_count,
+        ),
+    )
+
+
 def rank_candidate_claim(
     *,
     confidence: float,
@@ -22,7 +85,7 @@ def rank_candidate_claim(
     evidence_reference_count: int,
 ) -> ProposalRanking:
     """Compute a bounded ranking score for one candidate claim."""
-    confidence_component = max(0.0, min(confidence, 1.0))
+    confidence_component = _bounded_score(confidence)
     document_component = min(max(supporting_document_count, 0), 5) / 5
     evidence_component = min(max(evidence_reference_count, 0), 5) / 5
     score = round(
@@ -59,9 +122,9 @@ def rank_reviewed_candidate_claim(
     relation_specific: bool | None = None,
 ) -> ProposalRanking:
     """Compute a ranking score for one reviewed document-extraction claim."""
-    factual_component = max(0.0, min(factual_confidence, 1.0))
-    relevance_component = max(0.0, min(goal_relevance, 1.0))
-    priority_component = max(0.0, min(priority, 1.0))
+    factual_component = _bounded_score(factual_confidence)
+    relevance_component = _bounded_score(goal_relevance)
+    priority_component = _bounded_score(priority)
     document_component = min(max(supporting_document_count, 0), 5) / 5
     evidence_component = min(max(evidence_reference_count, 0), 5) / 5
     grounded_component = _optional_binary_component(grounded_sentence)
@@ -112,6 +175,45 @@ def _optional_binary_component(value: bool | None) -> float:
     return 1.0 if value else 0.0
 
 
+def _bounded_score(value: float) -> float:
+    return max(0.0, min(value, 1.0))
+
+
+def _round_score(value: float) -> float:
+    return round(value, 6)
+
+
+def _expected_calibration_error(
+    *,
+    scored_observations: tuple[tuple[float, float], ...],
+    bin_count: int,
+) -> float:
+    if bin_count < 1:
+        msg = "bin_count must be at least 1"
+        raise ValueError(msg)
+    total_count = len(scored_observations)
+    error = 0.0
+    for bin_index in range(bin_count):
+        bin_items = tuple(
+            item
+            for item in scored_observations
+            if _calibration_bin_index(score=item[0], bin_count=bin_count) == bin_index
+        )
+        if not bin_items:
+            continue
+        bin_confidence = sum(score for score, _outcome in bin_items) / len(bin_items)
+        bin_accuracy = sum(outcome for _score, outcome in bin_items) / len(bin_items)
+        error += (len(bin_items) / total_count) * abs(bin_confidence - bin_accuracy)
+    return _round_score(error)
+
+
+def _calibration_bin_index(*, score: float, bin_count: int) -> int:
+    bounded_score = _bounded_score(score)
+    if bounded_score == 1.0:
+        return bin_count - 1
+    return int(bounded_score * bin_count)
+
+
 def rank_chat_graph_write_candidate(
     *,
     evidence_relevance: float,
@@ -121,11 +223,11 @@ def rank_chat_graph_write_candidate(
     relation_prior_score: float,
 ) -> ProposalRanking:
     """Compute a bounded ranking score for one chat-derived graph-write candidate."""
-    evidence_component = max(0.0, min(evidence_relevance, 1.0))
-    suggestion_component = max(0.0, min(suggestion_final_score, 1.0))
-    vector_component = max(0.0, min(vector_score, 1.0))
-    overlap_component = max(0.0, min(graph_overlap_score, 1.0))
-    prior_component = max(0.0, min(relation_prior_score, 1.0))
+    evidence_component = _bounded_score(evidence_relevance)
+    suggestion_component = _bounded_score(suggestion_final_score)
+    vector_component = _bounded_score(vector_score)
+    overlap_component = _bounded_score(graph_overlap_score)
+    prior_component = _bounded_score(relation_prior_score)
     score = round(
         min(
             1.0,
@@ -158,7 +260,7 @@ def rank_mechanism_candidate(
     average_path_length: float,
 ) -> ProposalRanking:
     """Compute a bounded ranking score for one mechanism candidate."""
-    confidence_component = max(0.0, min(confidence, 1.0))
+    confidence_component = _bounded_score(confidence)
     path_count_component = min(max(path_count, 0), 6) / 6
     support_component = min(max(supporting_claim_count, 0), 8) / 8
     evidence_component = min(max(evidence_reference_count, 0), 8) / 8
@@ -195,6 +297,9 @@ def rank_mechanism_candidate(
 
 __all__ = [
     "ProposalRanking",
+    "ReviewRankingCalibrationObservation",
+    "ReviewRankingCalibrationSummary",
+    "build_review_ranking_calibration_summary",
     "rank_chat_graph_write_candidate",
     "rank_candidate_claim",
     "rank_mechanism_candidate",

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_artifact_modules.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_artifact_modules.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -41,13 +41,25 @@ class _ListStore:
         del space_id
         return list(self.records)
 
-    def list_proposals(self, *, space_id):  # noqa: ANN001
+    def list_proposals(self, *, space_id, status=None):  # noqa: ANN001
         del space_id
-        return list(self.records)
+        if status is None:
+            return list(self.records)
+        return [
+            record
+            for record in self.records
+            if getattr(record, "status", None) == status
+        ]
 
-    def list_review_items(self, *, space_id):  # noqa: ANN001
+    def list_review_items(self, *, space_id, status=None):  # noqa: ANN001
         del space_id
-        return list(self.records)
+        if status is None:
+            return list(self.records)
+        return [
+            record
+            for record in self.records
+            if getattr(record, "status", None) == status
+        ]
 
     def list_space_approvals(self, *, space_id):  # noqa: ANN001
         del space_id
@@ -270,6 +282,29 @@ def test_workspace_snapshot_captures_prior_state_and_dedup_keys() -> None:
         updated_at=now,
         claim_fingerprint="claim-fingerprint",
     )
+    rejected_proposal = HarnessProposalRecord(
+        id="proposal-2",
+        space_id=str(space_id),
+        run_id="run-prior",
+        proposal_type="candidate_claim",
+        source_kind="document_extraction",
+        source_key="document-1:1",
+        document_id="document-1",
+        title="Rejected MED13 claim",
+        summary="summary",
+        status="rejected",
+        confidence=0.5,
+        ranking_score=0.7,
+        reasoning_path={},
+        evidence_bundle=[],
+        payload={},
+        metadata={},
+        decision_reason="not useful",
+        decided_at=now,
+        created_at=now,
+        updated_at=now,
+        claim_fingerprint="rejected-claim-fingerprint",
+    )
     review_item = HarnessReviewItemRecord(
         id="review-1",
         space_id=str(space_id),
@@ -296,6 +331,58 @@ def test_workspace_snapshot_captures_prior_state_and_dedup_keys() -> None:
         updated_at=now,
         review_fingerprint="review-fingerprint",
     )
+    dismissed_review_item = HarnessReviewItemRecord(
+        id="review-2",
+        space_id=str(space_id),
+        run_id="run-prior",
+        review_type="source_record",
+        source_family="literature",
+        source_kind="source_search",
+        source_key="pubmed:2",
+        document_id="document-1",
+        title="Dismissed review",
+        summary="summary",
+        priority="medium",
+        status="dismissed",
+        confidence=0.4,
+        ranking_score=0.8,
+        evidence_bundle=[],
+        payload={},
+        metadata={},
+        decision_reason="not useful",
+        decided_at=now,
+        linked_proposal_id=None,
+        linked_approval_key=None,
+        created_at=now,
+        updated_at=now,
+        review_fingerprint="dismissed-review-fingerprint",
+    )
+    resolved_review_item = HarnessReviewItemRecord(
+        id="review-3",
+        space_id=str(space_id),
+        run_id="run-prior",
+        review_type="source_record",
+        source_family="literature",
+        source_kind="source_search",
+        source_key="pubmed:3",
+        document_id="document-1",
+        title="Resolved review",
+        summary="summary",
+        priority="high",
+        status="resolved",
+        confidence=0.9,
+        ranking_score=0.4,
+        evidence_bundle=[],
+        payload={},
+        metadata={},
+        decision_reason="useful",
+        decided_at=now,
+        linked_proposal_id=None,
+        linked_approval_key=None,
+        created_at=now,
+        updated_at=now,
+        review_fingerprint="resolved-review-fingerprint",
+    )
     approval = HarnessApprovalRecord(
         space_id=str(space_id),
         run_id="run-prior",
@@ -319,19 +406,116 @@ def test_workspace_snapshot_captures_prior_state_and_dedup_keys() -> None:
         parent_run_id=None,
         run_registry=_ListStore([current_run, prior_run]),
         document_store=_ListStore([document]),
-        proposal_store=_ListStore([proposal]),
-        review_item_store=_ListStore([review_item]),
+        proposal_store=_ListStore([proposal, rejected_proposal]),
+        review_item_store=_ListStore(
+            [review_item, dismissed_review_item, resolved_review_item],
+        ),
         approval_store=_ListStore([approval]),
     )
 
     assert snapshot["prior_evidence_run_count"] == 1
-    assert snapshot["proposal_status_counts"] == {"promoted": 1}
-    assert snapshot["review_item_status_counts"] == {"pending_review": 1}
+    assert snapshot["proposal_status_counts"] == {"promoted": 1, "rejected": 1}
+    assert snapshot["review_item_status_counts"] == {
+        "dismissed": 1,
+        "pending_review": 1,
+        "resolved": 1,
+    }
     assert snapshot["approval_status_counts"] == {"approved": 1}
     assert snapshot["graph_state_summary"]["approved_evidence_count"] == 1
+    assert snapshot["review_ranking_calibration"] == {
+        "sample_count": 4,
+        "mean_score": 0.675,
+        "observed_positive_rate": 0.5,
+        "expected_calibration_error": 0.475,
+        "basis": (
+            "Promoted proposals and resolved review items are positive outcomes; "
+            "rejected proposals and dismissed review items are negative outcomes."
+        ),
+    }
     assert snapshot["deduplication"]["proposal_fingerprints"] == [
         "claim-fingerprint",
+        "rejected-claim-fingerprint",
     ]
     assert snapshot["deduplication"]["review_fingerprints"] == [
+        "dismissed-review-fingerprint",
+        "resolved-review-fingerprint",
         "review-fingerprint",
     ]
+
+
+def test_workspace_snapshot_calibration_uses_decided_items_beyond_display_cap() -> None:
+    now = datetime.now(UTC)
+    space_id = uuid4()
+    current_run = HarnessRunRecord(
+        id="run-current",
+        space_id=str(space_id),
+        harness_id="evidence-selection",
+        title="Current run",
+        status="running",
+        input_payload={"goal": "current"},
+        graph_service_status="ok",
+        graph_service_version="test",
+        created_at=now,
+        updated_at=now,
+    )
+    pending_template = HarnessProposalRecord(
+        id="proposal-pending",
+        space_id=str(space_id),
+        run_id="run-prior",
+        proposal_type="candidate_claim",
+        source_kind="document_extraction",
+        source_key="document-1:pending",
+        document_id="document-1",
+        title="Pending claim",
+        summary="summary",
+        status="pending_review",
+        confidence=0.9,
+        ranking_score=0.99,
+        reasoning_path={},
+        evidence_bundle=[],
+        payload={},
+        metadata={},
+        decision_reason=None,
+        decided_at=None,
+        created_at=now,
+        updated_at=now,
+        claim_fingerprint=None,
+    )
+    pending_proposals = [
+        replace(
+            pending_template,
+            id=f"proposal-pending-{index}",
+            source_key=f"document-1:pending:{index}",
+        )
+        for index in range(50)
+    ]
+    promoted_outside_display_cap = replace(
+        pending_template,
+        id="proposal-promoted",
+        source_key="document-1:promoted",
+        status="promoted",
+        ranking_score=0.2,
+        decision_reason="useful",
+        decided_at=now,
+        claim_fingerprint="promoted-outside-display-cap",
+    )
+
+    snapshot = build_evidence_selection_workspace_snapshot(
+        space_id=space_id,
+        run=current_run,
+        goal="current",
+        instructions=None,
+        parent_run_id=None,
+        run_registry=_ListStore([current_run]),
+        document_store=_ListStore([]),
+        proposal_store=_ListStore(
+            [*pending_proposals, promoted_outside_display_cap],
+        ),
+        review_item_store=_ListStore([]),
+        approval_store=_ListStore([]),
+    )
+
+    assert len(snapshot["proposals"]) == 20
+    assert snapshot["review_ranking_calibration"]["sample_count"] == 1
+    assert snapshot["review_ranking_calibration"]["mean_score"] == 0.2
+    assert snapshot["review_ranking_calibration"]["observed_positive_rate"] == 1.0

--- a/services/artana_evidence_api/tests/unit/test_ranking.py
+++ b/services/artana_evidence_api/tests/unit/test_ranking.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from artana_evidence_api.ranking import (
+    ReviewRankingCalibrationObservation,
+    build_review_ranking_calibration_summary,
     rank_chat_graph_write_candidate,
     rank_mechanism_candidate,
     rank_reviewed_candidate_claim,
@@ -80,3 +82,34 @@ def test_rank_reviewed_candidate_claim_rewards_grounded_entailed_specific_eviden
     assert strong.score > weak.score
     assert strong.metadata["evidence_quality_component"] == 1.0
     assert weak.metadata["evidence_quality_component"] == 0.0
+
+
+def test_review_ranking_calibration_summary_uses_decided_review_outcomes() -> None:
+    summary = build_review_ranking_calibration_summary(
+        (
+            ReviewRankingCalibrationObservation(
+                ranking_score=0.9,
+                outcome_positive=True,
+            ),
+            ReviewRankingCalibrationObservation(
+                ranking_score=0.8,
+                outcome_positive=False,
+            ),
+            ReviewRankingCalibrationObservation(
+                ranking_score=1.4,
+                outcome_positive=True,
+            ),
+        ),
+        bin_count=10,
+    )
+
+    assert summary.sample_count == 3
+    assert summary.mean_score == 0.9
+    assert summary.observed_positive_rate == 0.666667
+    assert summary.expected_calibration_error == 0.3
+    assert summary.to_json() == {
+        "sample_count": 3,
+        "mean_score": 0.9,
+        "observed_positive_rate": 0.666667,
+        "expected_calibration_error": 0.3,
+    }


### PR DESCRIPTION
## Summary
- Add production review-ranking calibration summaries over decided human-review outcomes.
- Surface review-ranking calibration in evidence-selection workspace snapshots without using capped display lists.
- Update the tracker and PR evidence summary for the review-ranking calibration gap.

## Outcome Mapping
- Positive: promoted proposals and resolved review items.
- Negative: rejected proposals and dismissed review items.
- Pending items are ignored.

## Validation
- RED focused tests failed on missing calibration API.
- `uv run pytest services/artana_evidence_api/tests/unit/test_ranking.py services/artana_evidence_api/tests/unit/test_evidence_selection_artifact_modules.py -q` -> `8 passed`
- touched-file Ruff -> passed
- `make artana-evidence-api-type-check` -> passed
- `make artana-evidence-api-service-checks` -> passed
- `make service-checks` -> passed, coverage `87.03%`
- `uv run pre-commit run --all-files` -> passed

## Adversarial Review
- Initial review BLOCK found calibration was computed from capped preview lists and missed resolved-review positive coverage.
- Fixed by querying status-filtered decided outcomes separately and adding regressions for resolved positives plus a promoted proposal beyond the preview cap.
- Re-review PASS.

## Remaining Work
- Expert/shadow-mode review set is still needed before making production review-ranking ECE a hard merge gate.