### PR TITLE
Make shadow-study evidence categorical and scope ranking explicitly

### DIFF
--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -3140,6 +3140,35 @@ Reviewer/adversarial notes:
 The live report still flags `entailment_not_checked`,
 `relation_arguments_missing_from_sentence`, and `generic_relation_rate_high`.
 
+### 2026-07-13 - Categorical Shadow-Study Contracts
+
+Branch: `alvaro/evidence-shadow-study-categorical-contract`
+
+Evidence report:
+`docs/validation/reports/2026-07-13-pr-semantic-shadow-study-categorical-contract.md`
+
+Progress:
+
+- Review agents now return categorical findings, candidate-bound citations,
+  and explanations; deterministic code derives numeric quality metrics.
+- Selection-only studies no longer fabricate review-ranking evidence.
+- Production evidence origin is explicit, and AI/synthetic review cannot pass
+  the readiness gate.
+- Batch reports separate all observed entries from passed production entries.
+- Adversarial regressions cover contradictory overclaim declarations,
+  candidate binding, and all-selection and mixed-study suites.
+
+Remaining proof boundary:
+
+- `real_shadow_review` is still declared, not cryptographically attested.
+- Citation text and locators are not yet checked against immutable canonical
+  source bytes.
+- Source-manifest digests are not yet reverified by resolving artifacts at gate
+  time.
+- This contract work improves measurement integrity but does not change the
+  latest live trusted-graph precision, linking, specificity, or entailment
+  results.
+
 ## PR Update Template
 
 Copy this block when a PR is opened or merged.

--- a/docs/validation/evidence-selection-review-template.md
+++ b/docs/validation/evidence-selection-review-template.md
@@ -19,8 +19,21 @@ real shadow-mode human review before making any production-readiness claim.
   "duplicate_suggestion_ids": [],
   "false_positive_notes": {},
   "false_negative_notes": {},
-  "explanation_quality_score": 1,
-  "high_severity_overclaim_count": 0,
+  "explanation_assessment": {
+    "literal_citation_present": "yes",
+    "citation_entails_claim": "yes",
+    "all_required_criteria_addressed": "yes",
+    "unsupported_material_claim_present": "no",
+    "cited_evidence": [
+      {
+        "record_id": "",
+        "source_locator": "",
+        "quoted_text": ""
+      }
+    ],
+    "reviewer_explanation": ""
+  },
+  "high_severity_overclaim_findings": [],
   "reviewer_notes": ""
 }
 ```
@@ -34,10 +47,16 @@ Interpretation:
 - `false_positive_notes` and `false_negative_notes`: JSON objects keyed by the
   affected record ID, with a non-blank reviewer explanation as each value. Use
   an empty object when there are no findings of that kind.
-- `explanation_quality_score`: 1 is poor, 5 is excellent.
-- `high_severity_overclaim_count`: any clinical, regulatory, causal, or
-  graph-truth claim that goes beyond the source evidence. This must be zero as
-  a reviewer/process gate before production rollout.
+- `explanation_assessment`: atomic categorical findings, literal source text,
+  and the reviewer's reasoning. Do not author a numeric quality score. The
+  service derives `adequate`, `inadequate`, or `unclear` deterministically.
+- `citation_entails_claim`: use `unclear` when the cited text does not support a
+  confident yes/no judgment. `unclear` never counts as adequate.
+- `high_severity_overclaim_findings`: one structured item per clinical,
+  regulatory, causal, or graph-truth claim that goes beyond the source
+  evidence. The service derives the count; an empty list is required to pass.
+- Every cited `record_id`, including citations inside overclaim findings, must
+  exist in the producer-signed candidate packet.
 
 The service helper
 `artana_evidence_api.evidence_selection_validation.compare_evidence_selection_review`
@@ -101,17 +120,33 @@ uv run python scripts/build_evidence_selection_shadow_review_packet.py \
 ```
 
 The packet uses
-`schema_version: "evidence_selection_shadow_review_packet.v1"` and sets
+`schema_version: "evidence_selection_shadow_review_packet.v2"` and sets
 `production_readiness_claim: false`. It is a collection aid, not completed
 expert evidence. The command also writes
 `completed-shadow-review-packet.machine.json`, containing the producer-signed
 machine facts. Keep that sidecar under producer control and let reviewers edit
 only `completed-shadow-review-packet.json`. Reviewers must fill the required
-human selection labels, reviewer IDs, explanation-quality scores, overclaim
-counts, and positive/negative review-ranking outcomes before the data can be
-converted into the source-export inputs below.
+human selection labels, reviewer IDs, categorical explanation assessments,
+explicit overclaim findings, and, for combined studies, positive/negative
+review-ranking outcomes before conversion.
 
-Convert a completed packet into raw source-export writer inputs with:
+Packets are explicit about study scope:
+
+- `selection_relevance` measures source selection and requires no ranking data.
+- `selection_and_review_ranking` measures selection plus downstream ranking and
+  requires proposal/review-item outcomes and an adjudication note.
+
+Convert a completed selection-only packet into its raw writer input with:
+
+```bash
+uv run python scripts/build_evidence_selection_shadow_review_source_inputs.py \
+  --machine-packet path/to/completed-shadow-review-packet.machine.json \
+  --packet path/to/completed-shadow-review-packet.json \
+  --selection-reviews-output path/to/selection-review-labels.json
+```
+
+For a combined selection-and-ranking packet, add the ranking output and
+adjudication note:
 
 ```bash
 uv run python scripts/build_evidence_selection_shadow_review_source_inputs.py \
@@ -126,9 +161,9 @@ This conversion step is still not a readiness claim. It only creates the strict
 selection-review label file and review-ranking study file that the source-export
 writer consumes next.
 
-For a complete expert/shadow study, store selection reviews and review-ranking
-decisions as self-describing source exports. The selection-review export shape
-is:
+For a complete expert/shadow study, store selection reviews and any required
+review-ranking decisions as self-describing source exports. The
+selection-review export shape is:
 
 ```json
 {
@@ -161,16 +196,31 @@ The review-ranking export shape is:
 }
 ```
 
-The two source exports must have matching `source_system`, `export_id`,
+For combined studies, the two source exports must have matching `source_system`, `export_id`,
 `exported_at`, `exporter_id`, and `redaction_statement` values. The
 `exported_at` value must be canonical UTC ISO-8601 with a trailing `Z`, such as
 `2026-07-07T00:00:00Z`; timezone-naive values and offset spellings such as
 `+00:00` or `+01:00` are rejected. Identity text fields are compared literally
 and must not contain leading or trailing whitespace. Build the source exports
-from collected review JSON with:
+from collected review JSON. For a selection-only study:
 
 ```bash
 uv run python scripts/build_evidence_selection_source_exports.py \
+  --study-type selection_relevance \
+  --selection-reviews path/to/selection-review-labels.json \
+  --selection-export-output path/to/selection-review-export.json \
+  --source-system artana-shadow-review \
+  --export-id <export-id> \
+  --exported-at 2026-07-07T00:00:00Z \
+  --exporter-id <exporter-id> \
+  --redaction-statement "No PHI or raw patient text included."
+```
+
+For a combined study:
+
+```bash
+uv run python scripts/build_evidence_selection_source_exports.py \
+  --study-type selection_and_review_ranking \
   --selection-reviews path/to/selection-review-labels.json \
   --review-ranking path/to/review-ranking-study.json \
   --selection-export-output path/to/selection-review-export.json \
@@ -182,16 +232,20 @@ uv run python scripts/build_evidence_selection_source_exports.py \
   --redaction-statement "No PHI or raw patient text included."
 ```
 
-Then build the final study bundle with:
+Then build the final combined-study bundle with:
 
 ```bash
 uv run python scripts/build_evidence_selection_expert_study_bundle.py \
   --study-id <study-id> \
+  --study-type selection_and_review_ranking \
   --study-evidence-kind real_shadow_review \
   --selection-reviews path/to/selection-review-export.json \
   --review-ranking path/to/review-ranking-export.json \
   --output path/to/evidence-selection-expert-study.json
 ```
+
+For a selection-only bundle, use `--study-type selection_relevance` and omit
+both `--review-ranking` and `--review-ranking-uri`.
 
 `--source-system`, `--export-id`, `--exported-at`, `--exporter-id`, and
 `--redaction-statement` are optional compatibility checks only. When supplied,
@@ -201,7 +255,10 @@ in both source exports.
 Run `scripts/run_evidence_selection_expert_study_gate.py` on the bundle before
 using the study to support a production-readiness claim. Use
 `study_evidence_kind: "synthetic_fixture"` for mechanics fixtures; those bundles
-must fail the production-style study gate.
+must fail the production-style study gate. Every artifact and batch command
+requires the evidence kind explicitly; none defaults to `real_shadow_review`.
+The declaration prevents accidental promotion but does not replace signed
+reviewer attestation.
 
 The generated `source_manifest` must describe the real export used to create
 the bundle. The builder computes lowercase 64-character SHA-256 hashes for each
@@ -220,14 +277,17 @@ uv run python scripts/build_evidence_selection_shadow_review_study_batch_manifes
   --packet path/to/completed-shadow-review-packet-1.json \
   --packet path/to/completed-shadow-review-packet-2.json \
   --packet path/to/completed-shadow-review-packet-3.json \
+  --study-evidence-kind real_shadow_review \
   --output path/to/shadow-review-study-batch-manifest.json \
-  --adjudication-note "Reviewer adjudicated every packet." \
   --source-system artana-shadow-review \
   --export-id-prefix <export-id-prefix> \
   --exported-at 2026-07-07T00:00:00Z \
   --exporter-id <exporter-id> \
   --redaction-statement "No PHI or raw patient text included."
 ```
+
+Add `--adjudication-note` when the batch contains any
+`selection_and_review_ranking` packet. Selection-only batches do not require it.
 
 Then run:
 

--- a/docs/validation/evidence-selection-review-template.md
+++ b/docs/validation/evidence-selection-review-template.md
@@ -13,6 +13,7 @@ real shadow-mode human review before making any production-readiness claim.
   "run_id": "00000000-0000-0000-0000-000000000000",
   "goal": "",
   "reviewer_id": "",
+  "candidate_record_ids": [],
   "harness_selected_record_ids": [],
   "human_selected_record_ids": [],
   "harness_skipped_record_ids": [],
@@ -42,6 +43,9 @@ Interpretation:
 
 - `false_positive`: the harness selected a record the reviewer would not select.
 - `false_negative`: the reviewer selected a record the harness missed.
+- `candidate_record_ids`: the complete immutable candidate universe for this
+  review. Every harness decision, human decision, note, citation, and overclaim
+  finding must reference an ID in this list.
 - `duplicate_suggestion`: the harness suggested the same scientific source
   record again without adding useful new context.
 - `false_positive_notes` and `false_negative_notes`: JSON objects keyed by the
@@ -56,7 +60,8 @@ Interpretation:
   regulatory, causal, or graph-truth claim that goes beyond the source
   evidence. The service derives the count; an empty list is required to pass.
 - Every cited `record_id`, including citations inside overclaim findings, must
-  exist in the producer-signed candidate packet.
+  exist in `candidate_record_ids`. Packet-derived reviews populate this list
+  from the producer-signed candidate packet.
 
 The service helper
 `artana_evidence_api.evidence_selection_validation.compare_evidence_selection_review`
@@ -167,7 +172,7 @@ selection-review export shape is:
 
 ```json
 {
-  "schema_version": "evidence_selection_review_export.v1",
+  "schema_version": "evidence_selection_review_export.v2",
   "source_system": "",
   "export_id": "",
   "exported_at": "2026-07-07T00:00:00Z",
@@ -195,6 +200,10 @@ The review-ranking export shape is:
   }
 }
 ```
+
+Selection-review export v2 is the categorical contract and requires each
+review's `candidate_record_ids`. Legacy v1 numeric envelopes are rejected; they
+must not be reinterpreted as categorical review evidence.
 
 For combined studies, the two source exports must have matching `source_system`, `export_id`,
 `exported_at`, `exporter_id`, and `redaction_statement` values. The

--- a/docs/validation/evidence-selection-validation.md
+++ b/docs/validation/evidence-selection-validation.md
@@ -35,7 +35,7 @@ Useful metrics:
 - provenance completeness;
 - reviewer agreement;
 - high-severity overclaim count;
-- quality of selection and skip reasons.
+- categorical explanation adequacy derived from cited findings.
 
 High-severity overclaiming must be zero before calling the harness
 production-ready. This is a reviewer/process gate, not just an automated metric:
@@ -56,15 +56,23 @@ For each run, compare:
 - false positives;
 - false negatives;
 - duplicate suggestions;
-- explanation quality.
+- literal citations, entailment, criteria coverage, and unsupported claims.
 
 Use `docs/validation/evidence-selection-review-template.md` to capture reviewer
 labels. The service helper
 `artana_evidence_api.evidence_selection_validation.compare_evidence_selection_review`
 turns those labels into true positives, false positives, false negatives,
-confirmed skips, duplicate counts, precision, recall, explanation quality, and
-the zero high-severity-overclaim gate. The helper aggregates reviewer-supplied
-labels and counts; it does not replace reviewer judgment.
+confirmed skips, duplicate counts, precision, recall, categorical explanation
+adequacy, and the zero high-severity-overclaim gate. Reviewers provide atomic
+categories, literal citations, and written reasoning. Deterministic code derives
+all numeric metrics and gates; it does not replace reviewer judgment.
+
+Use `study_type: "selection_relevance"` when the source run does not produce
+proposal/review-item ranking decisions. Use
+`study_type: "selection_and_review_ranking"` only when both selection and
+ranking data exist. A selection-only study must never fabricate ranking rows to
+satisfy a schema. `ai_reviewer_simulation` is useful for mechanics and
+adversarial tests but cannot pass the production-readiness gate.
 
 Review-ranking calibration is gated separately from per-run precision/recall.
 Use
@@ -160,10 +168,11 @@ uv run python scripts/build_evidence_selection_shadow_review_source_inputs.py \
 
 The converter defaults to the same `.machine.json` sidecar when
 `--machine-packet` is omitted. It fails closed on invalid signatures, changed
-machine-owned fields, blank reviewer IDs, blank ranking outcomes, missing
-explanation scores, missing overclaim counts, unknown record IDs, or output
-paths that overwrite either packet. It writes paired outputs so a failed second
-write does not leave a half-converted review set.
+machine-owned fields, blank reviewer IDs, blank required ranking outcomes,
+missing categorical assessments, missing overclaim findings, citations to
+unknown record IDs, or output paths that overwrite either packet. Selection-only
+conversion writes one atomic selection file; combined conversion writes paired
+outputs so a failed second write does not leave a half-converted review set.
 
 When at least three completed packets are ready, build a strict batch manifest
 instead of hand-authoring entry metadata:
@@ -174,14 +183,24 @@ uv run python scripts/build_evidence_selection_shadow_review_study_batch_manifes
   --packet path/to/completed-shadow-review-packet-1.json \
   --packet path/to/completed-shadow-review-packet-2.json \
   --packet path/to/completed-shadow-review-packet-3.json \
+  --study-evidence-kind real_shadow_review \
   --output path/to/shadow-review-study-batch-manifest.json \
-  --adjudication-note "Reviewer adjudicated every packet." \
   --source-system artana-shadow-review \
   --export-id-prefix <export-id-prefix> \
   --exported-at 2026-07-07T00:00:00Z \
   --exporter-id <exporter-id> \
   --redaction-statement "No PHI or raw patient text included."
 ```
+
+Add `--adjudication-note` when any packet has
+`study_type: "selection_and_review_ranking"`. It is not required for a
+selection-only batch.
+
+`--study-evidence-kind` is mandatory. There is no default to
+`real_shadow_review`, so an AI simulation or synthetic fixture cannot be
+accidentally relabeled as human review by omission. This field records the
+declared origin; signed reviewer attestation remains a separate requirement
+before the declaration can be independently proven.
 
 The manifest builder validates each source packet with the same completed-packet
 contract as the source-input converter, derives entry IDs and output
@@ -191,8 +210,13 @@ to overwrite a source packet.
 
 Full expert/shadow study gate:
 
+For a selection-only study, pass `--study-type selection_relevance` to the
+source-export and bundle builders and omit all review-ranking paths. The
+combined example below uses `selection_and_review_ranking`:
+
 ```bash
 uv run python scripts/build_evidence_selection_source_exports.py \
+  --study-type selection_and_review_ranking \
   --selection-reviews path/to/selection-review-labels.json \
   --review-ranking path/to/review-ranking-study.json \
   --selection-export-output path/to/selection-review-export.json \
@@ -207,6 +231,7 @@ uv run python scripts/build_evidence_selection_source_exports.py \
 ```bash
 uv run python scripts/build_evidence_selection_expert_study_bundle.py \
   --study-id <study-id> \
+  --study-type selection_and_review_ranking \
   --study-evidence-kind real_shadow_review \
   --selection-reviews path/to/selection-review-export.json \
   --review-ranking path/to/review-ranking-export.json \
@@ -232,17 +257,19 @@ uv run python scripts/run_evidence_selection_expert_study_gate.py \
 ```
 
 This runner combines selection-review precision/recall, reviewer coverage,
-explanation quality, high-severity overclaim checks, and the review-ranking
-calibration gate above. It also requires a source manifest with hashed export
-artifacts, exact selection-review run IDs, exact review-ranking decision keys,
+deterministically derived explanation adequacy, high-severity overclaim checks,
+and, for combined studies, the review-ranking calibration gate above. It also
+requires a source manifest with hashed export artifacts, exact selection-review
+run IDs, exact required review-ranking decision keys,
 and a reviewer roster covering every reviewer ID in the bundle. It fails closed
-if either the selection-review study, source manifest, or review-ranking
-calibration study is undercovered or below threshold. The study bundle must
+if a required selection-review, source-manifest, or review-ranking gate is
+undercovered or below threshold. The study bundle must
 declare `study_evidence_kind: "real_shadow_review"` before it can pass.
 Synthetic fixtures remain valid for mechanics testing, but they must not
 produce a passing production-style study gate. Every selection review must
 include a reviewer ID, a nonblank goal, measurable precision, measurable recall,
-and an explanation-quality score.
+and a complete categorical explanation assessment with candidate-bound source
+citations.
 
 Batch production-readiness gate:
 
@@ -257,8 +284,11 @@ pipeline for every manifest entry, preserves per-entry gate reports, and writes
 aggregate JSON and Markdown reports. It fails closed unless the suite proves
 minimum entry count, successful entry rate, zero failed entries, total sample
 size, independent source/study identity, cross-batch goal/evidence-shape
-diversity, aggregate precision/recall/explanation quality, and review-ranking
-calibration together. `--allow-failed-gate` is diagnostic only; it lets reports
+diversity, aggregate precision/recall/explanation adequacy, and any required
+review-ranking calibration together. Reports expose both
+`all_entry_observed_quality` for diagnosis and
+`passed_entry_production_quality` for readiness; failed studies are not erased
+from the diagnostic view. `--allow-failed-gate` is diagnostic only; it lets reports
 be written with exit success but does not make a failed suite production-ready.
 
 ## Expert-Review Study
@@ -267,8 +297,8 @@ Use a small expert-review study before production rollout.
 
 1. Give the same goal and same source result set to the harness and to one or
    more human reviewers.
-2. Ask reviewers to score relevance, completeness, novelty, provenance,
-   uncertainty handling, and overclaiming.
+2. Ask reviewers to classify relevance, completeness, novelty, provenance,
+   uncertainty handling, and overclaiming with cited evidence and explanations.
 3. Record whether the harness saved review time without lowering evidence
    quality.
 4. Update benchmark fixtures and selection rules from the reviewer feedback.

--- a/docs/validation/evidence-selection-validation.md
+++ b/docs/validation/evidence-selection-validation.md
@@ -66,6 +66,9 @@ confirmed skips, duplicate counts, precision, recall, categorical explanation
 adequacy, and the zero high-severity-overclaim gate. Reviewers provide atomic
 categories, literal citations, and written reasoning. Deterministic code derives
 all numeric metrics and gates; it does not replace reviewer judgment.
+Each review also declares its complete `candidate_record_ids` universe. All
+harness and human decisions, audit-note keys, citations, and overclaim findings
+must bind to that universe before the study can be evaluated.
 
 Use `study_type: "selection_relevance"` when the source run does not produce
 proposal/review-item ranking decisions. Use
@@ -239,7 +242,7 @@ uv run python scripts/build_evidence_selection_expert_study_bundle.py \
 ```
 
 The selection-review source export must use
-`schema_version: "evidence_selection_review_export.v1"`. The review-ranking
+`schema_version: "evidence_selection_review_export.v2"`. The review-ranking
 source export must use
 `schema_version: "evidence_selection_review_ranking_export.v1"`. Both exports
 must carry matching `source_system`, `export_id`, `exported_at`, `exporter_id`,
@@ -249,6 +252,8 @@ those export fields and rejects identity drift before writing the final bundle.
 values and offset spellings such as `+00:00` or `+01:00` are rejected so source
 identity remains literal and reproducible. Identity text fields are not
 trimmed; leading or trailing whitespace is rejected instead of normalized.
+Selection-review v1 represented the former numeric explanation contract and is
+rejected rather than interpreted as categorical v2 evidence.
 
 ```bash
 uv run python scripts/run_evidence_selection_expert_study_gate.py \

--- a/docs/validation/reports/2026-07-13-pr-semantic-shadow-study-categorical-contract.md
+++ b/docs/validation/reports/2026-07-13-pr-semantic-shadow-study-categorical-contract.md
@@ -49,6 +49,15 @@ Fixed in this PR:
 - Rejected `unsupported_material_claim_present: yes` unless at least one
   candidate-bound high-severity overclaim finding is present.
 - Added all-selection and mixed-study batch matrix tests.
+- Removed the packet CLI's stale ranking requirement so real selection-only
+  result artifacts produce `selection_relevance` packets end to end.
+- Applied ranking-provenance consistency checks even when ranking evidence is
+  not required, rejecting stray or duplicate ranking keys.
+- Versioned categorical selection-review exports as v2 and rejected legacy v1
+  numeric envelopes instead of reinterpreting them.
+- Added an explicit candidate-record universe to each categorical review and
+  bound decisions, note keys, citations, overclaim targets, and overclaim
+  citations to that universe for packet-derived and direct-import studies.
 
 Required follow-up work:
 

--- a/docs/validation/reports/2026-07-13-pr-semantic-shadow-study-categorical-contract.md
+++ b/docs/validation/reports/2026-07-13-pr-semantic-shadow-study-categorical-contract.md
@@ -1,0 +1,88 @@
+# Semantic Shadow-Study Categorical Contract Report
+
+Date: 2026-07-13
+
+Branch: `alvaro/evidence-shadow-study-categorical-contract`
+
+## Goal
+
+Make shadow-study evidence measurable without asking an LLM or reviewer to
+invent numeric quality scores. Reviewers provide categorical findings,
+candidate-bound citations, and explanations. Deterministic code derives
+precision, recall, explanation adequacy, overclaim counts, calibration, and
+readiness decisions.
+
+## Implemented
+
+- Added a single-purpose categorical review contract package.
+- Replaced reviewer-authored explanation scores with explicit yes/no findings,
+  citations, and structured high-severity overclaim findings.
+- Derived explanation adequacy and overclaim counts deterministically.
+- Split `selection_relevance` studies from
+  `selection_and_review_ranking` studies across packets, completion, exports,
+  bundles, pipelines, batches, reports, and CLIs.
+- Prevented selection-only studies from fabricating review-ranking artifacts.
+- Required an explicit `study_evidence_kind` at artifact and batch boundaries;
+  AI simulations and synthetic fixtures cannot pass production readiness.
+- Bound review citations and overclaim findings to immutable candidate IDs.
+- Separated all-entry observed quality from passed-entry production quality in
+  batch reports.
+- Added adversarial tests for unsupported claims, candidate binding, invalid
+  study/ranking combinations, explicit evidence origin, and selection-only and
+  mixed batch behavior.
+
+## Measurement Rules
+
+- Agents and reviewers emit categories, evidence spans, record IDs, and short
+  explanations.
+- Deterministic code computes all numeric metrics and pass/fail outcomes.
+- Missing or contradictory categorical evidence fails closed.
+- Only `real_shadow_review` can contribute to a passing production-style gate.
+- Selection quality and ranking calibration remain separate claims.
+
+## Adversarial Review
+
+Fixed in this PR:
+
+- Removed the implicit `real_shadow_review` default from the study pipeline and
+  batch manifest builder.
+- Rejected `unsupported_material_claim_present: yes` unless at least one
+  candidate-bound high-severity overclaim finding is present.
+- Added all-selection and mixed-study batch matrix tests.
+
+Required follow-up work:
+
+1. Add signed reviewer identity and attestation so `real_shadow_review` is
+   proven rather than caller-declared.
+2. Capture immutable canonical source text and verify quoted spans and locators
+   against those bytes.
+3. Resolve every source-manifest URI at gate time and verify digest and parsed
+   payload equality.
+4. Publish study artifacts and gate reports as one staged, atomic directory.
+5. Surface rollback failures instead of suppressing restoration errors.
+6. Apply the same categorical-first contract to ranking outcomes before using
+   ranking calibration as trusted product evidence.
+
+## Validation Evidence
+
+- All evidence-selection unit and gate regressions passed.
+- `make artana-evidence-api-lint` passed.
+- `make artana-evidence-api-type-check` passed across 529 service source files
+  and every affected CLI.
+- `make artana-evidence-api-service-checks` passed against a fresh migrated
+  PostgreSQL database.
+- `make service-checks` passed for both backend services, generated contracts,
+  boundaries, architecture checks, migrations, and repository tests.
+- Repository coverage was 87.24%, above the required 86% floor.
+
+Live external API, running-service endpoint, and real OpenAI-agent tests were
+skipped by their existing opt-in environment gates. This PR therefore proves
+the categorical contract and orchestration behavior, not live model quality.
+
+## Readiness Conclusion
+
+This change improves evaluation integrity and prevents several false readiness
+claims. It does not prove trusted-graph readiness. The next evidence milestone
+is a genuinely human-attested, source-verifiable shadow-review batch; the graph
+quality claim still depends on live representative cases meeting the existing
+precision, recall, linking, specificity, and entailment gates.

--- a/scripts/build_evidence_selection_expert_study_bundle.py
+++ b/scripts/build_evidence_selection_expert_study_bundle.py
@@ -44,8 +44,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--study-id", required=True)
     parser.add_argument(
+        "--study-type",
+        choices=("selection_relevance", "selection_and_review_ranking"),
+        required=True,
+    )
+    parser.add_argument(
         "--study-evidence-kind",
-        choices=("real_shadow_review", "synthetic_fixture"),
+        choices=(
+            "real_shadow_review",
+            "ai_reviewer_simulation",
+            "synthetic_fixture",
+        ),
         required=True,
     )
     parser.add_argument(
@@ -57,7 +66,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--review-ranking",
         type=Path,
-        required=True,
+        default=None,
         help="JSON review-ranking calibration export.",
     )
     parser.add_argument(
@@ -119,6 +128,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         bundle = build_evidence_selection_expert_study_bundle(
             EvidenceSelectionExpertStudyBundleRequest(
                 study_id=args.study_id,
+                study_type=args.study_type,
                 study_evidence_kind=args.study_evidence_kind,
                 selection_reviews_path=args.selection_reviews,
                 review_ranking_path=args.review_ranking,
@@ -152,7 +162,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(
         "evidence_selection_expert_study_bundle "
         f"selection_reviews={len(bundle.selection_reviews)} "
-        f"review_ranking_decisions={len(bundle.review_ranking.decisions)} "
+        "review_ranking_decisions="
+        f"{len(bundle.review_ranking.decisions) if bundle.review_ranking else 0} "
         f"source_artifacts={artifact_count}",
     )
     print(f"Wrote bundle: {args.output}")
@@ -170,7 +181,9 @@ def _parse_exported_at(value: str) -> datetime:
 
 
 def _source_paths_from_args(args: argparse.Namespace) -> tuple[Path, ...]:
-    paths = [args.selection_reviews, args.review_ranking]
+    paths = [args.selection_reviews]
+    if args.review_ranking is not None:
+        paths.append(args.review_ranking)
     if args.adjudication_log is not None:
         paths.append(args.adjudication_log)
     return tuple(paths)

--- a/scripts/build_evidence_selection_shadow_review_packet.py
+++ b/scripts/build_evidence_selection_shadow_review_packet.py
@@ -193,13 +193,7 @@ def _review_ranking_items_from_result(
     )
     if shadow_candidate_items:
         return shadow_candidate_items
-
-    msg = (
-        "Evidence-selection result has no rankable items. Provide "
-        "review_ranking_items, proposals, review_items, or deferred shadow "
-        "candidates."
-    )
-    raise ValueError(msg)
+    return ()
 
 
 def _direct_review_ranking_items(

--- a/scripts/build_evidence_selection_shadow_review_source_inputs.py
+++ b/scripts/build_evidence_selection_shadow_review_source_inputs.py
@@ -30,6 +30,7 @@ from artana_evidence_api.evidence_selection.output_paths import (
 )
 from artana_evidence_api.evidence_selection.shadow_review_completion import (  # noqa: E402
     EvidenceSelectionShadowReviewSourceInputRequest,
+    EvidenceSelectionShadowReviewSourceInputs,
     build_evidence_selection_shadow_review_source_inputs,
     machine_packet_sidecar_path,
 )
@@ -50,8 +51,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Convert a human-completed shadow-review packet, bound to its "
-            "immutable machine packet, into "
-            "selection-review labels and review-ranking study inputs."
+            "immutable machine packet, into selection-review labels and, for "
+            "combined studies, review-ranking study inputs."
         ),
     )
     parser.add_argument(
@@ -75,13 +76,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--review-ranking-output",
         type=Path,
-        required=True,
-        help="Output JSON path for the review-ranking calibration source input.",
+        default=None,
+        help="Required output path only for selection_and_review_ranking studies.",
     )
     parser.add_argument(
         "--adjudication-note",
-        required=True,
-        help="Human adjudication note for the completed review-ranking study.",
+        default=None,
+        help="Required human adjudication note only for review-ranking studies.",
     )
     parser.add_argument("--description", default=None)
     return parser.parse_args(argv)
@@ -109,11 +110,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 description=args.description,
             ),
         )
-        _write_paired_json(
+        _write_source_input_payloads(
+            result=result,
             selection_output_path=args.selection_reviews_output,
-            selection_payload=result.selection_reviews_payload(),
             review_ranking_output_path=args.review_ranking_output,
-            review_ranking_payload=result.review_ranking_payload(),
         )
     except (OSError, ValueError, ValidationError) as exc:
         print(f"error: {cli_error_message(exc)}", file=sys.stderr)
@@ -121,11 +121,39 @@ def main(argv: Sequence[str] | None = None) -> int:
     print(
         "evidence_selection_shadow_review_source_inputs "
         f"selection_reviews={len(result.selection_reviews)} "
-        f"review_ranking_decisions={len(result.review_ranking.decisions)}",
+        "review_ranking_decisions="
+        f"{len(result.review_ranking.decisions) if result.review_ranking else 0}",
     )
     print(f"Wrote selection-review labels: {args.selection_reviews_output}")
-    print(f"Wrote review-ranking study: {args.review_ranking_output}")
+    if args.review_ranking_output is not None:
+        print(f"Wrote review-ranking study: {args.review_ranking_output}")
     return 0
+
+
+def _write_source_input_payloads(
+    *,
+    result: EvidenceSelectionShadowReviewSourceInputs,
+    selection_output_path: Path,
+    review_ranking_output_path: Path | None,
+) -> None:
+    if result.review_ranking is None:
+        if review_ranking_output_path is not None:
+            msg = "selection_relevance studies must not set --review-ranking-output."
+            raise ValueError(msg)
+        _write_single_json(
+            output_path=selection_output_path,
+            payload=result.selection_reviews_payload(),
+        )
+        return
+    if review_ranking_output_path is None:
+        msg = "selection_and_review_ranking studies require --review-ranking-output."
+        raise ValueError(msg)
+    _write_paired_json(
+        selection_output_path=selection_output_path,
+        selection_payload=result.selection_reviews_payload(),
+        review_ranking_output_path=review_ranking_output_path,
+        review_ranking_payload=result.review_ranking_payload(),
+    )
 
 
 def _validate_output_paths(
@@ -133,13 +161,19 @@ def _validate_output_paths(
     machine_packet_path: Path,
     packet_path: Path,
     selection_output_path: Path,
-    review_ranking_output_path: Path,
+    review_ranking_output_path: Path | None,
 ) -> None:
     source_packets = (machine_packet_path, packet_path)
-    if paths_alias(selection_output_path, review_ranking_output_path):
+    if review_ranking_output_path is not None and paths_alias(
+        selection_output_path,
+        review_ranking_output_path,
+    ):
         msg = "Selection-review and review-ranking outputs must be different files."
         raise ValueError(msg)
-    if paths_nested(selection_output_path, review_ranking_output_path):
+    if review_ranking_output_path is not None and paths_nested(
+        selection_output_path,
+        review_ranking_output_path,
+    ):
         msg = (
             "Selection-review and review-ranking outputs must not use nested "
             "parent/child paths."
@@ -149,17 +183,21 @@ def _validate_output_paths(
         if paths_alias(selection_output_path, source_packet):
             msg = "Selection-review output must not overwrite source packet."
             raise ValueError(msg)
-        if paths_alias(review_ranking_output_path, source_packet):
+        if review_ranking_output_path is not None and paths_alias(
+            review_ranking_output_path,
+            source_packet,
+        ):
             msg = "Review-ranking output must not overwrite source packet."
             raise ValueError(msg)
     _validate_output_file_path(
         output_path=selection_output_path,
         label="Selection-review output",
     )
-    _validate_output_file_path(
-        output_path=review_ranking_output_path,
-        label="Review-ranking output",
-    )
+    if review_ranking_output_path is not None:
+        _validate_output_file_path(
+            output_path=review_ranking_output_path,
+            label="Review-ranking output",
+        )
 
 
 def _validate_output_file_path(*, output_path: Path, label: str) -> None:
@@ -225,6 +263,28 @@ def _write_paired_json(
         _cleanup_temp_path(review_ranking_temp_path)
         _restore_prepared_outputs(prepared_outputs)
         msg = f"Unable to write paired shadow-review source inputs: {exc}"
+        raise OSError(msg) from exc
+
+
+def _write_single_json(*, output_path: Path, payload: JSONObject) -> None:
+    """Atomically replace one selection-only source input."""
+
+    _validate_output_file_path(
+        output_path=output_path,
+        label="Selection-review output",
+    )
+    temp_path: Path | None = None
+    prepared_outputs: list[_PreparedOutput] = []
+    try:
+        temp_path = _write_temp_sibling(final_path=output_path, payload=payload)
+        prepared_outputs.append(_prepare_output_for_replace(output_path))
+        temp_path.replace(output_path)
+        temp_path = None
+        _discard_prepared_backups(prepared_outputs)
+    except OSError as exc:
+        _cleanup_temp_path(temp_path)
+        _restore_prepared_outputs(prepared_outputs)
+        msg = f"Unable to write selection-only shadow-review source input: {exc}"
         raise OSError(msg) from exc
 
 

--- a/scripts/build_evidence_selection_shadow_review_study_artifacts.py
+++ b/scripts/build_evidence_selection_shadow_review_study_artifacts.py
@@ -66,7 +66,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         required=True,
         help="Directory for raw inputs, source exports, bundle, and gate report.",
     )
-    parser.add_argument("--adjudication-note", required=True)
+    parser.add_argument(
+        "--adjudication-note",
+        default=None,
+        help="Required only for selection_and_review_ranking studies.",
+    )
     parser.add_argument("--source-system", required=True)
     parser.add_argument("--export-id", required=True)
     parser.add_argument(
@@ -76,6 +80,16 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--exporter-id", required=True)
     parser.add_argument("--redaction-statement", required=True)
+    parser.add_argument(
+        "--study-evidence-kind",
+        choices=(
+            "real_shadow_review",
+            "ai_reviewer_simulation",
+            "synthetic_fixture",
+        ),
+        required=True,
+        help="Explicit origin of the completed review labels.",
+    )
     parser.add_argument("--description", default=None)
     parser.add_argument(
         "--allow-failed-gate",
@@ -106,6 +120,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exported_at=args.exported_at,
                 exporter_id=args.exporter_id,
                 redaction_statement=args.redaction_statement,
+                study_evidence_kind=args.study_evidence_kind,
                 machine_packet_path=machine_packet_path,
                 packet_path=args.packet,
                 description=args.description,
@@ -137,9 +152,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"blocking_reasons={len(blocking_reasons)}",
     )
     print(f"Wrote selection-review labels: {result.selection_reviews_path}")
-    print(f"Wrote review-ranking study: {result.review_ranking_path}")
+    if result.review_ranking_path is not None:
+        print(f"Wrote review-ranking study: {result.review_ranking_path}")
     print(f"Wrote selection-review export: {result.selection_export_path}")
-    print(f"Wrote review-ranking export: {result.review_ranking_export_path}")
+    if result.review_ranking_export_path is not None:
+        print(f"Wrote review-ranking export: {result.review_ranking_export_path}")
     print(f"Wrote expert-study bundle: {result.bundle_path}")
     print(f"Wrote gate JSON report: {gate_manifest['json_path']}")
     print(f"Wrote gate Markdown report: {gate_manifest['markdown_path']}")
@@ -154,8 +171,8 @@ def _add_gate_threshold_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--min-selection-reviewer-count", type=int, default=1)
     parser.add_argument("--min-mean-precision", type=float, default=0.8)
     parser.add_argument("--min-mean-recall", type=float, default=0.8)
-    parser.add_argument("--min-mean-explanation-quality", type=float, default=3.0)
-    parser.add_argument("--min-source-artifact-count", type=int, default=2)
+    parser.add_argument("--min-explanation-adequacy-rate", type=float, default=0.8)
+    parser.add_argument("--min-source-artifact-count", type=int, default=1)
     parser.add_argument("--min-review-ranking-sample-count", type=int, default=10)
     parser.add_argument("--max-expected-calibration-error", type=float, default=0.05)
     parser.add_argument("--min-distinct-ranking-goals", type=int, default=3)
@@ -171,7 +188,7 @@ def _thresholds_from_args(
         min_selection_reviewer_count=args.min_selection_reviewer_count,
         min_mean_precision=args.min_mean_precision,
         min_mean_recall=args.min_mean_recall,
-        min_mean_explanation_quality=args.min_mean_explanation_quality,
+        min_explanation_adequacy_rate=args.min_explanation_adequacy_rate,
         min_source_artifact_count=args.min_source_artifact_count,
         min_review_ranking_sample_count=args.min_review_ranking_sample_count,
         max_expected_calibration_error=args.max_expected_calibration_error,

--- a/scripts/build_evidence_selection_shadow_review_study_batch.py
+++ b/scripts/build_evidence_selection_shadow_review_study_batch.py
@@ -80,8 +80,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         "--allow-failed-gate",
         action="store_true",
         help=(
-            "Return success after writing reports even if an entry or suite gate "
-            "fails."
+            "Return success after writing reports even if an entry or suite gate fails."
         ),
     )
     _add_gate_threshold_args(parser)
@@ -331,8 +330,8 @@ def _add_gate_threshold_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--min-selection-reviewer-count", type=int, default=1)
     parser.add_argument("--min-mean-precision", type=float, default=0.8)
     parser.add_argument("--min-mean-recall", type=float, default=0.8)
-    parser.add_argument("--min-mean-explanation-quality", type=float, default=3.0)
-    parser.add_argument("--min-source-artifact-count", type=int, default=2)
+    parser.add_argument("--min-explanation-adequacy-rate", type=float, default=0.8)
+    parser.add_argument("--min-source-artifact-count", type=int, default=1)
     parser.add_argument("--min-review-ranking-sample-count", type=int, default=2)
     parser.add_argument("--max-expected-calibration-error", type=float, default=0.05)
     parser.add_argument("--min-distinct-ranking-goals", type=int, default=1)
@@ -344,9 +343,9 @@ def _add_gate_threshold_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--min-batch-mean-precision", type=float, default=0.8)
     parser.add_argument("--min-batch-mean-recall", type=float, default=0.8)
     parser.add_argument(
-        "--min-batch-mean-explanation-quality",
+        "--min-batch-explanation-adequacy-rate",
         type=float,
-        default=3.0,
+        default=0.8,
     )
     parser.add_argument(
         "--max-batch-expected-calibration-error",
@@ -379,7 +378,7 @@ def _thresholds_from_args(
         min_selection_reviewer_count=args.min_selection_reviewer_count,
         min_mean_precision=args.min_mean_precision,
         min_mean_recall=args.min_mean_recall,
-        min_mean_explanation_quality=args.min_mean_explanation_quality,
+        min_explanation_adequacy_rate=args.min_explanation_adequacy_rate,
         min_source_artifact_count=args.min_source_artifact_count,
         min_review_ranking_sample_count=args.min_review_ranking_sample_count,
         max_expected_calibration_error=args.max_expected_calibration_error,
@@ -398,13 +397,11 @@ def _suite_thresholds_from_args(
         min_passed_entry_rate=args.min_batch_passed_entry_rate,
         min_suite_mean_precision=args.min_batch_mean_precision,
         min_suite_mean_recall=args.min_batch_mean_recall,
-        min_suite_mean_explanation_quality=args.min_batch_mean_explanation_quality,
+        min_suite_explanation_adequacy_rate=(args.min_batch_explanation_adequacy_rate),
         max_suite_expected_calibration_error=(
             args.max_batch_expected_calibration_error
         ),
-        min_total_selection_review_count=(
-            args.min_batch_total_selection_review_count
-        ),
+        min_total_selection_review_count=(args.min_batch_total_selection_review_count),
         min_total_review_ranking_decision_count=(
             args.min_batch_total_review_ranking_decision_count
         ),
@@ -457,12 +454,15 @@ def _suite_gate_summary_rows(report: JSONObject) -> list[str]:
         ("passed_entry_count", "Passed entries"),
         ("failed_entry_count", "Failed entries"),
         ("passed_entry_rate", "Passed-entry rate"),
-        ("suite_mean_precision", "Suite mean precision"),
-        ("suite_mean_recall", "Suite mean recall"),
-        ("suite_mean_explanation_quality", "Suite explanation quality"),
+        ("suite_mean_precision", "Passed-entry production mean precision"),
+        ("suite_mean_recall", "Passed-entry production mean recall"),
+        (
+            "suite_explanation_adequacy_rate",
+            "Passed-entry production explanation adequacy rate",
+        ),
         (
             "max_review_ranking_expected_calibration_error",
-            "Max ranking ECE",
+            "Passed-entry production max ranking ECE",
         ),
         ("total_selection_review_count", "Total selection reviews"),
         (
@@ -475,10 +475,41 @@ def _suite_gate_summary_rows(report: JSONObject) -> list[str]:
         ("distinct_review_ranking_goal_count", "Distinct ranking goals"),
         ("distinct_evidence_shape_count", "Distinct evidence shapes"),
     )
-    return [
+    rows = [
         f"| {_table_text(label)} | {_table_text(summary.get(key))} |"
         for key, label in labels
         if key in summary
+    ]
+    rows.extend(
+        _quality_view_rows(
+            summary=summary,
+            key="all_entry_observed_quality",
+            label_prefix="All-entry observed",
+        ),
+    )
+    return rows
+
+
+def _quality_view_rows(
+    *,
+    summary: Mapping[str, object],
+    key: str,
+    label_prefix: str,
+) -> list[str]:
+    quality = summary.get(key)
+    if not isinstance(quality, dict):
+        return []
+    labels = (
+        ("suite_mean_precision", "mean precision"),
+        ("suite_mean_recall", "mean recall"),
+        ("suite_explanation_adequacy_rate", "explanation adequacy rate"),
+        ("max_review_ranking_expected_calibration_error", "max ranking ECE"),
+    )
+    return [
+        f"| {_table_text(f'{label_prefix} {label}')} | "
+        f"{_table_text(quality.get(metric))} |"
+        for metric, label in labels
+        if metric in quality
     ]
 
 
@@ -517,10 +548,9 @@ def _table_text(value: object) -> str:
 
 
 def _source_path_label(*, source_path: Path, manifest_path: Path | None) -> str:
-    if (
-        manifest_path is not None
-        and source_path.resolve(strict=False) == manifest_path.resolve(strict=False)
-    ):
+    if manifest_path is not None and source_path.resolve(
+        strict=False
+    ) == manifest_path.resolve(strict=False):
         return "manifest"
     return "source packet"
 

--- a/scripts/build_evidence_selection_shadow_review_study_batch_manifest.py
+++ b/scripts/build_evidence_selection_shadow_review_study_batch_manifest.py
@@ -65,14 +65,24 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--adjudication-note",
-        required=True,
-        help="Human adjudication note applied to each batch entry.",
+        default=None,
+        help="Required when any packet is selection_and_review_ranking.",
     )
     parser.add_argument("--source-system", required=True)
     parser.add_argument("--export-id-prefix", required=True)
     parser.add_argument("--exported-at", required=True)
     parser.add_argument("--exporter-id", required=True)
     parser.add_argument("--redaction-statement", required=True)
+    parser.add_argument(
+        "--study-evidence-kind",
+        choices=(
+            "real_shadow_review",
+            "ai_reviewer_simulation",
+            "synthetic_fixture",
+        ),
+        required=True,
+        help="Explicit origin of the review labels in every packet.",
+    )
     parser.add_argument("--description", default=None)
     return parser.parse_args(argv)
 
@@ -110,6 +120,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 exported_at=args.exported_at,
                 exporter_id=args.exporter_id,
                 redaction_statement=args.redaction_statement,
+                study_evidence_kind=args.study_evidence_kind,
                 description=args.description,
             ),
         )
@@ -132,7 +143,9 @@ def _validate_output_path(*, output_path: Path, packet_paths: tuple[Path, ...]) 
             msg = "Batch manifest output must not overwrite source packet."
             raise ValueError(msg)
     if output_path.exists() and output_path.is_dir():
-        msg = f"Batch manifest output must be a file path, not a directory: {output_path}"
+        msg = (
+            f"Batch manifest output must be a file path, not a directory: {output_path}"
+        )
         raise ValueError(msg)
     output_parent = output_path.parent
     if output_parent.exists() and not output_parent.is_dir():

--- a/scripts/build_evidence_selection_source_exports.py
+++ b/scripts/build_evidence_selection_source_exports.py
@@ -21,8 +21,10 @@ from artana_evidence_api.evidence_selection.cli_errors import (
     cli_error_message,  # noqa: E402
 )
 from artana_evidence_api.evidence_selection.source_export_writer import (  # noqa: E402
+    EvidenceSelectionReviewExportWriteRequest,
     EvidenceSelectionSourceExportWriteRequest,
     EvidenceSelectionSourceExportWriterError,
+    write_evidence_selection_review_export,
     write_evidence_selection_source_exports,
 )
 
@@ -32,9 +34,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(
         description=(
-            "Build self-describing selection-review and review-ranking source "
-            "exports for an evidence-selection expert/shadow study."
+            "Build self-describing source exports for a selection-only or "
+            "selection-and-review-ranking expert/shadow study."
         ),
+    )
+    parser.add_argument(
+        "--study-type",
+        choices=("selection_relevance", "selection_and_review_ranking"),
+        required=True,
     )
     parser.add_argument(
         "--selection-reviews",
@@ -45,8 +52,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--review-ranking",
         type=Path,
-        required=True,
-        help="JSON review-ranking calibration study input.",
+        default=None,
+        help="Required only for selection_and_review_ranking studies.",
     )
     parser.add_argument(
         "--selection-export-output",
@@ -57,8 +64,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--review-ranking-export-output",
         type=Path,
-        required=True,
-        help="Output path for the self-describing review-ranking export.",
+        default=None,
+        help="Required only for selection_and_review_ranking studies.",
     )
     parser.add_argument("--source-system", required=True)
     parser.add_argument("--export-id", required=True)
@@ -77,12 +84,33 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     args = parse_args(argv)
     try:
-        result = write_evidence_selection_source_exports(
-            EvidenceSelectionSourceExportWriteRequest(
+        selection_review_count, review_ranking_decision_count = _write_exports(args)
+    except (EvidenceSelectionSourceExportWriterError, ValidationError) as exc:
+        print(f"error: {cli_error_message(exc)}", file=sys.stderr)
+        return 1
+    print(
+        "evidence_selection_source_exports "
+        f"selection_reviews={selection_review_count} "
+        f"review_ranking_decisions={review_ranking_decision_count}",
+    )
+    print(f"Wrote selection-review export: {args.selection_export_output}")
+    if args.review_ranking_export_output is not None:
+        print(f"Wrote review-ranking export: {args.review_ranking_export_output}")
+    return 0
+
+
+def _write_exports(args: argparse.Namespace) -> tuple[int, int]:
+    if args.study_type == "selection_relevance":
+        if (
+            args.review_ranking is not None
+            or args.review_ranking_export_output is not None
+        ):
+            msg = "selection_relevance studies must not set review-ranking paths."
+            raise EvidenceSelectionSourceExportWriterError(msg)
+        selection_result = write_evidence_selection_review_export(
+            EvidenceSelectionReviewExportWriteRequest(
                 selection_reviews_path=args.selection_reviews,
-                review_ranking_path=args.review_ranking,
                 selection_export_path=args.selection_export_output,
-                review_ranking_export_path=args.review_ranking_export_output,
                 source_system=args.source_system,
                 export_id=args.export_id,
                 exported_at=args.exported_at,
@@ -90,17 +118,30 @@ def main(argv: Sequence[str] | None = None) -> int:
                 redaction_statement=args.redaction_statement,
             ),
         )
-    except (EvidenceSelectionSourceExportWriterError, ValidationError) as exc:
-        print(f"error: {cli_error_message(exc)}", file=sys.stderr)
-        return 1
-    print(
-        "evidence_selection_source_exports "
-        f"selection_reviews={result.selection_review_count} "
-        f"review_ranking_decisions={result.review_ranking_decision_count}",
+        return selection_result.selection_review_count, 0
+    if args.review_ranking is None or args.review_ranking_export_output is None:
+        msg = (
+            "selection_and_review_ranking studies require --review-ranking and "
+            "--review-ranking-export-output."
+        )
+        raise EvidenceSelectionSourceExportWriterError(msg)
+    combined_result = write_evidence_selection_source_exports(
+        EvidenceSelectionSourceExportWriteRequest(
+            selection_reviews_path=args.selection_reviews,
+            review_ranking_path=args.review_ranking,
+            selection_export_path=args.selection_export_output,
+            review_ranking_export_path=args.review_ranking_export_output,
+            source_system=args.source_system,
+            export_id=args.export_id,
+            exported_at=args.exported_at,
+            exporter_id=args.exporter_id,
+            redaction_statement=args.redaction_statement,
+        ),
     )
-    print(f"Wrote selection-review export: {result.selection_export_path}")
-    print(f"Wrote review-ranking export: {result.review_ranking_export_path}")
-    return 0
+    return (
+        combined_result.selection_review_count,
+        combined_result.review_ranking_decision_count,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/run_evidence_selection_expert_study_gate.py
+++ b/scripts/run_evidence_selection_expert_study_gate.py
@@ -39,8 +39,8 @@ class EvidenceSelectionExpertStudyRunnerThresholds:
     min_selection_reviewer_count: int = 1
     min_mean_precision: float = 0.8
     min_mean_recall: float = 0.8
-    min_mean_explanation_quality: float = 3.0
-    min_source_artifact_count: int = 2
+    min_explanation_adequacy_rate: float = 0.8
+    min_source_artifact_count: int = 1
     min_review_ranking_sample_count: int = 10
     max_expected_calibration_error: float = 0.05
     min_distinct_ranking_goals: int = 3
@@ -64,7 +64,9 @@ def build_evidence_selection_expert_study_gate_report(
         min_selection_reviewer_count=active_thresholds.min_selection_reviewer_count,
         min_mean_precision=active_thresholds.min_mean_precision,
         min_mean_recall=active_thresholds.min_mean_recall,
-        min_mean_explanation_quality=active_thresholds.min_mean_explanation_quality,
+        min_explanation_adequacy_rate=(
+            active_thresholds.min_explanation_adequacy_rate
+        ),
         min_source_artifact_count=active_thresholds.min_source_artifact_count,
     )
     ranking_thresholds = ReviewRankingCalibrationGateThresholds(
@@ -121,12 +123,14 @@ def render_evidence_selection_expert_study_gate_markdown(report: JSONObject) -> 
         f"{selection_summary.get('unmeasurable_precision_count')}",
         "- unmeasurable_recall_count: "
         f"{selection_summary.get('unmeasurable_recall_count')}",
-        "- missing_explanation_quality_count: "
-        f"{selection_summary.get('missing_explanation_quality_count')}",
+        "- missing_explanation_assessment_count: "
+        f"{selection_summary.get('missing_explanation_assessment_count')}",
         f"- mean_precision: {selection_summary.get('mean_precision')}",
         f"- mean_recall: {selection_summary.get('mean_recall')}",
-        "- mean_explanation_quality: "
-        f"{selection_summary.get('mean_explanation_quality')}",
+        "- explanation_adequacy_counts: "
+        f"{selection_summary.get('explanation_adequacy_counts')}",
+        "- explanation_adequacy_rate: "
+        f"{selection_summary.get('explanation_adequacy_rate')}",
         "- high_severity_overclaim_count: "
         f"{selection_summary.get('high_severity_overclaim_count')}",
         "- duplicate_suggestion_count: "
@@ -154,20 +158,24 @@ def render_evidence_selection_expert_study_gate_markdown(report: JSONObject) -> 
         f"{provenance_summary.get('reviewer_roster_count')}",
         "- unknown_reviewer_id_count: "
         f"{provenance_summary.get('unknown_reviewer_id_count')}",
-        "",
-        "## Review-Ranking Calibration",
-        "",
-        f"- status: {ranking_gate.get('status')}",
-        f"- sample_count: {ranking_calibration.get('sample_count')}",
-        "- expected_calibration_error: "
-        f"{ranking_calibration.get('expected_calibration_error')}",
-        f"- distinct_goal_count: {ranking_design.get('distinct_goal_count')}",
-        "- distinct_evidence_shape_count: "
-        f"{ranking_design.get('distinct_evidence_shape_count')}",
-        "",
-        "## Blocking Reasons",
-        "",
     ]
+    lines.extend(["", "## Review-Ranking Calibration", ""])
+    if gate.get("review_ranking_gate") is None:
+        lines.append("- not applicable for selection_relevance studies")
+    else:
+        lines.extend(
+            [
+                f"- status: {ranking_gate.get('status')}",
+                f"- sample_count: {ranking_calibration.get('sample_count')}",
+                "- expected_calibration_error: "
+                f"{ranking_calibration.get('expected_calibration_error')}",
+                "- distinct_goal_count: "
+                f"{ranking_design.get('distinct_goal_count')}",
+                "- distinct_evidence_shape_count: "
+                f"{ranking_design.get('distinct_evidence_shape_count')}",
+            ],
+        )
+    lines.extend(["", "## Blocking Reasons", ""])
     if blocking_reasons:
         lines.extend(f"- {reason}" for reason in blocking_reasons)
     else:
@@ -241,15 +249,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help="Minimum mean selection recall required for the study gate.",
     )
     parser.add_argument(
-        "--min-mean-explanation-quality",
+        "--min-explanation-adequacy-rate",
         type=float,
-        default=3.0,
-        help="Minimum mean explanation-quality score required for the study gate.",
+        default=0.8,
+        help="Minimum deterministically derived explanation-adequacy rate.",
     )
     parser.add_argument(
         "--min-source-artifact-count",
         type=int,
-        default=2,
+        default=1,
         help="Minimum source artifacts required for the study provenance gate.",
     )
     parser.add_argument(
@@ -298,7 +306,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         min_selection_reviewer_count=args.min_selection_reviewer_count,
         min_mean_precision=args.min_mean_precision,
         min_mean_recall=args.min_mean_recall,
-        min_mean_explanation_quality=args.min_mean_explanation_quality,
+        min_explanation_adequacy_rate=args.min_explanation_adequacy_rate,
         min_source_artifact_count=args.min_source_artifact_count,
         min_review_ranking_sample_count=args.min_review_ranking_sample_count,
         max_expected_calibration_error=args.max_expected_calibration_error,

--- a/services/artana_evidence_api/evidence_selection/provenance.py
+++ b/services/artana_evidence_api/evidence_selection/provenance.py
@@ -26,13 +26,6 @@ _SOURCE_ARTIFACT_KINDS: tuple[EvidenceSelectionExpertStudySourceArtifactKind, ..
     "review_ranking_export",
     "adjudication_log",
 )
-_REQUIRED_SOURCE_ARTIFACT_KINDS: tuple[
-    EvidenceSelectionExpertStudySourceArtifactKind,
-    ...,
-] = (
-    "selection_review_export",
-    "review_ranking_export",
-)
 
 
 def validate_source_identity_text(value: str) -> str:
@@ -66,16 +59,15 @@ def parse_canonical_source_exported_at(
         isinstance(value, str)
         and _CANONICAL_SOURCE_EXPORTED_AT_RE.fullmatch(value) is None
     ):
-        msg = (
-            f"{field_name} must use canonical UTC format "
-            f"{SOURCE_EXPORTED_AT_FORMAT}."
-        )
+        msg = f"{field_name} must use canonical UTC format {SOURCE_EXPORTED_AT_FORMAT}."
         raise ValueError(msg)
     return parsed.astimezone(UTC)
 
 
 def _parse_source_exported_at_string(*, value: str, field_name: str) -> datetime:
-    normalized_value = value.removesuffix("Z") + "+00:00" if value.endswith("Z") else value
+    normalized_value = (
+        value.removesuffix("Z") + "+00:00" if value.endswith("Z") else value
+    )
     try:
         return datetime.fromisoformat(normalized_value)
     except ValueError as exc:
@@ -158,7 +150,9 @@ class EvidenceSelectionExpertStudySourceManifest(BaseModel):
     @classmethod
     def _accept_json_run_id_array(cls, value: object) -> object:
         if isinstance(value, list):
-            return tuple(UUID(item) if isinstance(item, str) else item for item in value)
+            return tuple(
+                UUID(item) if isinstance(item, str) else item for item in value
+            )
         return value
 
     @field_validator("reviewer_roster")
@@ -182,6 +176,7 @@ def build_evidence_selection_provenance_summary(
     selection_run_ids: tuple[UUID, ...],
     review_ranking_decision_keys: tuple[str, ...],
     reviewer_ids: set[str],
+    require_review_ranking: bool = True,
 ) -> JSONObject:
     """Return stable provenance metrics for a study source manifest."""
 
@@ -200,16 +195,16 @@ def build_evidence_selection_provenance_summary(
                 duplicate_review_ranking_decision_keys
             ),
             expected_reviewer_ids=reviewer_ids,
+            require_review_ranking=require_review_ranking,
         )
     return _present_source_manifest_summary(
         source_manifest=source_manifest,
         expected_selection_run_id_set=expected_selection_run_id_set,
         duplicate_selection_run_ids=duplicate_selection_run_ids,
         expected_decision_key_set=expected_decision_key_set,
-        duplicate_review_ranking_decision_keys=(
-            duplicate_review_ranking_decision_keys
-        ),
+        duplicate_review_ranking_decision_keys=(duplicate_review_ranking_decision_keys),
         expected_reviewer_ids=reviewer_ids,
+        require_review_ranking=require_review_ranking,
     )
 
 
@@ -218,6 +213,7 @@ def source_manifest_blocking_reasons(
     provenance_summary: JSONObject,
     require_source_manifest: bool,
     min_source_artifact_count: int,
+    require_review_ranking: bool = True,
 ) -> tuple[str, ...]:
     """Return fail-closed reasons for source-manifest provenance gaps."""
 
@@ -243,7 +239,8 @@ def source_manifest_blocking_reasons(
         ),
     )
     reasons.extend(_source_selection_blocking_reasons(provenance_summary))
-    reasons.extend(_source_ranking_blocking_reasons(provenance_summary))
+    if require_review_ranking:
+        reasons.extend(_source_ranking_blocking_reasons(provenance_summary))
     if _int_from_json(provenance_summary, "unknown_reviewer_id_count") > 0:
         reasons.append(
             "Every study reviewer ID must be present in the source manifest "
@@ -259,6 +256,7 @@ def _missing_source_manifest_summary(
     expected_decision_keys: set[str],
     duplicate_review_ranking_decision_keys: tuple[str, ...],
     expected_reviewer_ids: set[str],
+    require_review_ranking: bool,
 ) -> JSONObject:
     return {
         "source_manifest_present": False,
@@ -269,7 +267,9 @@ def _missing_source_manifest_summary(
         "artifact_count": 0,
         "source_artifact_kind_counts": _empty_source_artifact_kind_counts(),
         "missing_required_source_artifact_kinds": list(
-            _REQUIRED_SOURCE_ARTIFACT_KINDS,
+            _required_source_artifact_kinds(
+                require_review_ranking=require_review_ranking,
+            ),
         ),
         "duplicate_source_artifact_id_count": 0,
         "duplicate_source_artifact_uri_count": 0,
@@ -311,6 +311,7 @@ def _present_source_manifest_summary(
     expected_decision_key_set: set[str],
     duplicate_review_ranking_decision_keys: tuple[str, ...],
     expected_reviewer_ids: set[str],
+    require_review_ranking: bool,
 ) -> JSONObject:
     manifest_selection_run_ids = set(source_manifest.selection_review_run_ids)
     manifest_decision_keys = set(source_manifest.review_ranking_decision_keys)
@@ -341,7 +342,9 @@ def _present_source_manifest_summary(
         "source_artifact_kind_counts": dict(artifact_kind_counts),
         "missing_required_source_artifact_kinds": [
             artifact_kind
-            for artifact_kind in _REQUIRED_SOURCE_ARTIFACT_KINDS
+            for artifact_kind in _required_source_artifact_kinds(
+                require_review_ranking=require_review_ranking,
+            )
             if artifact_kind_counts[artifact_kind] == 0
         ],
         "duplicate_source_artifact_id_count": len(_duplicate_strings(artifact_ids)),
@@ -411,7 +414,9 @@ def _present_source_manifest_summary(
         "reviewer_roster_count": len(manifest_reviewer_ids),
         "unknown_reviewer_id_count": len(expected_reviewer_ids - manifest_reviewer_ids),
         "unknown_reviewer_ids": sorted(expected_reviewer_ids - manifest_reviewer_ids),
-        "redaction_statement_present": bool(source_manifest.redaction_statement.strip()),
+        "redaction_statement_present": bool(
+            source_manifest.redaction_statement.strip()
+        ),
     }
 
 
@@ -443,6 +448,15 @@ def _source_artifact_blocking_reasons(
     if _int_from_json(provenance_summary, "duplicate_source_artifact_sha256_count") > 0:
         reasons.append("Source artifact SHA-256 hashes must be unique.")
     return tuple(reasons)
+
+
+def _required_source_artifact_kinds(
+    *,
+    require_review_ranking: bool,
+) -> tuple[EvidenceSelectionExpertStudySourceArtifactKind, ...]:
+    if require_review_ranking:
+        return ("selection_review_export", "review_ranking_export")
+    return ("selection_review_export",)
 
 
 def _source_selection_blocking_reasons(

--- a/services/artana_evidence_api/evidence_selection/provenance.py
+++ b/services/artana_evidence_api/evidence_selection/provenance.py
@@ -213,7 +213,6 @@ def source_manifest_blocking_reasons(
     provenance_summary: JSONObject,
     require_source_manifest: bool,
     min_source_artifact_count: int,
-    require_review_ranking: bool = True,
 ) -> tuple[str, ...]:
     """Return fail-closed reasons for source-manifest provenance gaps."""
 
@@ -239,8 +238,7 @@ def source_manifest_blocking_reasons(
         ),
     )
     reasons.extend(_source_selection_blocking_reasons(provenance_summary))
-    if require_review_ranking:
-        reasons.extend(_source_ranking_blocking_reasons(provenance_summary))
+    reasons.extend(_source_ranking_blocking_reasons(provenance_summary))
     if _int_from_json(provenance_summary, "unknown_reviewer_id_count") > 0:
         reasons.append(
             "Every study reviewer ID must be present in the source manifest "

--- a/services/artana_evidence_api/evidence_selection/review/__init__.py
+++ b/services/artana_evidence_api/evidence_selection/review/__init__.py
@@ -1,0 +1,1 @@
+"""Human-review contracts for evidence-selection studies."""

--- a/services/artana_evidence_api/evidence_selection/review/assessment.py
+++ b/services/artana_evidence_api/evidence_selection/review/assessment.py
@@ -125,6 +125,7 @@ class EvidenceSelectionReviewInput(BaseModel):
     run_id: UUID
     goal: str
     reviewer_id: str | None = None
+    candidate_record_ids: tuple[str, ...]
     harness_selected_record_ids: tuple[str, ...]
     human_selected_record_ids: tuple[str, ...]
     harness_skipped_record_ids: tuple[str, ...] = ()
@@ -145,6 +146,7 @@ class EvidenceSelectionReviewInput(BaseModel):
         return value
 
     @field_validator(
+        "candidate_record_ids",
         "harness_selected_record_ids",
         "human_selected_record_ids",
         "harness_skipped_record_ids",
@@ -159,6 +161,7 @@ class EvidenceSelectionReviewInput(BaseModel):
         return value
 
     @field_validator(
+        "candidate_record_ids",
         "harness_selected_record_ids",
         "human_selected_record_ids",
         "harness_skipped_record_ids",
@@ -193,6 +196,9 @@ class EvidenceSelectionReviewInput(BaseModel):
 
     @model_validator(mode="after")
     def _selected_and_skipped_must_not_overlap(self) -> EvidenceSelectionReviewInput:
+        if len(set(self.candidate_record_ids)) != len(self.candidate_record_ids):
+            msg = "candidate_record_ids must be unique."
+            raise ValueError(msg)
         overlap = set(self.harness_selected_record_ids).intersection(
             self.harness_skipped_record_ids,
         )
@@ -217,6 +223,26 @@ class EvidenceSelectionReviewInput(BaseModel):
             msg = (
                 "High-severity overclaim findings require "
                 "unsupported_material_claim_present to be yes."
+            )
+            raise ValueError(msg)
+        referenced_record_ids = {
+            *self.harness_selected_record_ids,
+            *self.harness_skipped_record_ids,
+        }
+        referenced_record_ids.update(self.human_selected_record_ids)
+        referenced_record_ids.update(self.duplicate_suggestion_ids)
+        referenced_record_ids.update(_review_evidence_record_ids(self))
+        if self.false_positive_notes is not None:
+            referenced_record_ids.update(self.false_positive_notes)
+        if self.false_negative_notes is not None:
+            referenced_record_ids.update(self.false_negative_notes)
+        unknown_record_ids = referenced_record_ids.difference(
+            self.candidate_record_ids,
+        )
+        if unknown_record_ids:
+            msg = (
+                "Review references unknown candidate record IDs: "
+                f"{', '.join(sorted(unknown_record_ids))}."
             )
             raise ValueError(msg)
         return self
@@ -317,6 +343,26 @@ def _safe_ratio(numerator: int, denominator: int) -> float | None:
     if denominator == 0:
         return None
     return numerator / denominator
+
+
+def _review_evidence_record_ids(review: EvidenceSelectionReviewInput) -> set[str]:
+    record_ids: set[str] = set()
+    if review.explanation_assessment is not None:
+        record_ids.update(
+            citation.record_id
+            for citation in review.explanation_assessment.cited_evidence
+        )
+    if review.high_severity_overclaim_findings is not None:
+        record_ids.update(
+            finding.record_id
+            for finding in review.high_severity_overclaim_findings
+        )
+        record_ids.update(
+            citation.record_id
+            for finding in review.high_severity_overclaim_findings
+            for citation in finding.cited_evidence
+        )
+    return record_ids
 
 
 __all__ = [

--- a/services/artana_evidence_api/evidence_selection/review/assessment.py
+++ b/services/artana_evidence_api/evidence_selection/review/assessment.py
@@ -1,0 +1,333 @@
+"""Categorical human-review findings for evidence-selection explanations."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+BinaryReviewFinding = Literal["yes", "no"]
+CitationEntailmentFinding = Literal["yes", "no", "unclear"]
+ExplanationAdequacy = Literal["adequate", "inadequate", "unclear"]
+
+
+class EvidenceSelectionReviewCitation(BaseModel):
+    """Literal source evidence cited by a reviewer."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    record_id: str = Field(min_length=1)
+    source_locator: str = Field(min_length=1)
+    quoted_text: str = Field(min_length=1)
+
+    @field_validator("record_id", "source_locator", "quoted_text")
+    @classmethod
+    def _reject_blank_text(cls, value: str) -> str:
+        if not value.strip():
+            msg = "Review citation fields must not be blank."
+            raise ValueError(msg)
+        return value
+
+
+class EvidenceSelectionExplanationAssessment(BaseModel):
+    """Atomic reviewer findings from which explanation adequacy is derived."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    literal_citation_present: BinaryReviewFinding
+    citation_entails_claim: CitationEntailmentFinding
+    all_required_criteria_addressed: BinaryReviewFinding
+    unsupported_material_claim_present: BinaryReviewFinding
+    cited_evidence: tuple[EvidenceSelectionReviewCitation, ...]
+    reviewer_explanation: str = Field(min_length=1)
+
+    @field_validator("cited_evidence", mode="before")
+    @classmethod
+    def _accept_json_citation_array(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("reviewer_explanation")
+    @classmethod
+    def _reject_blank_explanation(cls, value: str) -> str:
+        if not value.strip():
+            msg = "reviewer_explanation must not be blank."
+            raise ValueError(msg)
+        return value
+
+    @model_validator(mode="after")
+    def _citation_findings_must_match_evidence(self) -> Self:
+        if self.literal_citation_present == "yes" and not self.cited_evidence:
+            msg = "cited_evidence is required when a literal citation is present."
+            raise ValueError(msg)
+        if self.literal_citation_present == "no" and self.cited_evidence:
+            msg = "cited_evidence must be empty when no literal citation is present."
+            raise ValueError(msg)
+        if (
+            self.literal_citation_present == "no"
+            and self.citation_entails_claim != "unclear"
+        ):
+            msg = "citation_entails_claim must be unclear when no citation is present."
+            raise ValueError(msg)
+        return self
+
+
+class EvidenceSelectionOverclaimFinding(BaseModel):
+    """One material unsupported claim identified by a reviewer."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    record_id: str = Field(min_length=1)
+    material_claim: str = Field(min_length=1)
+    reviewer_explanation: str = Field(min_length=1)
+    cited_evidence: tuple[EvidenceSelectionReviewCitation, ...] = ()
+
+    @field_validator("cited_evidence", mode="before")
+    @classmethod
+    def _accept_json_citation_array(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("record_id", "material_claim", "reviewer_explanation")
+    @classmethod
+    def _reject_blank_text(cls, value: str) -> str:
+        if not value.strip():
+            msg = "Overclaim finding fields must not be blank."
+            raise ValueError(msg)
+        return value
+
+
+def derive_explanation_adequacy(
+    assessment: EvidenceSelectionExplanationAssessment,
+) -> ExplanationAdequacy:
+    """Derive a stable category without accepting a reviewer-authored score."""
+
+    if (
+        assessment.literal_citation_present == "no"
+        or assessment.citation_entails_claim == "no"
+        or assessment.all_required_criteria_addressed == "no"
+        or assessment.unsupported_material_claim_present == "yes"
+    ):
+        return "inadequate"
+    if assessment.citation_entails_claim == "unclear":
+        return "unclear"
+    return "adequate"
+
+
+class EvidenceSelectionReviewInput(BaseModel):
+    """Reviewer-labeled comparison input for one evidence-selection run."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    run_id: UUID
+    goal: str
+    reviewer_id: str | None = None
+    harness_selected_record_ids: tuple[str, ...]
+    human_selected_record_ids: tuple[str, ...]
+    harness_skipped_record_ids: tuple[str, ...] = ()
+    duplicate_suggestion_ids: tuple[str, ...] = ()
+    explanation_assessment: EvidenceSelectionExplanationAssessment | None = None
+    high_severity_overclaim_findings: (
+        tuple[EvidenceSelectionOverclaimFinding, ...] | None
+    ) = None
+    reviewer_notes: str | None = None
+    false_positive_notes: dict[str, str] | None = None
+    false_negative_notes: dict[str, str] | None = None
+
+    @field_validator("run_id", mode="before")
+    @classmethod
+    def _accept_json_run_id(cls, value: object) -> object:
+        if isinstance(value, str):
+            return UUID(value)
+        return value
+
+    @field_validator(
+        "harness_selected_record_ids",
+        "human_selected_record_ids",
+        "harness_skipped_record_ids",
+        "duplicate_suggestion_ids",
+        "high_severity_overclaim_findings",
+        mode="before",
+    )
+    @classmethod
+    def _accept_json_record_id_array(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator(
+        "harness_selected_record_ids",
+        "human_selected_record_ids",
+        "harness_skipped_record_ids",
+        "duplicate_suggestion_ids",
+    )
+    @classmethod
+    def _normalize_record_ids(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(record_id.strip() for record_id in value)
+        if any(record_id == "" for record_id in normalized):
+            msg = "record IDs must not be blank"
+            raise ValueError(msg)
+        return normalized
+
+    @field_validator("false_positive_notes", "false_negative_notes")
+    @classmethod
+    def _normalize_finding_notes(
+        cls,
+        value: dict[str, str] | None,
+    ) -> dict[str, str] | None:
+        if value is None:
+            return None
+        normalized = {
+            record_id.strip(): note.strip() for record_id, note in value.items()
+        }
+        if any(record_id == "" for record_id in normalized):
+            msg = "finding-note record IDs must not be blank"
+            raise ValueError(msg)
+        if any(note == "" for note in normalized.values()):
+            msg = "finding notes must not be blank"
+            raise ValueError(msg)
+        return normalized
+
+    @model_validator(mode="after")
+    def _selected_and_skipped_must_not_overlap(self) -> EvidenceSelectionReviewInput:
+        overlap = set(self.harness_selected_record_ids).intersection(
+            self.harness_skipped_record_ids,
+        )
+        if overlap:
+            msg = "harness_selected_record_ids and harness_skipped_record_ids overlap"
+            raise ValueError(msg)
+        if (
+            self.explanation_assessment is not None
+            and self.explanation_assessment.unsupported_material_claim_present == "yes"
+            and not self.high_severity_overclaim_findings
+        ):
+            msg = (
+                "Unsupported material claims require at least one explicit "
+                "high-severity overclaim finding."
+            )
+            raise ValueError(msg)
+        if (
+            self.explanation_assessment is not None
+            and self.explanation_assessment.unsupported_material_claim_present == "no"
+            and self.high_severity_overclaim_findings
+        ):
+            msg = (
+                "High-severity overclaim findings require "
+                "unsupported_material_claim_present to be yes."
+            )
+            raise ValueError(msg)
+        return self
+
+
+class EvidenceSelectionReviewReport(BaseModel):
+    """Computed review metrics for one evidence-selection run."""
+
+    model_config = ConfigDict(strict=True, frozen=True)
+
+    run_id: UUID
+    goal: str
+    true_positive_ids: tuple[str, ...]
+    false_positive_ids: tuple[str, ...]
+    false_negative_ids: tuple[str, ...]
+    confirmed_skip_ids: tuple[str, ...]
+    duplicate_suggestion_ids: tuple[str, ...]
+    precision: float | None
+    recall: float | None
+    duplicate_suggestion_count: int
+    explanation_assessment: EvidenceSelectionExplanationAssessment | None
+    explanation_adequacy: ExplanationAdequacy | None
+    high_severity_overclaim_findings: (
+        tuple[EvidenceSelectionOverclaimFinding, ...] | None
+    )
+    high_severity_overclaim_count: int | None
+    overclaim_gate_passed: bool
+    reviewer_id: str | None
+    reviewer_notes: str | None
+    false_positive_notes: dict[str, str] | None
+    false_negative_notes: dict[str, str] | None
+
+
+def compare_evidence_selection_review(
+    review: EvidenceSelectionReviewInput,
+) -> EvidenceSelectionReviewReport:
+    """Compare harness-selected records with reviewer-selected records."""
+
+    harness_selected = tuple(dict.fromkeys(review.harness_selected_record_ids))
+    human_selected = tuple(dict.fromkeys(review.human_selected_record_ids))
+    harness_skipped = tuple(dict.fromkeys(review.harness_skipped_record_ids))
+    duplicate_suggestions = tuple(dict.fromkeys(review.duplicate_suggestion_ids))
+    harness_selected_set = set(harness_selected)
+    human_selected_set = set(human_selected)
+    true_positive_ids = tuple(
+        record_id for record_id in harness_selected if record_id in human_selected_set
+    )
+    false_positive_ids = tuple(
+        record_id
+        for record_id in harness_selected
+        if record_id not in human_selected_set
+    )
+    false_negative_ids = tuple(
+        record_id
+        for record_id in human_selected
+        if record_id not in harness_selected_set
+    )
+    confirmed_skip_ids = tuple(
+        record_id
+        for record_id in harness_skipped
+        if record_id not in human_selected_set
+    )
+    return EvidenceSelectionReviewReport(
+        run_id=review.run_id,
+        goal=review.goal,
+        true_positive_ids=true_positive_ids,
+        false_positive_ids=false_positive_ids,
+        false_negative_ids=false_negative_ids,
+        confirmed_skip_ids=confirmed_skip_ids,
+        duplicate_suggestion_ids=duplicate_suggestions,
+        precision=_safe_ratio(len(true_positive_ids), len(harness_selected)),
+        recall=_safe_ratio(len(true_positive_ids), len(human_selected)),
+        duplicate_suggestion_count=len(duplicate_suggestions),
+        explanation_assessment=review.explanation_assessment,
+        explanation_adequacy=(
+            derive_explanation_adequacy(review.explanation_assessment)
+            if review.explanation_assessment is not None
+            else None
+        ),
+        high_severity_overclaim_findings=review.high_severity_overclaim_findings,
+        high_severity_overclaim_count=(
+            len(review.high_severity_overclaim_findings)
+            if review.high_severity_overclaim_findings is not None
+            else None
+        ),
+        overclaim_gate_passed=(
+            review.high_severity_overclaim_findings is not None
+            and not review.high_severity_overclaim_findings
+        ),
+        reviewer_id=review.reviewer_id,
+        reviewer_notes=review.reviewer_notes,
+        false_positive_notes=review.false_positive_notes,
+        false_negative_notes=review.false_negative_notes,
+    )
+
+
+def _safe_ratio(numerator: int, denominator: int) -> float | None:
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+__all__ = [
+    "BinaryReviewFinding",
+    "CitationEntailmentFinding",
+    "EvidenceSelectionExplanationAssessment",
+    "EvidenceSelectionOverclaimFinding",
+    "EvidenceSelectionReviewCitation",
+    "EvidenceSelectionReviewInput",
+    "EvidenceSelectionReviewReport",
+    "ExplanationAdequacy",
+    "compare_evidence_selection_review",
+    "derive_explanation_adequacy",
+]

--- a/services/artana_evidence_api/evidence_selection/shadow_review_completion.py
+++ b/services/artana_evidence_api/evidence_selection/shadow_review_completion.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Literal, cast
 from uuid import UUID
 
+from artana_evidence_api.evidence_selection.review.assessment import (
+    EvidenceSelectionExplanationAssessment,
+    EvidenceSelectionOverclaimFinding,
+)
 from artana_evidence_api.evidence_selection.shadow_review_integrity import (
     verify_machine_packet_signature,
 )
@@ -18,6 +22,7 @@ from artana_evidence_api.evidence_selection.shadow_review_packet import (
     machine_packet_digest,
 )
 from artana_evidence_api.evidence_selection_validation import (
+    EvidenceSelectionExpertStudyType,
     EvidenceSelectionReviewInput,
     ReviewRankingCalibrationDecision,
     ReviewRankingCalibrationStudyInput,
@@ -27,11 +32,13 @@ from artana_evidence_api.evidence_selection_validation import (
 from artana_evidence_api.types.common import JSONObject
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-_COMPLETION_REQUIRED_FIELDS = (
+_SELECTION_COMPLETION_REQUIRED_FIELDS = (
     "selection_review_forms[].reviewer_id",
     "selection_review_forms[].human_selected_record_ids",
-    "selection_review_forms[].explanation_quality_score",
-    "selection_review_forms[].high_severity_overclaim_count",
+    "selection_review_forms[].explanation_assessment",
+    "selection_review_forms[].high_severity_overclaim_findings",
+)
+_RANKING_COMPLETION_REQUIRED_FIELDS = (
     "review_ranking_forms[].reviewer_id",
     "review_ranking_forms[].outcome",
 )
@@ -43,7 +50,7 @@ class EvidenceSelectionShadowReviewSourceInputRequest:
 
     machine_packet: JSONObject
     packet: JSONObject
-    adjudication_note: str
+    adjudication_note: str | None = None
     description: str | None = None
 
 
@@ -51,8 +58,10 @@ class EvidenceSelectionShadowReviewSourceInputRequest:
 class EvidenceSelectionShadowReviewSourceInputs:
     """Selection-review labels and review-ranking study input."""
 
+    study_id: str
+    study_type: EvidenceSelectionExpertStudyType
     selection_reviews: tuple[EvidenceSelectionReviewInput, ...]
-    review_ranking: ReviewRankingCalibrationStudyInput
+    review_ranking: ReviewRankingCalibrationStudyInput | None
 
     def selection_reviews_payload(self) -> JSONObject:
         """Return the JSON input expected by the source-export writer."""
@@ -67,6 +76,9 @@ class EvidenceSelectionShadowReviewSourceInputs:
     def review_ranking_payload(self) -> JSONObject:
         """Return the JSON input expected by the source-export writer."""
 
+        if self.review_ranking is None:
+            msg = "Selection-only source inputs do not contain review-ranking data."
+            raise ValueError(msg)
         return cast("JSONObject", self.review_ranking.model_dump(mode="json"))
 
 
@@ -83,8 +95,8 @@ class _CompletedSelectionReviewForm(BaseModel):
     harness_deferred_record_ids: tuple[str, ...] = ()
     human_selected_record_ids: tuple[str, ...]
     duplicate_suggestion_ids: tuple[str, ...] = ()
-    explanation_quality_score: int = Field(ge=1, le=5)
-    high_severity_overclaim_count: int = Field(ge=0)
+    explanation_assessment: EvidenceSelectionExplanationAssessment
+    high_severity_overclaim_findings: tuple[EvidenceSelectionOverclaimFinding, ...]
     reviewer_notes: str | None = Field(default=None, min_length=1)
 
     @field_validator("run_id", mode="before")
@@ -105,6 +117,7 @@ class _CompletedSelectionReviewForm(BaseModel):
         "harness_deferred_record_ids",
         "human_selected_record_ids",
         "duplicate_suggestion_ids",
+        "high_severity_overclaim_findings",
         mode="before",
     )
     @classmethod
@@ -138,8 +151,9 @@ class _CompletedShadowReviewPacket(BaseModel):
 
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
-    schema_version: Literal["evidence_selection_shadow_review_packet.v1"]
+    schema_version: Literal["evidence_selection_shadow_review_packet.v2"]
     study_id: str = Field(min_length=1)
+    study_type: EvidenceSelectionExpertStudyType
     source_run_id: UUID
     goal: str = Field(min_length=1)
     production_readiness_claim: Literal[False]
@@ -173,19 +187,22 @@ class _CompletedShadowReviewPacket(BaseModel):
             return tuple(value)
         return value
 
-    @field_validator("completion_required_fields")
-    @classmethod
-    def _required_fields_must_match_packet_contract(
-        cls,
-        value: tuple[str, ...],
-    ) -> tuple[str, ...]:
-        if tuple(value) != _COMPLETION_REQUIRED_FIELDS:
-            msg = "completion_required_fields must match the shadow packet contract."
-            raise ValueError(msg)
-        return value
-
     @model_validator(mode="after")
     def _forms_must_match_packet_candidates(self) -> _CompletedShadowReviewPacket:
+        if self.completion_required_fields != _completion_required_fields(
+            self.study_type,
+        ):
+            msg = "completion_required_fields must match the shadow packet contract."
+            raise ValueError(msg)
+        if self.study_type == "selection_relevance" and self.review_ranking_forms:
+            msg = "selection_relevance packets must not include ranking forms."
+            raise ValueError(msg)
+        if (
+            self.study_type == "selection_and_review_ranking"
+            and not self.review_ranking_forms
+        ):
+            msg = "selection_and_review_ranking packets require ranking forms."
+            raise ValueError(msg)
         candidate_ids = {record.record_id for record in self.candidate_records}
         for form in self.selection_review_forms:
             if form.run_id != self.source_run_id:
@@ -202,6 +219,19 @@ class _CompletedShadowReviewPacket(BaseModel):
                     *form.harness_deferred_record_ids,
                     *form.human_selected_record_ids,
                     *form.duplicate_suggestion_ids,
+                    *(
+                        citation.record_id
+                        for citation in form.explanation_assessment.cited_evidence
+                    ),
+                    *(
+                        finding.record_id
+                        for finding in form.high_severity_overclaim_findings
+                    ),
+                    *(
+                        citation.record_id
+                        for finding in form.high_severity_overclaim_findings
+                        for citation in finding.cited_evidence
+                    ),
                 ),
             )
         return self
@@ -220,10 +250,17 @@ def build_evidence_selection_shadow_review_source_inputs(
         machine_packet=machine_packet,
         completed_packet=packet,
     )
-    adjudication_note = _required_text(
-        request.adjudication_note,
-        field_name="adjudication_note",
+    adjudication_note = (
+        _required_text(request.adjudication_note, field_name="adjudication_note")
+        if request.adjudication_note is not None
+        else None
     )
+    if (
+        packet.study_type == "selection_and_review_ranking"
+        and adjudication_note is None
+    ):
+        msg = "adjudication_note is required for review-ranking studies."
+        raise ValueError(msg)
     description = (
         _required_text(request.description, field_name="description")
         if request.description is not None
@@ -238,9 +275,9 @@ def build_evidence_selection_shadow_review_source_inputs(
             human_selected_record_ids=completed_form.human_selected_record_ids,
             harness_skipped_record_ids=machine_form.harness_skipped_record_ids,
             duplicate_suggestion_ids=completed_form.duplicate_suggestion_ids,
-            explanation_quality_score=completed_form.explanation_quality_score,
-            high_severity_overclaim_count=(
-                completed_form.high_severity_overclaim_count
+            explanation_assessment=completed_form.explanation_assessment,
+            high_severity_overclaim_findings=(
+                completed_form.high_severity_overclaim_findings
             ),
             reviewer_notes=completed_form.reviewer_notes,
         )
@@ -250,29 +287,35 @@ def build_evidence_selection_shadow_review_source_inputs(
             strict=True,
         )
     )
-    review_ranking = ReviewRankingCalibrationStudyInput(
-        schema_version="evidence_selection_review_ranking_calibration.v1",
-        study_id=machine_packet.study_id,
-        decisions=tuple(
-            ReviewRankingCalibrationDecision(
-                source_kind=machine_form.source_kind,
-                item_id=machine_form.item_id,
-                ranking_score=machine_form.ranking_score,
-                outcome=completed_form.outcome,
-                reviewer_id=completed_form.reviewer_id,
-                goal=machine_form.goal,
-                evidence_shape=machine_form.evidence_shape,
-            )
-            for machine_form, completed_form in zip(
-                machine_packet.review_ranking_forms,
-                packet.review_ranking_forms,
-                strict=True,
-            )
-        ),
-        adjudication_note=adjudication_note,
-        description=description,
+    review_ranking = (
+        ReviewRankingCalibrationStudyInput(
+            schema_version="evidence_selection_review_ranking_calibration.v1",
+            study_id=machine_packet.study_id,
+            decisions=tuple(
+                ReviewRankingCalibrationDecision(
+                    source_kind=machine_form.source_kind,
+                    item_id=machine_form.item_id,
+                    ranking_score=machine_form.ranking_score,
+                    outcome=completed_form.outcome,
+                    reviewer_id=completed_form.reviewer_id,
+                    goal=machine_form.goal,
+                    evidence_shape=machine_form.evidence_shape,
+                )
+                for machine_form, completed_form in zip(
+                    machine_packet.review_ranking_forms,
+                    packet.review_ranking_forms,
+                    strict=True,
+                )
+            ),
+            adjudication_note=adjudication_note,
+            description=description,
+        )
+        if packet.study_type == "selection_and_review_ranking"
+        else None
     )
     return EvidenceSelectionShadowReviewSourceInputs(
+        study_id=machine_packet.study_id,
+        study_type=packet.study_type,
         selection_reviews=selection_reviews,
         review_ranking=review_ranking,
     )
@@ -285,7 +328,9 @@ def _validate_completed_packet_integrity(
 ) -> None:
     expected_digest = machine_packet_digest(machine_packet)
     if machine_packet.machine_packet_sha256 != expected_digest:
-        msg = "Immutable machine packet digest is missing or does not match its contents."
+        msg = (
+            "Immutable machine packet digest is missing or does not match its contents."
+        )
         raise ValueError(msg)
     if machine_packet.machine_packet_signature is None:
         msg = "Immutable machine packet is missing its producer signature."
@@ -297,7 +342,10 @@ def _validate_completed_packet_integrity(
     if completed_packet.machine_packet_sha256 != expected_digest:
         msg = "Completed packet is not bound to the immutable machine packet digest."
         raise ValueError(msg)
-    if completed_packet.machine_packet_signature != machine_packet.machine_packet_signature:
+    if (
+        completed_packet.machine_packet_signature
+        != machine_packet.machine_packet_signature
+    ):
         msg = "Completed packet is not bound to the immutable machine packet signature."
         raise ValueError(msg)
     if not _top_level_machine_fields_match(
@@ -352,6 +400,7 @@ def _top_level_machine_fields_match(
     return (
         machine_packet.schema_version == completed_packet.schema_version
         and machine_packet.study_id == completed_packet.study_id
+        and machine_packet.study_type == completed_packet.study_type
         and machine_packet.source_run_id == completed_packet.source_run_id
         and machine_packet.goal == completed_packet.goal
         and machine_packet.production_readiness_claim
@@ -363,6 +412,17 @@ def _top_level_machine_fields_match(
         == completed_packet.completion_required_fields
         and machine_packet.candidate_records == completed_packet.candidate_records
     )
+
+
+def _completion_required_fields(
+    study_type: EvidenceSelectionExpertStudyType,
+) -> tuple[str, ...]:
+    if study_type == "selection_and_review_ranking":
+        return (
+            *_SELECTION_COMPLETION_REQUIRED_FIELDS,
+            *_RANKING_COMPLETION_REQUIRED_FIELDS,
+        )
+    return _SELECTION_COMPLETION_REQUIRED_FIELDS
 
 
 def _selection_machine_fields_match(

--- a/services/artana_evidence_api/evidence_selection/shadow_review_completion.py
+++ b/services/artana_evidence_api/evidence_selection/shadow_review_completion.py
@@ -271,6 +271,9 @@ def build_evidence_selection_shadow_review_source_inputs(
             run_id=machine_form.run_id,
             goal=machine_form.goal,
             reviewer_id=completed_form.reviewer_id,
+            candidate_record_ids=tuple(
+                record.record_id for record in machine_packet.candidate_records
+            ),
             harness_selected_record_ids=machine_form.harness_selected_record_ids,
             human_selected_record_ids=completed_form.human_selected_record_ids,
             harness_skipped_record_ids=machine_form.harness_skipped_record_ids,

--- a/services/artana_evidence_api/evidence_selection/shadow_review_packet.py
+++ b/services/artana_evidence_api/evidence_selection/shadow_review_packet.py
@@ -18,20 +18,25 @@ from artana_evidence_api.evidence_selection_candidates import (
     required_decision_string,
     score_from_decision,
 )
-from artana_evidence_api.evidence_selection_validation import ReviewRankingSourceKind
+from artana_evidence_api.evidence_selection_validation import (
+    EvidenceSelectionExpertStudyType,
+    ReviewRankingSourceKind,
+)
 from artana_evidence_api.types.common import JSONObject, JSONValue
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 EvidenceSelectionShadowReviewPacketSchemaVersion = Literal[
-    "evidence_selection_shadow_review_packet.v1"
+    "evidence_selection_shadow_review_packet.v2"
 ]
 EvidenceSelectionShadowReviewCompletionStatus = Literal["requires_human_labels"]
 
-_COMPLETION_REQUIRED_FIELDS = (
+_SELECTION_COMPLETION_REQUIRED_FIELDS = (
     "selection_review_forms[].reviewer_id",
     "selection_review_forms[].human_selected_record_ids",
-    "selection_review_forms[].explanation_quality_score",
-    "selection_review_forms[].high_severity_overclaim_count",
+    "selection_review_forms[].explanation_assessment",
+    "selection_review_forms[].high_severity_overclaim_findings",
+)
+_RANKING_COMPLETION_REQUIRED_FIELDS = (
     "review_ranking_forms[].reviewer_id",
     "review_ranking_forms[].outcome",
 )
@@ -91,8 +96,8 @@ class EvidenceSelectionShadowSelectionReviewForm(BaseModel):
     harness_deferred_record_ids: tuple[str, ...] = ()
     human_selected_record_ids: tuple[str, ...] = ()
     duplicate_suggestion_ids: tuple[str, ...] = ()
-    explanation_quality_score: None = None
-    high_severity_overclaim_count: None = None
+    explanation_assessment: None = None
+    high_severity_overclaim_findings: None = None
     reviewer_notes: None = None
 
     @field_validator("run_id", mode="before")
@@ -150,6 +155,7 @@ class EvidenceSelectionShadowReviewPacket(BaseModel):
 
     schema_version: EvidenceSelectionShadowReviewPacketSchemaVersion
     study_id: str = Field(min_length=1)
+    study_type: EvidenceSelectionExpertStudyType
     source_run_id: UUID
     goal: str = Field(min_length=1)
     production_readiness_claim: Literal[False] = False
@@ -164,7 +170,7 @@ class EvidenceSelectionShadowReviewPacket(BaseModel):
         default=None,
         pattern=r"^[a-f0-9]{64}$",
     )
-    completion_required_fields: tuple[str, ...] = _COMPLETION_REQUIRED_FIELDS
+    completion_required_fields: tuple[str, ...]
     candidate_records: tuple[EvidenceSelectionShadowCandidateRecord, ...]
     selection_review_forms: tuple[EvidenceSelectionShadowSelectionReviewForm, ...]
     review_ranking_forms: tuple[EvidenceSelectionShadowReviewRankingForm, ...] = ()
@@ -189,21 +195,23 @@ class EvidenceSelectionShadowReviewPacket(BaseModel):
             return tuple(value)
         return value
 
-    @field_validator("completion_required_fields")
-    @classmethod
-    def _completion_fields_must_match_packet_contract(
-        cls,
-        value: tuple[str, ...],
-    ) -> tuple[str, ...]:
-        if tuple(value) != _COMPLETION_REQUIRED_FIELDS:
-            msg = "completion_required_fields must match the shadow packet contract."
-            raise ValueError(msg)
-        return value
-
     @model_validator(mode="after")
-    def _machine_digest_must_match_machine_owned_fields(
+    def _validate_packet_contract(
         self,
     ) -> EvidenceSelectionShadowReviewPacket:
+        expected_fields = _completion_required_fields(self.study_type)
+        if self.completion_required_fields != expected_fields:
+            msg = "completion_required_fields must match the shadow packet contract."
+            raise ValueError(msg)
+        if self.study_type == "selection_relevance" and self.review_ranking_forms:
+            msg = "selection_relevance packets must not include ranking forms."
+            raise ValueError(msg)
+        if (
+            self.study_type == "selection_and_review_ranking"
+            and not self.review_ranking_forms
+        ):
+            msg = "selection_and_review_ranking packets require ranking forms."
+            raise ValueError(msg)
         if (
             self.machine_packet_sha256 is not None
             and self.machine_packet_sha256 != machine_packet_digest(self)
@@ -239,11 +247,18 @@ def build_evidence_selection_shadow_review_packet(
     review_selected = (*selected, *shadow_selected)
     candidate_records = (*selected, *skipped, *deferred)
     _reject_duplicate_candidate_ids(candidate_records)
+    study_type: EvidenceSelectionExpertStudyType = (
+        "selection_and_review_ranking"
+        if request.review_ranking_items
+        else "selection_relevance"
+    )
     packet = EvidenceSelectionShadowReviewPacket(
-        schema_version="evidence_selection_shadow_review_packet.v1",
+        schema_version="evidence_selection_shadow_review_packet.v2",
         study_id=study_id,
+        study_type=study_type,
         source_run_id=run_id,
         goal=goal,
+        completion_required_fields=_completion_required_fields(study_type),
         candidate_records=candidate_records,
         selection_review_forms=(
             EvidenceSelectionShadowSelectionReviewForm(
@@ -286,6 +301,7 @@ def machine_packet_digest(packet: EvidenceSelectionShadowReviewPacket) -> str:
     payload = {
         "schema_version": packet.schema_version,
         "study_id": packet.study_id,
+        "study_type": packet.study_type,
         "source_run_id": str(packet.source_run_id),
         "goal": packet.goal,
         "production_readiness_claim": packet.production_readiness_claim,
@@ -322,6 +338,17 @@ def machine_packet_digest(packet: EvidenceSelectionShadowReviewPacket) -> str:
         sort_keys=True,
     ).encode("utf-8")
     return hashlib.sha256(canonical_payload).hexdigest()
+
+
+def _completion_required_fields(
+    study_type: EvidenceSelectionExpertStudyType,
+) -> tuple[str, ...]:
+    if study_type == "selection_and_review_ranking":
+        return (
+            *_SELECTION_COMPLETION_REQUIRED_FIELDS,
+            *_RANKING_COMPLETION_REQUIRED_FIELDS,
+        )
+    return _SELECTION_COMPLETION_REQUIRED_FIELDS
 
 
 def _is_shadow_selected_decision(decision: JSONObject) -> bool:

--- a/services/artana_evidence_api/evidence_selection/shadow_review_study_batch.py
+++ b/services/artana_evidence_api/evidence_selection/shadow_review_study_batch.py
@@ -22,6 +22,9 @@ from artana_evidence_api.evidence_selection.shadow_review_study_batch_validation
     EvidenceSelectionShadowReviewStudyBatchSuiteThresholds,
 )
 from artana_evidence_api.evidence_selection.shadow_review_study_batch_validation import (
+    shadow_review_study_batch_suite_thresholds_to_json as _suite_thresholds_to_json,
+)
+from artana_evidence_api.evidence_selection.shadow_review_study_batch_validation import (
     validate_shadow_review_study_batch_suite_thresholds as _validate_suite_thresholds,
 )
 from artana_evidence_api.evidence_selection.shadow_review_study_pipeline import (
@@ -30,6 +33,7 @@ from artana_evidence_api.evidence_selection.shadow_review_study_pipeline import 
     build_evidence_selection_shadow_review_study_artifacts,
 )
 from artana_evidence_api.evidence_selection_validation import (
+    EvidenceSelectionExpertStudyEvidenceKind,
     EvidenceSelectionExpertStudyGateThresholds,
     EvidenceSelectionExpertStudyInput,
     ReviewRankingCalibrationGateThresholds,
@@ -60,12 +64,13 @@ class EvidenceSelectionShadowReviewStudyBatchEntry(BaseModel):
     machine_packet_path: Path | None = None
     packet_path: Path
     output_subdir: str
-    adjudication_note: str
+    adjudication_note: str | None = None
     source_system: str
     export_id: str
     exported_at: str
     exporter_id: str
     redaction_statement: str
+    study_evidence_kind: EvidenceSelectionExpertStudyEvidenceKind
     description: str | None = None
 
     @field_validator("machine_packet_path", "packet_path", mode="before")
@@ -82,7 +87,6 @@ class EvidenceSelectionShadowReviewStudyBatchEntry(BaseModel):
 
     @field_validator(
         "entry_id",
-        "adjudication_note",
         "source_system",
         "export_id",
         "exported_at",
@@ -95,7 +99,25 @@ class EvidenceSelectionShadowReviewStudyBatchEntry(BaseModel):
             msg = "Batch manifest text fields must not be blank."
             raise ValueError(msg)
         if value != value.strip():
-            msg = "Batch manifest text fields must not have leading/trailing whitespace."
+            msg = (
+                "Batch manifest text fields must not have leading/trailing whitespace."
+            )
+            raise ValueError(msg)
+        return value
+
+    @field_validator("adjudication_note")
+    @classmethod
+    def _reject_blank_or_padded_adjudication_note(
+        cls,
+        value: str | None,
+    ) -> str | None:
+        if value is None:
+            return None
+        if not value.strip():
+            msg = "adjudication_note must not be blank when provided."
+            raise ValueError(msg)
+        if value != value.strip():
+            msg = "adjudication_note must not have leading/trailing whitespace."
             raise ValueError(msg)
         return value
 
@@ -193,8 +215,8 @@ class EvidenceSelectionShadowReviewStudyBatchThresholds:
     min_selection_reviewer_count: int = 1
     min_mean_precision: float = 0.8
     min_mean_recall: float = 0.8
-    min_mean_explanation_quality: float = 3.0
-    min_source_artifact_count: int = 2
+    min_explanation_adequacy_rate: float = 0.8
+    min_source_artifact_count: int = 1
     min_review_ranking_sample_count: int = 2
     max_expected_calibration_error: float = 0.05
     min_distinct_ranking_goals: int = 1
@@ -210,15 +232,15 @@ _PRODUCTION_SUITE_THRESHOLD_FLOORS = (
 class _BatchQualityMetrics:
     suite_mean_precision: float
     suite_mean_recall: float
-    suite_mean_explanation_quality: float
+    suite_explanation_adequacy_rate: float
     max_review_ranking_expected_calibration_error: float
 
     def to_json(self) -> JSONObject:
         return {
             "suite_mean_precision": round(self.suite_mean_precision, 4),
             "suite_mean_recall": round(self.suite_mean_recall, 4),
-            "suite_mean_explanation_quality": round(
-                self.suite_mean_explanation_quality,
+            "suite_explanation_adequacy_rate": round(
+                self.suite_explanation_adequacy_rate,
                 4,
             ),
             "max_review_ranking_expected_calibration_error": round(
@@ -285,10 +307,16 @@ class EvidenceSelectionShadowReviewStudyBatchEntryResult:
             "source_artifact_count": self.artifact_result.source_artifact_count,
             "paths": {
                 "selection_reviews": str(self.artifact_result.selection_reviews_path),
-                "review_ranking": str(self.artifact_result.review_ranking_path),
+                "review_ranking": (
+                    str(self.artifact_result.review_ranking_path)
+                    if self.artifact_result.review_ranking_path is not None
+                    else None
+                ),
                 "selection_export": str(self.artifact_result.selection_export_path),
-                "review_ranking_export": str(
-                    self.artifact_result.review_ranking_export_path,
+                "review_ranking_export": (
+                    str(self.artifact_result.review_ranking_export_path)
+                    if self.artifact_result.review_ranking_export_path is not None
+                    else None
                 ),
                 "bundle": str(self.artifact_result.bundle_path),
             },
@@ -428,6 +456,7 @@ def build_evidence_selection_shadow_review_study_batch(
                     exported_at=entry.exported_at,
                     exporter_id=entry.exporter_id,
                     redaction_statement=entry.redaction_statement,
+                    study_evidence_kind=entry.study_evidence_kind,
                     description=entry.description,
                 ),
             )
@@ -489,22 +518,26 @@ def build_evidence_selection_shadow_review_study_batch_suite_gate(
         entry.artifact_result.selection_review_count for entry in passed_entries
     )
     total_review_ranking_decision_count = sum(
-        entry.artifact_result.review_ranking_decision_count
-        for entry in passed_entries
+        entry.artifact_result.review_ranking_decision_count for entry in passed_entries
     )
-    quality_metrics = _batch_quality_metrics(passed_entries)
+    all_entry_quality_metrics = _batch_quality_metrics(entries)
+    production_quality_metrics = _batch_quality_metrics(passed_entries)
     selection_goals = _batch_selection_goals(passed_entries)
     review_ranking_goals, evidence_shapes = _batch_review_ranking_labels(passed_entries)
     source_outcomes = _batch_review_ranking_source_outcomes(passed_entries)
     source_run_ids, study_ids = _batch_study_identity_labels(passed_entries)
+    combined_study_count = _combined_study_count(passed_entries)
     summary: JSONObject = {
         "entry_count": len(entries),
         "passed_entry_count": passed_entry_count,
         "failed_entry_count": failed_entry_count,
         "passed_entry_rate": round(passed_entry_rate, 4),
-        **quality_metrics.to_json(),
+        **production_quality_metrics.to_json(),
+        "all_entry_observed_quality": all_entry_quality_metrics.to_json(),
+        "passed_entry_production_quality": production_quality_metrics.to_json(),
         "total_selection_review_count": total_selection_review_count,
         "total_review_ranking_decision_count": total_review_ranking_decision_count,
+        "combined_study_count": combined_study_count,
         "distinct_source_run_id_count": len(source_run_ids),
         "distinct_study_id_count": len(study_ids),
         "distinct_selection_goal_count": len(selection_goals),
@@ -518,7 +551,7 @@ def build_evidence_selection_shadow_review_study_batch_suite_gate(
     blocking_reasons = _batch_suite_blocking_reasons(
         summary=summary,
         raw_passed_entry_rate=passed_entry_rate,
-        raw_quality_metrics=quality_metrics,
+        production_quality_metrics=production_quality_metrics,
         source_outcomes=source_outcomes,
         thresholds=effective_thresholds,
     )
@@ -553,7 +586,7 @@ def build_evidence_selection_shadow_review_study_gate_report(
             min_selection_reviewer_count=thresholds.min_selection_reviewer_count,
             min_mean_precision=thresholds.min_mean_precision,
             min_mean_recall=thresholds.min_mean_recall,
-            min_mean_explanation_quality=thresholds.min_mean_explanation_quality,
+            min_explanation_adequacy_rate=(thresholds.min_explanation_adequacy_rate),
             min_source_artifact_count=thresholds.min_source_artifact_count,
         ),
         review_ranking_thresholds=ReviewRankingCalibrationGateThresholds(
@@ -614,9 +647,9 @@ def _production_suite_thresholds(
             thresholds.min_suite_mean_recall,
             floors.min_suite_mean_recall,
         ),
-        min_suite_mean_explanation_quality=max(
-            thresholds.min_suite_mean_explanation_quality,
-            floors.min_suite_mean_explanation_quality,
+        min_suite_explanation_adequacy_rate=max(
+            thresholds.min_suite_explanation_adequacy_rate,
+            floors.min_suite_explanation_adequacy_rate,
         ),
         max_suite_expected_calibration_error=min(
             thresholds.max_suite_expected_calibration_error,
@@ -651,36 +684,6 @@ def _production_suite_thresholds(
             floors.min_distinct_evidence_shapes,
         ),
     )
-
-
-def _suite_thresholds_to_json(
-    thresholds: EvidenceSelectionShadowReviewStudyBatchSuiteThresholds,
-) -> JSONObject:
-    return {
-        "min_entry_count": thresholds.min_entry_count,
-        "min_passed_entry_count": thresholds.min_passed_entry_count,
-        "max_failed_entry_count": thresholds.max_failed_entry_count,
-        "min_passed_entry_rate": thresholds.min_passed_entry_rate,
-        "min_suite_mean_precision": thresholds.min_suite_mean_precision,
-        "min_suite_mean_recall": thresholds.min_suite_mean_recall,
-        "min_suite_mean_explanation_quality": (
-            thresholds.min_suite_mean_explanation_quality
-        ),
-        "max_suite_expected_calibration_error": (
-            thresholds.max_suite_expected_calibration_error
-        ),
-        "min_total_selection_review_count": thresholds.min_total_selection_review_count,
-        "min_total_review_ranking_decision_count": (
-            thresholds.min_total_review_ranking_decision_count
-        ),
-        "min_distinct_source_run_ids": thresholds.min_distinct_source_run_ids,
-        "min_distinct_study_ids": thresholds.min_distinct_study_ids,
-        "min_distinct_selection_goals": thresholds.min_distinct_selection_goals,
-        "min_distinct_review_ranking_goals": (
-            thresholds.min_distinct_review_ranking_goals
-        ),
-        "min_distinct_evidence_shapes": thresholds.min_distinct_evidence_shapes,
-    }
 
 
 def _protected_manifest_paths(manifest_path: Path | None) -> tuple[Path, ...]:
@@ -730,10 +733,7 @@ def _validate_batch_artifact_source_collisions(
 
 
 def _source_path_label(*, source_path: Path, manifest_path: Path | None) -> str:
-    if (
-        manifest_path is not None
-        and paths_alias(source_path, manifest_path)
-    ):
+    if manifest_path is not None and paths_alias(source_path, manifest_path):
         return "manifest"
     return "source packet"
 
@@ -787,6 +787,8 @@ def _batch_review_ranking_labels(
         study_input = EvidenceSelectionExpertStudyInput.model_validate(
             _load_json_object(entry.artifact_result.bundle_path),
         )
+        if study_input.review_ranking is None:
+            continue
         for decision in study_input.review_ranking.decisions:
             if goal := _normalized_label(decision.goal):
                 goals.add(goal)
@@ -805,6 +807,8 @@ def _batch_review_ranking_source_outcomes(
         study_input = EvidenceSelectionExpertStudyInput.model_validate(
             _load_json_object(entry.artifact_result.bundle_path),
         )
+        if study_input.review_ranking is None:
+            continue
         for decision in study_input.review_ranking.decisions:
             source_outcomes[decision.source_kind].add(decision.outcome)
     return source_outcomes
@@ -816,7 +820,7 @@ def _batch_quality_metrics(
     total_review_count = 0
     weighted_precision = 0.0
     weighted_recall = 0.0
-    weighted_explanation_quality = 0.0
+    weighted_explanation_adequacy = 0.0
     max_expected_calibration_error = 0.0
     for entry in entries:
         gate = _object_value(entry.gate_report, "gate")
@@ -830,8 +834,8 @@ def _batch_quality_metrics(
             weighted_recall += (
                 _float_value(selection_summary.get("mean_recall")) * review_count
             )
-            weighted_explanation_quality += (
-                _float_value(selection_summary.get("mean_explanation_quality"))
+            weighted_explanation_adequacy += (
+                _float_value(selection_summary.get("explanation_adequacy_rate"))
                 * review_count
             )
         review_ranking_gate = _object_value(gate, "review_ranking_gate")
@@ -849,8 +853,8 @@ def _batch_quality_metrics(
             numerator=weighted_recall,
             denominator=total_review_count,
         ),
-        suite_mean_explanation_quality=_ratio(
-            numerator=weighted_explanation_quality,
+        suite_explanation_adequacy_rate=_ratio(
+            numerator=weighted_explanation_adequacy,
             denominator=total_review_count,
         ),
         max_review_ranking_expected_calibration_error=max_expected_calibration_error,
@@ -874,11 +878,24 @@ def _batch_study_identity_labels(
     return source_run_ids, study_ids
 
 
+def _combined_study_count(
+    entries: tuple[EvidenceSelectionShadowReviewStudyBatchEntryResult, ...],
+) -> int:
+    return sum(
+        1
+        for entry in entries
+        if EvidenceSelectionExpertStudyInput.model_validate(
+            _load_json_object(entry.artifact_result.bundle_path),
+        ).study_type
+        == "selection_and_review_ranking"
+    )
+
+
 def _batch_suite_blocking_reasons(
     *,
     summary: JSONObject,
     raw_passed_entry_rate: float,
-    raw_quality_metrics: _BatchQualityMetrics,
+    production_quality_metrics: _BatchQualityMetrics,
     source_outcomes: Mapping[str, set[str]],
     thresholds: EvidenceSelectionShadowReviewStudyBatchSuiteThresholds,
 ) -> tuple[str, ...]:
@@ -889,7 +906,7 @@ def _batch_suite_blocking_reasons(
             thresholds=thresholds,
         ),
         *_batch_suite_quality_blocking_reasons(
-            raw_quality_metrics=raw_quality_metrics,
+            raw_quality_metrics=production_quality_metrics,
             thresholds=thresholds,
         ),
         *_batch_suite_sample_blocking_reasons(
@@ -905,6 +922,7 @@ def _batch_suite_blocking_reasons(
             thresholds=thresholds,
         ),
         *_batch_suite_source_outcome_blocking_reasons(
+            summary=summary,
             source_outcomes=source_outcomes,
         ),
     )
@@ -923,13 +941,19 @@ def _batch_suite_entry_blocking_reasons(
             f"{thresholds.min_entry_count} batch entries are required for "
             "production study evidence.",
         )
-    if _int_value(summary.get("passed_entry_count")) < thresholds.min_passed_entry_count:
+    if (
+        _int_value(summary.get("passed_entry_count"))
+        < thresholds.min_passed_entry_count
+    ):
         reasons.append(
             "At least "
             f"{thresholds.min_passed_entry_count} batch entries must pass their "
             "expert-study gates.",
         )
-    if _int_value(summary.get("failed_entry_count")) > thresholds.max_failed_entry_count:
+    if (
+        _int_value(summary.get("failed_entry_count"))
+        > thresholds.max_failed_entry_count
+    ):
         reasons.append(
             "No more than "
             f"{thresholds.max_failed_entry_count} batch entries may fail their "
@@ -962,13 +986,13 @@ def _batch_suite_quality_blocking_reasons(
             f"{thresholds.min_suite_mean_recall:.6f}.",
         )
     if (
-        raw_quality_metrics.suite_mean_explanation_quality
-        < thresholds.min_suite_mean_explanation_quality
+        raw_quality_metrics.suite_explanation_adequacy_rate
+        < thresholds.min_suite_explanation_adequacy_rate
     ):
         reasons.append(
-            "Batch suite mean explanation quality is below target: "
-            f"{raw_quality_metrics.suite_mean_explanation_quality:.6f} < "
-            f"{thresholds.min_suite_mean_explanation_quality:.6f}.",
+            "Batch suite explanation adequacy rate is below target: "
+            f"{raw_quality_metrics.suite_explanation_adequacy_rate:.6f} < "
+            f"{thresholds.min_suite_explanation_adequacy_rate:.6f}.",
         )
     if (
         raw_quality_metrics.max_review_ranking_expected_calibration_error
@@ -999,7 +1023,8 @@ def _batch_suite_sample_blocking_reasons(
             "are required across passed batch entries.",
         )
     if (
-        _int_value(summary.get("total_review_ranking_decision_count"))
+        _int_value(summary.get("combined_study_count")) > 0
+        and _int_value(summary.get("total_review_ranking_decision_count"))
         < thresholds.min_total_review_ranking_decision_count
     ):
         reasons.append(
@@ -1053,7 +1078,8 @@ def _batch_suite_diversity_blocking_reasons(
             "are required across the batch.",
         )
     if (
-        _int_value(summary.get("distinct_review_ranking_goal_count"))
+        _int_value(summary.get("combined_study_count")) > 0
+        and _int_value(summary.get("distinct_review_ranking_goal_count"))
         < thresholds.min_distinct_review_ranking_goals
     ):
         reasons.append(
@@ -1062,7 +1088,8 @@ def _batch_suite_diversity_blocking_reasons(
             "goals are required across the batch.",
         )
     if (
-        _int_value(summary.get("distinct_evidence_shape_count"))
+        _int_value(summary.get("combined_study_count")) > 0
+        and _int_value(summary.get("distinct_evidence_shape_count"))
         < thresholds.min_distinct_evidence_shapes
     ):
         reasons.append(
@@ -1075,8 +1102,11 @@ def _batch_suite_diversity_blocking_reasons(
 
 def _batch_suite_source_outcome_blocking_reasons(
     *,
+    summary: JSONObject,
     source_outcomes: Mapping[str, set[str]],
 ) -> tuple[str, ...]:
+    if _int_value(summary.get("combined_study_count")) == 0:
+        return ()
     return tuple(
         f"At least one {outcome} reviewer outcome is required for source kind "
         f"{source_kind} across passed batch entries."

--- a/services/artana_evidence_api/evidence_selection/shadow_review_study_batch_manifest.py
+++ b/services/artana_evidence_api/evidence_selection/shadow_review_study_batch_manifest.py
@@ -17,6 +17,9 @@ from artana_evidence_api.evidence_selection.shadow_review_completion import (
 from artana_evidence_api.evidence_selection.shadow_review_study_batch import (
     EvidenceSelectionShadowReviewStudyBatchManifest,
 )
+from artana_evidence_api.evidence_selection_validation import (
+    EvidenceSelectionExpertStudyEvidenceKind,
+)
 from artana_evidence_api.types.common import JSONObject, json_object
 from pydantic import ValidationError
 
@@ -30,12 +33,13 @@ class EvidenceSelectionShadowReviewStudyBatchManifestBuildRequest:
 
     batch_id: str
     packet_paths: tuple[Path, ...]
-    adjudication_note: str
     source_system: str
     export_id_prefix: str
     exported_at: str
     exporter_id: str
     redaction_statement: str
+    study_evidence_kind: EvidenceSelectionExpertStudyEvidenceKind
+    adjudication_note: str | None = None
     manifest_path: Path | None = None
     description: str | None = None
     machine_packet_paths: tuple[Path, ...] | None = None
@@ -50,8 +54,7 @@ def build_evidence_selection_shadow_review_study_batch_manifest(
         msg = "At least one completed shadow-review packet is required."
         raise ValueError(msg)
     machine_packet_paths = request.machine_packet_paths or tuple(
-        machine_packet_sidecar_path(packet_path)
-        for packet_path in request.packet_paths
+        machine_packet_sidecar_path(packet_path) for packet_path in request.packet_paths
     )
     if len(machine_packet_paths) != len(request.packet_paths):
         msg = "Every completed shadow-review packet requires one machine packet path."
@@ -94,6 +97,7 @@ def build_evidence_selection_shadow_review_study_batch_manifest(
                 "exported_at": request.exported_at,
                 "exporter_id": request.exporter_id,
                 "redaction_statement": request.redaction_statement,
+                "study_evidence_kind": request.study_evidence_kind,
                 "description": request.description,
             },
         )
@@ -120,7 +124,7 @@ def _load_completed_packet(
     *,
     machine_packet_path: Path,
     packet_path: Path,
-    adjudication_note: str,
+    adjudication_note: str | None,
     description: str | None,
 ) -> JSONObject:
     machine_packet = _load_json_object(machine_packet_path)

--- a/services/artana_evidence_api/evidence_selection/shadow_review_study_batch_validation.py
+++ b/services/artana_evidence_api/evidence_selection/shadow_review_study_batch_validation.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from math import isfinite
 
-_MIN_EXPLANATION_QUALITY = 1.0
-_MAX_EXPLANATION_QUALITY = 5.0
+from artana_evidence_api.types.common import JSONObject
 
 
 @dataclass(frozen=True, slots=True)
@@ -19,7 +18,7 @@ class EvidenceSelectionShadowReviewStudyBatchSuiteThresholds:
     min_passed_entry_rate: float = 1.0
     min_suite_mean_precision: float = 0.8
     min_suite_mean_recall: float = 0.8
-    min_suite_mean_explanation_quality: float = 3.0
+    min_suite_explanation_adequacy_rate: float = 0.8
     max_suite_expected_calibration_error: float = 0.05
     min_total_selection_review_count: int = 3
     min_total_review_ranking_decision_count: int = 10
@@ -39,8 +38,8 @@ def validate_shadow_review_study_batch_suite_thresholds(
         "min_passed_entry_rate": thresholds.min_passed_entry_rate,
         "min_suite_mean_precision": thresholds.min_suite_mean_precision,
         "min_suite_mean_recall": thresholds.min_suite_mean_recall,
-        "min_suite_mean_explanation_quality": (
-            thresholds.min_suite_mean_explanation_quality
+        "min_suite_explanation_adequacy_rate": (
+            thresholds.min_suite_explanation_adequacy_rate
         ),
         "max_suite_expected_calibration_error": (
             thresholds.max_suite_expected_calibration_error
@@ -78,6 +77,9 @@ def validate_shadow_review_study_batch_suite_thresholds(
     bounded_float_thresholds = {
         "min_suite_mean_precision": thresholds.min_suite_mean_precision,
         "min_suite_mean_recall": thresholds.min_suite_mean_recall,
+        "min_suite_explanation_adequacy_rate": (
+            thresholds.min_suite_explanation_adequacy_rate
+        ),
         "max_suite_expected_calibration_error": (
             thresholds.max_suite_expected_calibration_error
         ),
@@ -86,15 +88,44 @@ def validate_shadow_review_study_batch_suite_thresholds(
         if float_value < 0 or float_value > 1:
             msg = f"{float_name} must be between 0 and 1."
             raise ValueError(msg)
-    if (
-        thresholds.min_suite_mean_explanation_quality < _MIN_EXPLANATION_QUALITY
-        or thresholds.min_suite_mean_explanation_quality > _MAX_EXPLANATION_QUALITY
-    ):
-        msg = "min_suite_mean_explanation_quality must be between 1 and 5."
-        raise ValueError(msg)
+
+
+def shadow_review_study_batch_suite_thresholds_to_json(
+    thresholds: EvidenceSelectionShadowReviewStudyBatchSuiteThresholds,
+) -> JSONObject:
+    """Serialize suite policy thresholds for immutable gate reports."""
+
+    return {
+        "min_entry_count": thresholds.min_entry_count,
+        "min_passed_entry_count": thresholds.min_passed_entry_count,
+        "max_failed_entry_count": thresholds.max_failed_entry_count,
+        "min_passed_entry_rate": thresholds.min_passed_entry_rate,
+        "min_suite_mean_precision": thresholds.min_suite_mean_precision,
+        "min_suite_mean_recall": thresholds.min_suite_mean_recall,
+        "min_suite_explanation_adequacy_rate": (
+            thresholds.min_suite_explanation_adequacy_rate
+        ),
+        "max_suite_expected_calibration_error": (
+            thresholds.max_suite_expected_calibration_error
+        ),
+        "min_total_selection_review_count": (
+            thresholds.min_total_selection_review_count
+        ),
+        "min_total_review_ranking_decision_count": (
+            thresholds.min_total_review_ranking_decision_count
+        ),
+        "min_distinct_source_run_ids": thresholds.min_distinct_source_run_ids,
+        "min_distinct_study_ids": thresholds.min_distinct_study_ids,
+        "min_distinct_selection_goals": thresholds.min_distinct_selection_goals,
+        "min_distinct_review_ranking_goals": (
+            thresholds.min_distinct_review_ranking_goals
+        ),
+        "min_distinct_evidence_shapes": thresholds.min_distinct_evidence_shapes,
+    }
 
 
 __all__ = [
     "EvidenceSelectionShadowReviewStudyBatchSuiteThresholds",
+    "shadow_review_study_batch_suite_thresholds_to_json",
     "validate_shadow_review_study_batch_suite_thresholds",
 ]

--- a/services/artana_evidence_api/evidence_selection/shadow_review_study_pipeline.py
+++ b/services/artana_evidence_api/evidence_selection/shadow_review_study_pipeline.py
@@ -15,7 +15,9 @@ from artana_evidence_api.evidence_selection.shadow_review_completion import (
     build_evidence_selection_shadow_review_source_inputs,
 )
 from artana_evidence_api.evidence_selection.source_export_writer import (
+    EvidenceSelectionReviewExportWriteRequest,
     EvidenceSelectionSourceExportWriteRequest,
+    write_evidence_selection_review_export,
     write_evidence_selection_source_exports,
 )
 from artana_evidence_api.evidence_selection.study_bundle import (
@@ -43,16 +45,16 @@ class EvidenceSelectionShadowReviewStudyArtifactRequest:
     machine_packet: JSONObject
     packet: JSONObject
     output_dir: Path
-    adjudication_note: str
+    adjudication_note: str | None
     source_system: str
     export_id: str
     exported_at: datetime | str
     exporter_id: str
     redaction_statement: str
+    study_evidence_kind: EvidenceSelectionExpertStudyEvidenceKind
     machine_packet_path: Path | None = None
     packet_path: Path | None = None
     protected_source_paths: tuple[Path, ...] = ()
-    study_evidence_kind: EvidenceSelectionExpertStudyEvidenceKind = "real_shadow_review"
     description: str | None = None
 
 
@@ -61,9 +63,9 @@ class EvidenceSelectionShadowReviewStudyArtifactResult:
     """Paths and counts produced by the completed-packet artifact pipeline."""
 
     selection_reviews_path: Path
-    review_ranking_path: Path
+    review_ranking_path: Path | None
     selection_export_path: Path
-    review_ranking_export_path: Path
+    review_ranking_export_path: Path | None
     bundle_path: Path
     selection_review_count: int
     review_ranking_decision_count: int
@@ -101,35 +103,66 @@ def build_evidence_selection_shadow_review_study_artifacts(
             paths.selection_reviews_path,
             source_inputs.selection_reviews_payload(),
         )
-        _write_json_payload(
-            paths.review_ranking_path,
-            source_inputs.review_ranking_payload(),
-        )
-        source_export_result = write_evidence_selection_source_exports(
-            EvidenceSelectionSourceExportWriteRequest(
-                selection_reviews_path=paths.selection_reviews_path,
-                review_ranking_path=paths.review_ranking_path,
-                selection_export_path=paths.selection_export_path,
-                review_ranking_export_path=paths.review_ranking_export_path,
-                source_system=request.source_system,
-                export_id=request.export_id,
-                exported_at=request.exported_at,
-                exporter_id=request.exporter_id,
-                redaction_statement=request.redaction_statement,
-            ),
-        )
+        if source_inputs.review_ranking is None:
+            selection_export_result = write_evidence_selection_review_export(
+                EvidenceSelectionReviewExportWriteRequest(
+                    selection_reviews_path=paths.selection_reviews_path,
+                    selection_export_path=paths.selection_export_path,
+                    source_system=request.source_system,
+                    export_id=request.export_id,
+                    exported_at=request.exported_at,
+                    exporter_id=request.exporter_id,
+                    redaction_statement=request.redaction_statement,
+                ),
+            )
+            selection_review_count = selection_export_result.selection_review_count
+            review_ranking_decision_count = 0
+        else:
+            _write_json_payload(
+                paths.review_ranking_path,
+                source_inputs.review_ranking_payload(),
+            )
+            source_export_result = write_evidence_selection_source_exports(
+                EvidenceSelectionSourceExportWriteRequest(
+                    selection_reviews_path=paths.selection_reviews_path,
+                    review_ranking_path=paths.review_ranking_path,
+                    selection_export_path=paths.selection_export_path,
+                    review_ranking_export_path=paths.review_ranking_export_path,
+                    source_system=request.source_system,
+                    export_id=request.export_id,
+                    exported_at=request.exported_at,
+                    exporter_id=request.exporter_id,
+                    redaction_statement=request.redaction_statement,
+                ),
+            )
+            selection_review_count = source_export_result.selection_review_count
+            review_ranking_decision_count = (
+                source_export_result.review_ranking_decision_count
+            )
+        bundle_source_paths = [paths.selection_export_path]
+        if source_inputs.review_ranking is not None:
+            bundle_source_paths.append(paths.review_ranking_export_path)
         validate_evidence_selection_expert_study_bundle_output_path(
             output_path=paths.bundle_path,
-            source_paths=(paths.selection_export_path, paths.review_ranking_export_path),
+            source_paths=tuple(bundle_source_paths),
         )
         bundle = build_evidence_selection_expert_study_bundle(
             EvidenceSelectionExpertStudyBundleRequest(
-                study_id=source_inputs.review_ranking.study_id,
+                study_id=source_inputs.study_id,
+                study_type=source_inputs.study_type,
                 study_evidence_kind=request.study_evidence_kind,
                 selection_reviews_path=paths.selection_export_path,
-                review_ranking_path=paths.review_ranking_export_path,
+                review_ranking_path=(
+                    paths.review_ranking_export_path
+                    if source_inputs.review_ranking is not None
+                    else None
+                ),
                 selection_reviews_uri=str(final_paths.selection_export_path),
-                review_ranking_uri=str(final_paths.review_ranking_export_path),
+                review_ranking_uri=(
+                    str(final_paths.review_ranking_export_path)
+                    if source_inputs.review_ranking is not None
+                    else None
+                ),
                 description=request.description,
             ),
         )
@@ -142,16 +175,26 @@ def build_evidence_selection_shadow_review_study_artifacts(
         _remove_staging_dir(staging_dir)
         raise
     source_artifact_count = (
-        0 if bundle.source_manifest is None else len(bundle.source_manifest.source_artifacts)
+        0
+        if bundle.source_manifest is None
+        else len(bundle.source_manifest.source_artifacts)
     )
     return EvidenceSelectionShadowReviewStudyArtifactResult(
         selection_reviews_path=final_paths.selection_reviews_path,
-        review_ranking_path=final_paths.review_ranking_path,
+        review_ranking_path=(
+            final_paths.review_ranking_path
+            if source_inputs.review_ranking is not None
+            else None
+        ),
         selection_export_path=final_paths.selection_export_path,
-        review_ranking_export_path=final_paths.review_ranking_export_path,
+        review_ranking_export_path=(
+            final_paths.review_ranking_export_path
+            if source_inputs.review_ranking is not None
+            else None
+        ),
         bundle_path=final_paths.bundle_path,
-        selection_review_count=source_export_result.selection_review_count,
-        review_ranking_decision_count=source_export_result.review_ranking_decision_count,
+        selection_review_count=selection_review_count,
+        review_ranking_decision_count=review_ranking_decision_count,
         source_artifact_count=source_artifact_count,
     )
 

--- a/services/artana_evidence_api/evidence_selection/source_export_writer.py
+++ b/services/artana_evidence_api/evidence_selection/source_export_writer.py
@@ -55,6 +55,27 @@ class EvidenceSelectionSourceExportWriteResult:
 
 
 @dataclass(frozen=True, slots=True)
+class EvidenceSelectionReviewExportWriteRequest:
+    """Selection-only labels, output path, and source identity."""
+
+    selection_reviews_path: Path
+    selection_export_path: Path
+    source_system: str
+    export_id: str
+    exported_at: datetime | str
+    exporter_id: str
+    redaction_statement: str
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSelectionReviewExportWriteResult:
+    """Count and output path produced by the selection-only writer."""
+
+    selection_export_path: Path
+    selection_review_count: int
+
+
+@dataclass(frozen=True, slots=True)
 class _PreparedOutput:
     """Rollback information for one final output path."""
 
@@ -119,6 +140,46 @@ def write_evidence_selection_source_exports(
         review_ranking_export_path=request.review_ranking_export_path,
         selection_review_count=len(selection_reviews),
         review_ranking_decision_count=len(review_ranking.decisions),
+    )
+
+
+def write_evidence_selection_review_export(
+    request: EvidenceSelectionReviewExportWriteRequest,
+) -> EvidenceSelectionReviewExportWriteResult:
+    """Write one self-describing selection-review export atomically."""
+
+    if paths_alias(request.selection_export_path, request.selection_reviews_path):
+        msg = (
+            "Selection-review export output must not overwrite source input: "
+            f"{request.selection_export_path} matches {request.selection_reviews_path}."
+        )
+        raise EvidenceSelectionSourceExportWriterError(msg)
+    selection_reviews = _load_selection_reviews(request.selection_reviews_path)
+    identity = EvidenceSelectionSourceExportIdentity.model_validate(
+        {
+            "source_system": request.source_system,
+            "export_id": request.export_id,
+            "exported_at": request.exported_at,
+            "exporter_id": request.exporter_id,
+            "redaction_statement": request.redaction_statement,
+        },
+    )
+    selection_export = EvidenceSelectionReviewExport(
+        schema_version="evidence_selection_review_export.v1",
+        source_system=identity.source_system,
+        export_id=identity.export_id,
+        exported_at=identity.exported_at,
+        exporter_id=identity.exporter_id,
+        redaction_statement=identity.redaction_statement,
+        selection_reviews=selection_reviews,
+    )
+    _write_single_json_model(
+        output_path=request.selection_export_path,
+        model=selection_export,
+    )
+    return EvidenceSelectionReviewExportWriteResult(
+        selection_export_path=request.selection_export_path,
+        selection_review_count=len(selection_reviews),
     )
 
 
@@ -233,6 +294,24 @@ def _write_paired_json_models(
         raise EvidenceSelectionSourceExportWriterError(msg) from exc
 
 
+def _write_single_json_model(*, output_path: Path, model: BaseModel) -> None:
+    payload = _json_model_text(model)
+    temp_path: Path | None = None
+    prepared_outputs: list[_PreparedOutput] = []
+    try:
+        _preflight_output_file(output_path)
+        temp_path = _write_temp_sibling(final_path=output_path, payload=payload)
+        prepared_outputs.append(_prepare_output_for_replace(output_path))
+        temp_path.replace(output_path)
+        temp_path = None
+        _discard_prepared_output_backups(prepared_outputs)
+    except (OSError, EvidenceSelectionSourceExportWriterError) as exc:
+        _remove_temp_file(temp_path)
+        _rollback_prepared_outputs(prepared_outputs)
+        msg = f"Unable to write selection-review source export: {exc}"
+        raise EvidenceSelectionSourceExportWriterError(msg) from exc
+
+
 def _json_model_text(model: BaseModel) -> str:
     return json.dumps(model.model_dump(mode="json"), indent=2) + "\n"
 
@@ -288,9 +367,12 @@ def _remove_temp_file(path: Path | None) -> None:
 
 
 __all__ = [
+    "EvidenceSelectionReviewExportWriteRequest",
+    "EvidenceSelectionReviewExportWriteResult",
     "EvidenceSelectionSourceExportWriteRequest",
     "EvidenceSelectionSourceExportWriteResult",
     "EvidenceSelectionSourceExportWriterError",
     "validate_evidence_selection_source_export_output_paths",
+    "write_evidence_selection_review_export",
     "write_evidence_selection_source_exports",
 ]

--- a/services/artana_evidence_api/evidence_selection/source_export_writer.py
+++ b/services/artana_evidence_api/evidence_selection/source_export_writer.py
@@ -112,7 +112,7 @@ def write_evidence_selection_source_exports(
     review_ranking = _load_review_ranking(request.review_ranking_path)
     identity = _source_identity(request)
     selection_export = EvidenceSelectionReviewExport(
-        schema_version="evidence_selection_review_export.v1",
+        schema_version="evidence_selection_review_export.v2",
         source_system=identity.source_system,
         export_id=identity.export_id,
         exported_at=identity.exported_at,
@@ -165,7 +165,7 @@ def write_evidence_selection_review_export(
         },
     )
     selection_export = EvidenceSelectionReviewExport(
-        schema_version="evidence_selection_review_export.v1",
+        schema_version="evidence_selection_review_export.v2",
         source_system=identity.source_system,
         export_id=identity.export_id,
         exported_at=identity.exported_at,

--- a/services/artana_evidence_api/evidence_selection/source_exports.py
+++ b/services/artana_evidence_api/evidence_selection/source_exports.py
@@ -16,7 +16,7 @@ from artana_evidence_api.evidence_selection_validation import (
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 EvidenceSelectionReviewExportSchemaVersion = Literal[
-    "evidence_selection_review_export.v1"
+    "evidence_selection_review_export.v2"
 ]
 ReviewRankingCalibrationExportSchemaVersion = Literal[
     "evidence_selection_review_ranking_export.v1"

--- a/services/artana_evidence_api/evidence_selection/study_bundle.py
+++ b/services/artana_evidence_api/evidence_selection/study_bundle.py
@@ -25,6 +25,7 @@ from artana_evidence_api.evidence_selection.source_exports import (
 from artana_evidence_api.evidence_selection_validation import (
     EvidenceSelectionExpertStudyEvidenceKind,
     EvidenceSelectionExpertStudyInput,
+    EvidenceSelectionExpertStudyType,
     EvidenceSelectionReviewInput,
     ReviewRankingCalibrationStudyInput,
 )
@@ -39,9 +40,10 @@ class EvidenceSelectionExpertStudyBundleRequest:
     """Source files and metadata required to build an expert-study bundle."""
 
     study_id: str
+    study_type: EvidenceSelectionExpertStudyType
     study_evidence_kind: EvidenceSelectionExpertStudyEvidenceKind
     selection_reviews_path: Path
-    review_ranking_path: Path
+    review_ranking_path: Path | None = None
     description: str | None = None
     selection_reviews_uri: str | None = None
     review_ranking_uri: str | None = None
@@ -73,9 +75,13 @@ def build_evidence_selection_expert_study_bundle(
         path=request.selection_reviews_path,
         uri=request.selection_reviews_uri,
     )
-    ranking_source = _read_source_artifact(
-        path=request.review_ranking_path,
-        uri=request.review_ranking_uri,
+    ranking_source = (
+        _read_source_artifact(
+            path=request.review_ranking_path,
+            uri=request.review_ranking_uri,
+        )
+        if request.review_ranking_path is not None
+        else None
     )
     adjudication_source = (
         _read_source_artifact(
@@ -86,7 +92,12 @@ def build_evidence_selection_expert_study_bundle(
         else None
     )
     selection_export = _load_selection_export(selection_source)
-    ranking_export = _load_review_ranking_export(ranking_source)
+    ranking_export = (
+        _load_review_ranking_export(ranking_source)
+        if ranking_source is not None
+        else None
+    )
+    _validate_study_sources(request=request, ranking_export=ranking_export)
     source_identity = _source_identity(
         request=request,
         selection_export=selection_export,
@@ -98,14 +109,19 @@ def build_evidence_selection_expert_study_bundle(
         ranking_source=ranking_source,
         adjudication_source=adjudication_source,
         selection_reviews=selection_export.selection_reviews,
-        review_ranking=ranking_export.review_ranking,
+        review_ranking=(
+            ranking_export.review_ranking if ranking_export is not None else None
+        ),
     )
     return EvidenceSelectionExpertStudyInput(
-        schema_version="evidence_selection_expert_study.v1",
+        schema_version="evidence_selection_expert_study.v2",
         study_id=request.study_id,
+        study_type=request.study_type,
         study_evidence_kind=request.study_evidence_kind,
         selection_reviews=selection_export.selection_reviews,
-        review_ranking=ranking_export.review_ranking,
+        review_ranking=(
+            ranking_export.review_ranking if ranking_export is not None else None
+        ),
         source_manifest=source_manifest,
         description=request.description,
     )
@@ -167,15 +183,28 @@ def _source_identity(
     *,
     request: EvidenceSelectionExpertStudyBundleRequest,
     selection_export: EvidenceSelectionReviewExport,
-    ranking_export: ReviewRankingCalibrationExport,
+    ranking_export: ReviewRankingCalibrationExport | None,
 ) -> EvidenceSelectionSourceExportIdentity:
-    try:
-        source_identity = ensure_matching_source_export_identity(
-            selection_export=selection_export,
-            ranking_export=ranking_export,
+    if ranking_export is None:
+        source_identity = EvidenceSelectionSourceExportIdentity.model_validate(
+            selection_export.model_dump(
+                include={
+                    "source_system",
+                    "export_id",
+                    "exported_at",
+                    "exporter_id",
+                    "redaction_statement",
+                },
+            ),
         )
-    except ValueError as exc:
-        raise EvidenceSelectionExpertStudyBundleError(str(exc)) from exc
+    else:
+        try:
+            source_identity = ensure_matching_source_export_identity(
+                selection_export=selection_export,
+                ranking_export=ranking_export,
+            )
+        except ValueError as exc:
+            raise EvidenceSelectionExpertStudyBundleError(str(exc)) from exc
     requested_identity = _requested_source_identity(request)
     if requested_identity is not None and requested_identity != source_identity:
         msg = (
@@ -231,10 +260,10 @@ def _build_source_manifest(
     *,
     source_identity: EvidenceSelectionSourceExportIdentity,
     selection_source: _LoadedSourceArtifact,
-    ranking_source: _LoadedSourceArtifact,
+    ranking_source: _LoadedSourceArtifact | None,
     adjudication_source: _LoadedSourceArtifact | None,
     selection_reviews: tuple[EvidenceSelectionReviewInput, ...],
-    review_ranking: ReviewRankingCalibrationStudyInput,
+    review_ranking: ReviewRankingCalibrationStudyInput | None,
 ) -> EvidenceSelectionExpertStudySourceManifest:
     return EvidenceSelectionExpertStudySourceManifest(
         source_system=source_identity.source_system,
@@ -248,9 +277,13 @@ def _build_source_manifest(
             adjudication_source=adjudication_source,
         ),
         selection_review_run_ids=tuple(review.run_id for review in selection_reviews),
-        review_ranking_decision_keys=tuple(
-            f"{decision.source_kind}:{decision.item_id}"
-            for decision in review_ranking.decisions
+        review_ranking_decision_keys=(
+            tuple(
+                f"{decision.source_kind}:{decision.item_id}"
+                for decision in review_ranking.decisions
+            )
+            if review_ranking is not None
+            else ()
         ),
         reviewer_roster=_reviewer_roster(
             selection_reviews=selection_reviews,
@@ -262,7 +295,7 @@ def _build_source_manifest(
 def _source_artifacts(
     *,
     selection_source: _LoadedSourceArtifact,
-    ranking_source: _LoadedSourceArtifact,
+    ranking_source: _LoadedSourceArtifact | None,
     adjudication_source: _LoadedSourceArtifact | None,
 ) -> tuple[EvidenceSelectionExpertStudySourceArtifact, ...]:
     artifacts = [
@@ -271,12 +304,15 @@ def _source_artifacts(
             artifact_kind="selection_review_export",
             source=selection_source,
         ),
-        _source_artifact(
-            artifact_id="review-ranking-export",
-            artifact_kind="review_ranking_export",
-            source=ranking_source,
-        ),
     ]
+    if ranking_source is not None:
+        artifacts.append(
+            _source_artifact(
+                artifact_id="review-ranking-export",
+                artifact_kind="review_ranking_export",
+                source=ranking_source,
+            ),
+        )
     if adjudication_source is not None:
         artifacts.append(
             _source_artifact(
@@ -305,19 +341,36 @@ def _source_artifact(
 def _reviewer_roster(
     *,
     selection_reviews: tuple[EvidenceSelectionReviewInput, ...],
-    review_ranking: ReviewRankingCalibrationStudyInput,
+    review_ranking: ReviewRankingCalibrationStudyInput | None,
 ) -> tuple[str, ...]:
     reviewer_ids = {
         reviewer_id.strip()
         for review in selection_reviews
         if (reviewer_id := review.reviewer_id) and reviewer_id.strip()
     }
-    reviewer_ids.update(
-        reviewer_id.strip()
-        for decision in review_ranking.decisions
-        if (reviewer_id := decision.reviewer_id) and reviewer_id.strip()
-    )
+    if review_ranking is not None:
+        reviewer_ids.update(
+            reviewer_id.strip()
+            for decision in review_ranking.decisions
+            if (reviewer_id := decision.reviewer_id) and reviewer_id.strip()
+        )
     return tuple(sorted(reviewer_ids))
+
+
+def _validate_study_sources(
+    *,
+    request: EvidenceSelectionExpertStudyBundleRequest,
+    ranking_export: ReviewRankingCalibrationExport | None,
+) -> None:
+    if request.study_type == "selection_relevance" and ranking_export is not None:
+        msg = "selection_relevance bundles must not include review-ranking input."
+        raise EvidenceSelectionExpertStudyBundleError(msg)
+    if (
+        request.study_type == "selection_and_review_ranking"
+        and ranking_export is None
+    ):
+        msg = "selection_and_review_ranking bundles require review-ranking input."
+        raise EvidenceSelectionExpertStudyBundleError(msg)
 
 
 def _read_source_artifact(*, path: Path, uri: str | None) -> _LoadedSourceArtifact:

--- a/services/artana_evidence_api/evidence_selection_validation.py
+++ b/services/artana_evidence_api/evidence_selection_validation.py
@@ -930,7 +930,6 @@ def _expert_study_blocking_reasons(
             provenance_summary=provenance_summary,
             require_source_manifest=thresholds.require_source_manifest,
             min_source_artifact_count=thresholds.min_source_artifact_count,
-            require_review_ranking=require_review_ranking,
         ),
         *_expert_study_coverage_blocking_reasons(
             selection_summary=selection_summary,

--- a/services/artana_evidence_api/evidence_selection_validation.py
+++ b/services/artana_evidence_api/evidence_selection_validation.py
@@ -13,6 +13,11 @@ from artana_evidence_api.evidence_selection.provenance import (
     build_evidence_selection_provenance_summary,
     source_manifest_blocking_reasons,
 )
+from artana_evidence_api.evidence_selection.review.assessment import (
+    EvidenceSelectionReviewInput,
+    EvidenceSelectionReviewReport,
+    compare_evidence_selection_review,
+)
 from artana_evidence_api.ranking import (
     ReviewRankingCalibrationObservation,
     ReviewRankingCalibrationSummary,
@@ -28,11 +33,16 @@ ReviewRankingCalibrationSchemaVersion = Literal[
     "evidence_selection_review_ranking_calibration.v1"
 ]
 EvidenceSelectionExpertStudySchemaVersion = Literal[
-    "evidence_selection_expert_study.v1"
+    "evidence_selection_expert_study.v2"
 ]
 EvidenceSelectionExpertStudyEvidenceKind = Literal[
     "real_shadow_review",
+    "ai_reviewer_simulation",
     "synthetic_fixture",
+]
+EvidenceSelectionExpertStudyType = Literal[
+    "selection_relevance",
+    "selection_and_review_ranking",
 ]
 
 _SOURCE_KINDS: tuple[ReviewRankingSourceKind, ...] = ("proposal", "review_item")
@@ -45,114 +55,6 @@ def _normalize_non_blank_study_id(value: str) -> str:
         msg = "study_id must not be blank"
         raise ValueError(msg)
     return normalized
-
-
-class EvidenceSelectionReviewInput(BaseModel):
-    """Reviewer-labeled comparison input for one evidence-selection run."""
-
-    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
-
-    run_id: UUID
-    goal: str
-    reviewer_id: str | None = None
-    harness_selected_record_ids: tuple[str, ...]
-    human_selected_record_ids: tuple[str, ...]
-    harness_skipped_record_ids: tuple[str, ...] = ()
-    duplicate_suggestion_ids: tuple[str, ...] = ()
-    explanation_quality_score: int | None = Field(default=None, ge=1, le=5)
-    high_severity_overclaim_count: int | None = Field(default=None, ge=0)
-    reviewer_notes: str | None = None
-    false_positive_notes: dict[str, str] | None = None
-    false_negative_notes: dict[str, str] | None = None
-
-    @field_validator("run_id", mode="before")
-    @classmethod
-    def _accept_json_run_id(cls, value: object) -> object:
-        if isinstance(value, str):
-            return UUID(value)
-        return value
-
-    @field_validator(
-        "harness_selected_record_ids",
-        "human_selected_record_ids",
-        "harness_skipped_record_ids",
-        "duplicate_suggestion_ids",
-        mode="before",
-    )
-    @classmethod
-    def _accept_json_record_id_array(cls, value: object) -> object:
-        if isinstance(value, list):
-            return tuple(value)
-        return value
-
-    @field_validator(
-        "harness_selected_record_ids",
-        "human_selected_record_ids",
-        "harness_skipped_record_ids",
-        "duplicate_suggestion_ids",
-    )
-    @classmethod
-    def _normalize_record_ids(cls, value: tuple[str, ...]) -> tuple[str, ...]:
-        normalized = tuple(record_id.strip() for record_id in value)
-        if any(record_id == "" for record_id in normalized):
-            msg = "record IDs must not be blank"
-            raise ValueError(msg)
-        return normalized
-
-    @field_validator("false_positive_notes", "false_negative_notes")
-    @classmethod
-    def _normalize_finding_notes(
-        cls,
-        value: dict[str, str] | None,
-    ) -> dict[str, str] | None:
-        if value is None:
-            return None
-        normalized = {
-            record_id.strip(): note.strip() for record_id, note in value.items()
-        }
-        if any(record_id == "" for record_id in normalized):
-            msg = "finding-note record IDs must not be blank"
-            raise ValueError(msg)
-        if any(note == "" for note in normalized.values()):
-            msg = "finding notes must not be blank"
-            raise ValueError(msg)
-        return normalized
-
-    @model_validator(mode="after")
-    def _selected_and_skipped_must_not_overlap(
-        self,
-    ) -> EvidenceSelectionReviewInput:
-        overlap = set(self.harness_selected_record_ids).intersection(
-            self.harness_skipped_record_ids,
-        )
-        if overlap:
-            msg = "harness_selected_record_ids and harness_skipped_record_ids overlap"
-            raise ValueError(msg)
-        return self
-
-
-class EvidenceSelectionReviewReport(BaseModel):
-    """Computed review metrics for one evidence-selection run."""
-
-    model_config = ConfigDict(strict=True, frozen=True)
-
-    run_id: UUID
-    goal: str
-    true_positive_ids: tuple[str, ...]
-    false_positive_ids: tuple[str, ...]
-    false_negative_ids: tuple[str, ...]
-    confirmed_skip_ids: tuple[str, ...]
-    duplicate_suggestion_ids: tuple[str, ...]
-    precision: float | None
-    recall: float | None
-    duplicate_suggestion_count: int
-    explanation_quality_score: int | None
-    high_severity_overclaim_count: int | None
-    overclaim_gate_passed: bool
-    reviewer_id: str | None
-    reviewer_notes: str | None
-    false_positive_notes: dict[str, str] | None
-    false_negative_notes: dict[str, str] | None
 
 
 class ReviewRankingCalibrationDecision(BaseModel):
@@ -231,10 +133,10 @@ class EvidenceSelectionExpertStudyGateThresholds(BaseModel):
     min_selection_reviewer_count: int = Field(default=1, ge=1)
     min_mean_precision: float = Field(default=0.8, ge=0.0, le=1.0)
     min_mean_recall: float = Field(default=0.8, ge=0.0, le=1.0)
-    min_mean_explanation_quality: float = Field(default=3.0, ge=1.0, le=5.0)
+    min_explanation_adequacy_rate: float = Field(default=0.8, ge=0.0, le=1.0)
     require_zero_high_severity_overclaims: bool = True
     require_source_manifest: bool = True
-    min_source_artifact_count: int = Field(default=2, ge=1)
+    min_source_artifact_count: int = Field(default=1, ge=1)
 
 
 class EvidenceSelectionExpertStudyInput(BaseModel):
@@ -244,9 +146,10 @@ class EvidenceSelectionExpertStudyInput(BaseModel):
 
     schema_version: EvidenceSelectionExpertStudySchemaVersion
     study_id: str
+    study_type: EvidenceSelectionExpertStudyType
     study_evidence_kind: EvidenceSelectionExpertStudyEvidenceKind
     selection_reviews: tuple[EvidenceSelectionReviewInput, ...]
-    review_ranking: ReviewRankingCalibrationStudyInput
+    review_ranking: ReviewRankingCalibrationStudyInput | None = None
     source_manifest: EvidenceSelectionExpertStudySourceManifest | None = None
     description: str | None = Field(default=None, min_length=1)
 
@@ -266,7 +169,19 @@ class EvidenceSelectionExpertStudyInput(BaseModel):
     def _ranking_study_must_match_outer_study(
         self,
     ) -> EvidenceSelectionExpertStudyInput:
-        if self.study_id != self.review_ranking.study_id:
+        if self.study_type == "selection_relevance" and self.review_ranking is not None:
+            msg = "selection_relevance studies must not include review_ranking"
+            raise ValueError(msg)
+        if (
+            self.study_type == "selection_and_review_ranking"
+            and self.review_ranking is None
+        ):
+            msg = "selection_and_review_ranking studies require review_ranking"
+            raise ValueError(msg)
+        if (
+            self.review_ranking is not None
+            and self.study_id != self.review_ranking.study_id
+        ):
             msg = "review_ranking study_id must match the expert study_id"
             raise ValueError(msg)
         return self
@@ -349,11 +264,12 @@ class EvidenceSelectionExpertStudyGateReport:
 
     passed: bool
     status: ReviewRankingGateStatus
+    study_type: EvidenceSelectionExpertStudyType
     thresholds: EvidenceSelectionExpertStudyGateThresholds
     selection_summary: JSONObject
     provenance_summary: JSONObject
     selection_reports: tuple[EvidenceSelectionReviewReport, ...]
-    review_ranking_gate: ReviewRankingCalibrationGateReport
+    review_ranking_gate: ReviewRankingCalibrationGateReport | None
     blocking_reasons: tuple[str, ...]
 
     def to_json(self) -> JSONObject:
@@ -361,6 +277,7 @@ class EvidenceSelectionExpertStudyGateReport:
         return {
             "passed": self.passed,
             "status": self.status,
+            "study_type": self.study_type,
             "thresholds": {
                 "min_selection_review_count": (
                     self.thresholds.min_selection_review_count
@@ -373,15 +290,13 @@ class EvidenceSelectionExpertStudyGateReport:
                 ),
                 "min_mean_precision": self.thresholds.min_mean_precision,
                 "min_mean_recall": self.thresholds.min_mean_recall,
-                "min_mean_explanation_quality": (
-                    self.thresholds.min_mean_explanation_quality
+                "min_explanation_adequacy_rate": (
+                    self.thresholds.min_explanation_adequacy_rate
                 ),
                 "require_zero_high_severity_overclaims": (
                     self.thresholds.require_zero_high_severity_overclaims
                 ),
-                "require_source_manifest": (
-                    self.thresholds.require_source_manifest
-                ),
+                "require_source_manifest": (self.thresholds.require_source_manifest),
                 "min_source_artifact_count": (
                     self.thresholds.min_source_artifact_count
                 ),
@@ -389,59 +304,15 @@ class EvidenceSelectionExpertStudyGateReport:
             "selection_summary": dict(self.selection_summary),
             "provenance_summary": dict(self.provenance_summary),
             "selection_reports": [
-                _selection_report_to_json(report)
-                for report in self.selection_reports
+                _selection_report_to_json(report) for report in self.selection_reports
             ],
-            "review_ranking_gate": self.review_ranking_gate.to_json(),
+            "review_ranking_gate": (
+                self.review_ranking_gate.to_json()
+                if self.review_ranking_gate is not None
+                else None
+            ),
             "blocking_reasons": list(self.blocking_reasons),
         }
-
-
-def compare_evidence_selection_review(
-    review: EvidenceSelectionReviewInput,
-) -> EvidenceSelectionReviewReport:
-    """Compare harness-selected records with reviewer-selected records."""
-
-    harness_selected = tuple(dict.fromkeys(review.harness_selected_record_ids))
-    human_selected = tuple(dict.fromkeys(review.human_selected_record_ids))
-    harness_skipped = tuple(dict.fromkeys(review.harness_skipped_record_ids))
-    duplicate_suggestions = tuple(dict.fromkeys(review.duplicate_suggestion_ids))
-    harness_selected_set = set(harness_selected)
-    human_selected_set = set(human_selected)
-    true_positive_ids = tuple(
-        record_id for record_id in harness_selected if record_id in human_selected_set
-    )
-    false_positive_ids = tuple(
-        record_id for record_id in harness_selected if record_id not in human_selected_set
-    )
-    false_negative_ids = tuple(
-        record_id for record_id in human_selected if record_id not in harness_selected_set
-    )
-    confirmed_skip_ids = tuple(
-        record_id for record_id in harness_skipped if record_id not in human_selected_set
-    )
-    return EvidenceSelectionReviewReport(
-        run_id=review.run_id,
-        goal=review.goal,
-        true_positive_ids=true_positive_ids,
-        false_positive_ids=false_positive_ids,
-        false_negative_ids=false_negative_ids,
-        confirmed_skip_ids=confirmed_skip_ids,
-        duplicate_suggestion_ids=duplicate_suggestions,
-        precision=_safe_ratio(len(true_positive_ids), len(harness_selected)),
-        recall=_safe_ratio(len(true_positive_ids), len(human_selected)),
-        duplicate_suggestion_count=len(duplicate_suggestions),
-        explanation_quality_score=review.explanation_quality_score,
-        high_severity_overclaim_count=review.high_severity_overclaim_count,
-        overclaim_gate_passed=(
-            review.high_severity_overclaim_count is not None
-            and review.high_severity_overclaim_count == 0
-        ),
-        reviewer_id=review.reviewer_id,
-        reviewer_notes=review.reviewer_notes,
-        false_positive_notes=review.false_positive_notes,
-        false_negative_notes=review.false_negative_notes,
-    )
 
 
 def evaluate_review_ranking_calibration_gate(
@@ -517,40 +388,53 @@ def evaluate_evidence_selection_expert_study_gate(
 
     active_thresholds = thresholds or EvidenceSelectionExpertStudyGateThresholds()
     selection_reports = tuple(
-        compare_evidence_selection_review(review)
-        for review in study.selection_reviews
+        compare_evidence_selection_review(review) for review in study.selection_reviews
     )
     selection_summary = _selection_study_summary(
         reports=selection_reports,
+        study_type=study.study_type,
         study_evidence_kind=study.study_evidence_kind,
+    )
+    review_ranking = study.review_ranking
+    review_ranking_decision_keys = (
+        tuple(
+            _review_ranking_decision_key(decision)
+            for decision in review_ranking.decisions
+        )
+        if review_ranking is not None
+        else ()
     )
     provenance_summary = build_evidence_selection_provenance_summary(
         source_manifest=study.source_manifest,
         selection_run_ids=tuple(report.run_id for report in selection_reports),
-        review_ranking_decision_keys=tuple(
-            _review_ranking_decision_key(decision)
-            for decision in study.review_ranking.decisions
-        ),
+        review_ranking_decision_keys=review_ranking_decision_keys,
         reviewer_ids=_expert_study_reviewer_ids(
             study=study,
             reports=selection_reports,
         ),
+        require_review_ranking=review_ranking is not None,
     )
-    review_ranking_gate = evaluate_review_ranking_calibration_gate(
-        decisions=study.review_ranking.decisions,
-        adjudication_note=study.review_ranking.adjudication_note,
-        thresholds=review_ranking_thresholds,
+    review_ranking_gate = (
+        evaluate_review_ranking_calibration_gate(
+            decisions=review_ranking.decisions,
+            adjudication_note=review_ranking.adjudication_note,
+            thresholds=review_ranking_thresholds,
+        )
+        if review_ranking is not None
+        else None
     )
     blocking_reasons = _expert_study_blocking_reasons(
         selection_summary=selection_summary,
         provenance_summary=provenance_summary,
         thresholds=active_thresholds,
+        require_review_ranking=review_ranking is not None,
         review_ranking_gate=review_ranking_gate,
     )
     passed = not blocking_reasons
     return EvidenceSelectionExpertStudyGateReport(
         passed=passed,
         status="passed" if passed else "failed",
+        study_type=study.study_type,
         thresholds=active_thresholds,
         selection_summary=selection_summary,
         provenance_summary=provenance_summary,
@@ -631,10 +515,14 @@ def _mean_outcome_score(
 
 def _roc_auc(decisions: tuple[ReviewRankingCalibrationDecision, ...]) -> float:
     positive_scores = tuple(
-        decision.ranking_score for decision in decisions if decision.outcome == "positive"
+        decision.ranking_score
+        for decision in decisions
+        if decision.outcome == "positive"
     )
     negative_scores = tuple(
-        decision.ranking_score for decision in decisions if decision.outcome == "negative"
+        decision.ranking_score
+        for decision in decisions
+        if decision.outcome == "negative"
     )
     pair_count = len(positive_scores) * len(negative_scores)
     if pair_count == 0:
@@ -871,6 +759,7 @@ def _normalized_study_label(value: str | None) -> str:
 def _selection_study_summary(
     *,
     reports: tuple[EvidenceSelectionReviewReport, ...],
+    study_type: EvidenceSelectionExpertStudyType,
     study_evidence_kind: EvidenceSelectionExpertStudyEvidenceKind,
 ) -> JSONObject:
     precision_values = tuple(
@@ -879,10 +768,17 @@ def _selection_study_summary(
     recall_values = tuple(
         report.recall for report in reports if report.recall is not None
     )
-    explanation_values = tuple(
-        report.explanation_quality_score
-        for report in reports
-        if report.explanation_quality_score is not None
+    explanation_adequacy_counts = {
+        category: sum(
+            1 for report in reports if report.explanation_adequacy == category
+        )
+        for category in ("adequate", "inadequate", "unclear")
+    }
+    assessed_explanation_count = sum(explanation_adequacy_counts.values())
+    adequate_explanation_count = explanation_adequacy_counts["adequate"]
+    explanation_adequacy_rate = _safe_ratio(
+        adequate_explanation_count,
+        len(reports),
     )
     reviewer_ids = {
         reviewer_id.strip()
@@ -896,6 +792,7 @@ def _selection_study_summary(
     }
     duplicate_run_ids = _duplicate_selection_run_ids(reports)
     return {
+        "study_type": study_type,
         "study_evidence_kind": study_evidence_kind,
         "review_count": len(reports),
         "distinct_goal_count": len(goals),
@@ -914,19 +811,20 @@ def _selection_study_summary(
         "unmeasurable_recall_count": sum(
             1 for report in reports if report.recall is None
         ),
-        "missing_explanation_quality_count": sum(
-            1 for report in reports if report.explanation_quality_score is None
+        "missing_explanation_assessment_count": (
+            len(reports) - assessed_explanation_count
         ),
-        "missing_high_severity_overclaim_count": sum(
-            1
-            for report in reports
-            if report.high_severity_overclaim_count is None
+        "missing_high_severity_overclaim_findings_count": sum(
+            1 for report in reports if report.high_severity_overclaim_count is None
         ),
         "duplicate_run_id_count": len(duplicate_run_ids),
         "duplicate_run_ids": list(duplicate_run_ids),
         "mean_precision": _round_gate_metric(_mean(precision_values)),
         "mean_recall": _round_gate_metric(_mean(recall_values)),
-        "mean_explanation_quality": _round_gate_metric(_mean(explanation_values)),
+        "explanation_adequacy_counts": explanation_adequacy_counts,
+        "explanation_adequacy_rate": _round_gate_metric(
+            explanation_adequacy_rate or 0.0,
+        ),
         "high_severity_overclaim_count": sum(
             report.high_severity_overclaim_count
             for report in reports
@@ -951,7 +849,20 @@ def _selection_report_to_json(report: EvidenceSelectionReviewReport) -> JSONObje
         "precision": report.precision,
         "recall": report.recall,
         "duplicate_suggestion_count": report.duplicate_suggestion_count,
-        "explanation_quality_score": report.explanation_quality_score,
+        "explanation_assessment": (
+            report.explanation_assessment.model_dump(mode="json")
+            if report.explanation_assessment is not None
+            else None
+        ),
+        "explanation_adequacy": report.explanation_adequacy,
+        "high_severity_overclaim_findings": (
+            [
+                finding.model_dump(mode="json")
+                for finding in report.high_severity_overclaim_findings
+            ]
+            if report.high_severity_overclaim_findings is not None
+            else None
+        ),
         "high_severity_overclaim_count": report.high_severity_overclaim_count,
         "overclaim_gate_passed": report.overclaim_gate_passed,
         "reviewer_notes": report.reviewer_notes,
@@ -987,11 +898,15 @@ def _expert_study_reviewer_ids(
         for report in reports
         if (reviewer_id := report.reviewer_id) and reviewer_id.strip()
     }
-    ranking_reviewer_ids = {
-        reviewer_id.strip()
-        for decision in study.review_ranking.decisions
-        if (reviewer_id := decision.reviewer_id) and reviewer_id.strip()
-    }
+    ranking_reviewer_ids = (
+        {
+            reviewer_id.strip()
+            for decision in study.review_ranking.decisions
+            if (reviewer_id := decision.reviewer_id) and reviewer_id.strip()
+        }
+        if study.review_ranking is not None
+        else set()
+    )
     return selection_reviewer_ids | ranking_reviewer_ids
 
 
@@ -1006,7 +921,8 @@ def _expert_study_blocking_reasons(
     selection_summary: JSONObject,
     provenance_summary: JSONObject,
     thresholds: EvidenceSelectionExpertStudyGateThresholds,
-    review_ranking_gate: ReviewRankingCalibrationGateReport,
+    require_review_ranking: bool,
+    review_ranking_gate: ReviewRankingCalibrationGateReport | None,
 ) -> tuple[str, ...]:
     return (
         *_expert_study_provenance_blocking_reasons(selection_summary),
@@ -1014,6 +930,7 @@ def _expert_study_blocking_reasons(
             provenance_summary=provenance_summary,
             require_source_manifest=thresholds.require_source_manifest,
             min_source_artifact_count=thresholds.min_source_artifact_count,
+            require_review_ranking=require_review_ranking,
         ),
         *_expert_study_coverage_blocking_reasons(
             selection_summary=selection_summary,
@@ -1023,7 +940,10 @@ def _expert_study_blocking_reasons(
             selection_summary=selection_summary,
             thresholds=thresholds,
         ),
-        *_expert_study_ranking_blocking_reasons(review_ranking_gate),
+        *_expert_study_ranking_blocking_reasons(
+            require_review_ranking=require_review_ranking,
+            review_ranking_gate=review_ranking_gate,
+        ),
     )
 
 
@@ -1081,9 +1001,9 @@ def _expert_study_coverage_blocking_reasons(
         reasons.append("Every selection review must have measurable precision.")
     if _int_from_json(selection_summary, "unmeasurable_recall_count") > 0:
         reasons.append("Every selection review must have measurable recall.")
-    if _int_from_json(selection_summary, "missing_explanation_quality_count") > 0:
+    if _int_from_json(selection_summary, "missing_explanation_assessment_count") > 0:
         reasons.append(
-            "Every selection review must include an explanation-quality score.",
+            "Every selection review must include a categorical explanation assessment.",
         )
     return tuple(reasons)
 
@@ -1094,7 +1014,10 @@ def _expert_study_quality_blocking_reasons(
     thresholds: EvidenceSelectionExpertStudyGateThresholds,
 ) -> tuple[str, ...]:
     reasons: list[str] = []
-    if _float_from_json(selection_summary, "mean_precision") < thresholds.min_mean_precision:
+    if (
+        _float_from_json(selection_summary, "mean_precision")
+        < thresholds.min_mean_precision
+    ):
         reasons.append(
             "Expert/shadow mean selection precision is below target: "
             f"{_float_from_json(selection_summary, 'mean_precision'):.6f} < "
@@ -1107,24 +1030,24 @@ def _expert_study_quality_blocking_reasons(
             f"{thresholds.min_mean_recall:.6f}.",
         )
     if (
-        _float_from_json(selection_summary, "mean_explanation_quality")
-        < thresholds.min_mean_explanation_quality
+        _float_from_json(selection_summary, "explanation_adequacy_rate")
+        < thresholds.min_explanation_adequacy_rate
     ):
         reasons.append(
-            "Expert/shadow mean explanation quality is below target: "
-            f"{_float_from_json(selection_summary, 'mean_explanation_quality'):.6f} < "
-            f"{thresholds.min_mean_explanation_quality:.6f}.",
+            "Expert/shadow explanation adequacy rate is below target: "
+            f"{_float_from_json(selection_summary, 'explanation_adequacy_rate'):.6f} < "
+            f"{thresholds.min_explanation_adequacy_rate:.6f}.",
         )
     if (
         thresholds.require_zero_high_severity_overclaims
         and _int_from_json(
             selection_summary,
-            "missing_high_severity_overclaim_count",
+            "missing_high_severity_overclaim_findings_count",
         )
         > 0
     ):
         reasons.append(
-            "Every selection review must include a high-severity overclaim count.",
+            "Every selection review must include explicit high-severity overclaim findings.",
         )
     if (
         thresholds.require_zero_high_severity_overclaims
@@ -1135,8 +1058,14 @@ def _expert_study_quality_blocking_reasons(
 
 
 def _expert_study_ranking_blocking_reasons(
-    review_ranking_gate: ReviewRankingCalibrationGateReport,
+    *,
+    require_review_ranking: bool,
+    review_ranking_gate: ReviewRankingCalibrationGateReport | None,
 ) -> tuple[str, ...]:
+    if not require_review_ranking:
+        return ()
+    if review_ranking_gate is None:
+        return ("A review-ranking gate is required for the combined study type.",)
     if review_ranking_gate.passed:
         return ()
     return (

--- a/services/artana_evidence_api/tests/unit/evidence_selection_review_fixtures.py
+++ b/services/artana_evidence_api/tests/unit/evidence_selection_review_fixtures.py
@@ -1,0 +1,94 @@
+"""Reusable categorical reviewer evidence for evidence-selection tests."""
+
+from __future__ import annotations
+
+from artana_evidence_api.evidence_selection.review.assessment import (
+    EvidenceSelectionExplanationAssessment,
+    EvidenceSelectionOverclaimFinding,
+    EvidenceSelectionReviewCitation,
+)
+
+
+def adequate_explanation_assessment(
+    record_id: str = "pubmed:search-1:0",
+) -> EvidenceSelectionExplanationAssessment:
+    """Return an assessment that deterministically derives to adequate."""
+
+    return EvidenceSelectionExplanationAssessment(
+        literal_citation_present="yes",
+        citation_entails_claim="yes",
+        all_required_criteria_addressed="yes",
+        unsupported_material_claim_present="no",
+        cited_evidence=(
+            EvidenceSelectionReviewCitation(
+                record_id=record_id,
+                source_locator=f"candidate:{record_id}:abstract",
+                quoted_text="Literal evidence supporting the review decision.",
+            ),
+        ),
+        reviewer_explanation="The cited source addresses every required criterion.",
+    )
+
+
+def inadequate_explanation_assessment(
+    record_id: str = "pubmed:search-1:0",
+) -> EvidenceSelectionExplanationAssessment:
+    """Return an assessment with a deterministic criteria-coverage veto."""
+
+    return EvidenceSelectionExplanationAssessment(
+        literal_citation_present="yes",
+        citation_entails_claim="yes",
+        all_required_criteria_addressed="no",
+        unsupported_material_claim_present="no",
+        cited_evidence=(
+            EvidenceSelectionReviewCitation(
+                record_id=record_id,
+                source_locator=f"candidate:{record_id}:abstract",
+                quoted_text="Literal evidence supporting only part of the decision.",
+            ),
+        ),
+        reviewer_explanation="The explanation does not address every required criterion.",
+    )
+
+
+def high_severity_overclaim_finding(
+    record_id: str = "record-1",
+) -> EvidenceSelectionOverclaimFinding:
+    """Return one explicit high-severity overclaim finding."""
+
+    return EvidenceSelectionOverclaimFinding(
+        record_id=record_id,
+        material_claim="The intervention is proven safe for all patients.",
+        reviewer_explanation="The cited source does not establish universal safety.",
+        cited_evidence=(
+            EvidenceSelectionReviewCitation(
+                record_id=record_id,
+                source_locator=f"candidate:{record_id}:limitations",
+                quoted_text="Safety evidence remains limited.",
+            ),
+        ),
+    )
+
+
+def complete_selection_review_form(
+    form: dict[str, object],
+    *,
+    reviewer_id: str = "reviewer-a",
+    human_selected_record_ids: list[str] | None = None,
+) -> None:
+    """Fill the human-owned fields of one mutable packet form."""
+
+    form["reviewer_id"] = reviewer_id
+    form["human_selected_record_ids"] = human_selected_record_ids or []
+    form["explanation_assessment"] = adequate_explanation_assessment().model_dump(
+        mode="json",
+    )
+    form["high_severity_overclaim_findings"] = []
+
+
+__all__ = [
+    "adequate_explanation_assessment",
+    "complete_selection_review_form",
+    "high_severity_overclaim_finding",
+    "inadequate_explanation_assessment",
+]

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_review_assessment.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_review_assessment.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from artana_evidence_api.evidence_selection.review.assessment import (
     EvidenceSelectionExplanationAssessment,
+    EvidenceSelectionOverclaimFinding,
     EvidenceSelectionReviewCitation,
     EvidenceSelectionReviewInput,
     derive_explanation_adequacy,
@@ -95,6 +96,7 @@ def test_unsupported_material_claim_requires_explicit_overclaim_finding() -> Non
             run_id="00000000-0000-0000-0000-000000000001",
             goal="Assess source relevance.",
             reviewer_id="reviewer-a",
+            candidate_record_ids=("pubmed:search-1:0",),
             harness_selected_record_ids=("pubmed:search-1:0",),
             human_selected_record_ids=("pubmed:search-1:0",),
             explanation_assessment=assessment,
@@ -108,10 +110,71 @@ def test_overclaim_finding_cannot_contradict_no_unsupported_claim() -> None:
             run_id="00000000-0000-0000-0000-000000000001",
             goal="Assess source relevance.",
             reviewer_id="reviewer-a",
+            candidate_record_ids=("pubmed:search-1:0",),
             harness_selected_record_ids=("pubmed:search-1:0",),
             human_selected_record_ids=("pubmed:search-1:0",),
             explanation_assessment=adequate_explanation_assessment(),
             high_severity_overclaim_findings=(
                 high_severity_overclaim_finding("pubmed:search-1:0"),
             ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("assessment", "overclaim_findings"),
+    [
+        pytest.param(
+            adequate_explanation_assessment("unknown-record"),
+            (),
+            id="explanation-citation",
+        ),
+        pytest.param(
+            adequate_explanation_assessment("record-1").model_copy(
+                update={"unsupported_material_claim_present": "yes"},
+            ),
+            (
+                high_severity_overclaim_finding("unknown-record").model_copy(
+                    update={"cited_evidence": ()},
+                ),
+            ),
+            id="overclaim-record",
+        ),
+        pytest.param(
+            adequate_explanation_assessment("record-1").model_copy(
+                update={"unsupported_material_claim_present": "yes"},
+            ),
+            (
+                high_severity_overclaim_finding("record-1").model_copy(
+                    update={
+                        "cited_evidence": (
+                            EvidenceSelectionReviewCitation(
+                                record_id="unknown-record",
+                                source_locator="candidate:unknown-record:limitations",
+                                quoted_text="Unbound source text.",
+                            ),
+                        ),
+                    },
+                ),
+            ),
+            id="overclaim-citation",
+        ),
+    ],
+)
+def test_direct_review_rejects_unknown_evidence_record_ids(
+    assessment: EvidenceSelectionExplanationAssessment,
+    overclaim_findings: tuple[EvidenceSelectionOverclaimFinding, ...],
+) -> None:
+    with pytest.raises(
+        ValidationError,
+        match="unknown candidate record IDs: unknown-record",
+    ):
+        EvidenceSelectionReviewInput(
+            run_id="00000000-0000-0000-0000-000000000001",
+            goal="Assess source relevance.",
+            reviewer_id="reviewer-a",
+            candidate_record_ids=("record-1",),
+            harness_selected_record_ids=("record-1",),
+            human_selected_record_ids=("record-1",),
+            explanation_assessment=assessment,
+            high_severity_overclaim_findings=overclaim_findings,
         )

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_review_assessment.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_review_assessment.py
@@ -1,0 +1,117 @@
+"""Adversarial tests for categorical explanation-review findings."""
+
+from __future__ import annotations
+
+import pytest
+from artana_evidence_api.evidence_selection.review.assessment import (
+    EvidenceSelectionExplanationAssessment,
+    EvidenceSelectionReviewCitation,
+    EvidenceSelectionReviewInput,
+    derive_explanation_adequacy,
+)
+from pydantic import ValidationError
+
+from .evidence_selection_review_fixtures import (
+    adequate_explanation_assessment,
+    high_severity_overclaim_finding,
+    inadequate_explanation_assessment,
+)
+
+
+def test_complete_grounded_findings_derive_adequate() -> None:
+    assessment = adequate_explanation_assessment()
+
+    assert derive_explanation_adequacy(assessment) == "adequate"
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("literal_citation_present", "no"),
+        ("citation_entails_claim", "no"),
+        ("all_required_criteria_addressed", "no"),
+        ("unsupported_material_claim_present", "yes"),
+    ],
+)
+def test_each_atomic_veto_derives_inadequate(
+    field_name: str,
+    value: str,
+) -> None:
+    payload = adequate_explanation_assessment().model_dump(mode="json")
+    payload[field_name] = value
+    if field_name == "literal_citation_present":
+        payload["cited_evidence"] = []
+        payload["citation_entails_claim"] = "unclear"
+
+    assessment = EvidenceSelectionExplanationAssessment.model_validate(payload)
+
+    assert derive_explanation_adequacy(assessment) == "inadequate"
+
+
+def test_unclear_entailment_is_not_laundered_into_adequate() -> None:
+    assessment = adequate_explanation_assessment().model_copy(
+        update={"citation_entails_claim": "unclear"},
+    )
+
+    assert derive_explanation_adequacy(assessment) == "unclear"
+
+
+def test_claimed_citation_requires_literal_evidence() -> None:
+    payload = adequate_explanation_assessment().model_dump(mode="json")
+    payload["cited_evidence"] = []
+
+    with pytest.raises(ValidationError, match="cited_evidence is required"):
+        EvidenceSelectionExplanationAssessment.model_validate(payload)
+
+
+def test_absent_citation_cannot_claim_entailment() -> None:
+    payload = adequate_explanation_assessment().model_dump(mode="json")
+    payload["literal_citation_present"] = "no"
+    payload["cited_evidence"] = []
+
+    with pytest.raises(ValidationError, match="must be unclear"):
+        EvidenceSelectionExplanationAssessment.model_validate(payload)
+
+
+def test_literal_quote_is_preserved_without_lossy_normalization() -> None:
+    citation = EvidenceSelectionReviewCitation(
+        record_id="record-1",
+        source_locator="candidate:record-1:abstract",
+        quoted_text="  Exact source text with meaningful spacing.  ",
+    )
+
+    assert citation.quoted_text == "  Exact source text with meaningful spacing.  "
+
+
+def test_unsupported_material_claim_requires_explicit_overclaim_finding() -> None:
+    assessment = inadequate_explanation_assessment().model_copy(
+        update={
+            "all_required_criteria_addressed": "yes",
+            "unsupported_material_claim_present": "yes",
+        },
+    )
+    with pytest.raises(ValidationError, match="require at least one explicit"):
+        EvidenceSelectionReviewInput(
+            run_id="00000000-0000-0000-0000-000000000001",
+            goal="Assess source relevance.",
+            reviewer_id="reviewer-a",
+            harness_selected_record_ids=("pubmed:search-1:0",),
+            human_selected_record_ids=("pubmed:search-1:0",),
+            explanation_assessment=assessment,
+            high_severity_overclaim_findings=(),
+        )
+
+
+def test_overclaim_finding_cannot_contradict_no_unsupported_claim() -> None:
+    with pytest.raises(ValidationError, match="require.*to be yes"):
+        EvidenceSelectionReviewInput(
+            run_id="00000000-0000-0000-0000-000000000001",
+            goal="Assess source relevance.",
+            reviewer_id="reviewer-a",
+            harness_selected_record_ids=("pubmed:search-1:0",),
+            human_selected_record_ids=("pubmed:search-1:0",),
+            explanation_assessment=adequate_explanation_assessment(),
+            high_severity_overclaim_findings=(
+                high_severity_overclaim_finding("pubmed:search-1:0"),
+            ),
+        )

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_completion.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_completion.py
@@ -19,6 +19,8 @@ from artana_evidence_api.evidence_selection_validation import (
 )
 from pydantic import ValidationError
 
+from .evidence_selection_review_fixtures import adequate_explanation_assessment
+
 _RUN_ID = "00000000-0000-0000-0000-000000000048"
 _GOAL = "Review BRAF V600E treatment-response evidence."
 
@@ -49,8 +51,10 @@ def test_completed_packet_builds_source_export_inputs() -> None:
                 ],
                 "harness_skipped_record_ids": ["pubmed:search-1:1"],
                 "duplicate_suggestion_ids": ["pubmed:search-1:1"],
-                "explanation_quality_score": 4,
-                "high_severity_overclaim_count": 0,
+                "explanation_assessment": (
+                    adequate_explanation_assessment().model_dump(mode="json")
+                ),
+                "high_severity_overclaim_findings": [],
                 "reviewer_notes": "Selected the deferred ClinVar record as useful.",
                 "false_positive_notes": None,
                 "false_negative_notes": None,
@@ -100,6 +104,51 @@ def test_completed_packet_rejects_unknown_human_selected_record_id() -> None:
     packet["selection_review_forms"][0]["human_selected_record_ids"] = [
         "pubmed:search-1:0",
         "unknown:record",
+    ]
+
+    with pytest.raises(ValueError, match="unknown record id"):
+        completion.build_evidence_selection_shadow_review_source_inputs(
+            completion.EvidenceSelectionShadowReviewSourceInputRequest(
+                machine_packet=_machine_packet(),
+                packet=packet,
+                adjudication_note="Reviewer A completed labels.",
+            ),
+        )
+
+
+def test_completed_packet_rejects_explanation_citation_for_unknown_record() -> None:
+    completion = _completion_module()
+    packet = _completed_packet()
+    packet["selection_review_forms"][0]["explanation_assessment"] = (
+        adequate_explanation_assessment("unknown:record").model_dump(mode="json")
+    )
+
+    with pytest.raises(ValueError, match="unknown record id"):
+        completion.build_evidence_selection_shadow_review_source_inputs(
+            completion.EvidenceSelectionShadowReviewSourceInputRequest(
+                machine_packet=_machine_packet(),
+                packet=packet,
+                adjudication_note="Reviewer A completed labels.",
+            ),
+        )
+
+
+def test_completed_packet_rejects_overclaim_citation_for_unknown_record() -> None:
+    completion = _completion_module()
+    packet = _completed_packet()
+    packet["selection_review_forms"][0]["high_severity_overclaim_findings"] = [
+        {
+            "record_id": "pubmed:search-1:0",
+            "material_claim": "The intervention is universally safe.",
+            "reviewer_explanation": "The packet does not establish this claim.",
+            "cited_evidence": [
+                {
+                    "record_id": "unknown:record",
+                    "source_locator": "candidate:unknown:record:abstract",
+                    "quoted_text": "No matching source exists in this packet.",
+                },
+            ],
+        },
     ]
 
     with pytest.raises(ValueError, match="unknown record id"):
@@ -237,8 +286,10 @@ def _completed_packet() -> dict[str, object]:
         "clinvar:search-1:2",
     ]
     selection_form["duplicate_suggestion_ids"] = ["pubmed:search-1:1"]
-    selection_form["explanation_quality_score"] = 4
-    selection_form["high_severity_overclaim_count"] = 0
+    selection_form["explanation_assessment"] = (
+        adequate_explanation_assessment().model_dump(mode="json")
+    )
+    selection_form["high_severity_overclaim_findings"] = []
     selection_form["reviewer_notes"] = "Selected the deferred ClinVar record as useful."
     for index, ranking_form in enumerate(packet["review_ranking_forms"]):
         ranking_form["outcome"] = "positive" if index == 0 else "negative"
@@ -252,8 +303,8 @@ def _machine_packet() -> dict[str, object]:
     selection_form["reviewer_id"] = None
     selection_form["human_selected_record_ids"] = []
     selection_form["duplicate_suggestion_ids"] = []
-    selection_form["explanation_quality_score"] = None
-    selection_form["high_severity_overclaim_count"] = None
+    selection_form["explanation_assessment"] = None
+    selection_form["high_severity_overclaim_findings"] = None
     selection_form["reviewer_notes"] = None
     for ranking_form in packet["review_ranking_forms"]:
         ranking_form["outcome"] = None
@@ -267,8 +318,9 @@ def _machine_packet() -> dict[str, object]:
 
 def _packet_payload() -> dict[str, object]:
     return {
-        "schema_version": "evidence_selection_shadow_review_packet.v1",
+        "schema_version": "evidence_selection_shadow_review_packet.v2",
         "study_id": "shadow-study-2026-07-07",
+        "study_type": "selection_and_review_ranking",
         "source_run_id": _RUN_ID,
         "goal": _GOAL,
         "production_readiness_claim": False,
@@ -276,8 +328,8 @@ def _packet_payload() -> dict[str, object]:
         "completion_required_fields": [
             "selection_review_forms[].reviewer_id",
             "selection_review_forms[].human_selected_record_ids",
-            "selection_review_forms[].explanation_quality_score",
-            "selection_review_forms[].high_severity_overclaim_count",
+            "selection_review_forms[].explanation_assessment",
+            "selection_review_forms[].high_severity_overclaim_findings",
             "review_ranking_forms[].reviewer_id",
             "review_ranking_forms[].outcome",
         ],
@@ -299,8 +351,10 @@ def _packet_payload() -> dict[str, object]:
                     "clinvar:search-1:2",
                 ],
                 "duplicate_suggestion_ids": ["pubmed:search-1:1"],
-                "explanation_quality_score": 4,
-                "high_severity_overclaim_count": 0,
+                "explanation_assessment": (
+                    adequate_explanation_assessment().model_dump(mode="json")
+                ),
+                "high_severity_overclaim_findings": [],
                 "reviewer_notes": "Selected the deferred ClinVar record as useful.",
             },
         ],

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_completion.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_completion.py
@@ -44,6 +44,11 @@ def test_completed_packet_builds_source_export_inputs() -> None:
                 "run_id": _RUN_ID,
                 "goal": _GOAL,
                 "reviewer_id": "reviewer-a",
+                "candidate_record_ids": [
+                    "pubmed:search-1:0",
+                    "pubmed:search-1:1",
+                    "clinvar:search-1:2",
+                ],
                 "harness_selected_record_ids": ["pubmed:search-1:0"],
                 "human_selected_record_ids": [
                     "pubmed:search-1:0",

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_completion_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_completion_cli.py
@@ -19,6 +19,8 @@ from artana_evidence_api.evidence_selection.shadow_review_packet import (
     machine_packet_digest,
 )
 
+from .evidence_selection_review_fixtures import adequate_explanation_assessment
+
 
 def test_shadow_review_completion_cli_writes_source_input_files(
     tmp_path: Path,
@@ -56,6 +58,33 @@ def test_shadow_review_completion_cli_writes_source_input_files(
     )
     assert ranking_payload["adjudication_note"] == "Reviewer A completed all labels."
     assert ranking_payload["decisions"][0]["outcome"] == "positive"
+
+
+def test_shadow_review_completion_cli_writes_selection_only_input(
+    tmp_path: Path,
+) -> None:
+    cli = _cli_module()
+    packet_path = tmp_path / "completed-selection-packet.json"
+    selection_output = tmp_path / "selection-review-labels.json"
+    packet = _completed_packet()
+    packet["study_type"] = "selection_relevance"
+    packet["completion_required_fields"] = packet["completion_required_fields"][:4]
+    packet["review_ranking_forms"] = []
+    _write_completed_packet(packet_path, packet)
+
+    exit_code = cli.main(
+        (
+            "--packet",
+            str(packet_path),
+            "--selection-reviews-output",
+            str(selection_output),
+        ),
+    )
+
+    assert exit_code == 0
+    payload = json.loads(selection_output.read_text())
+    assert payload["selection_reviews"][0]["reviewer_id"] == "reviewer-a"
+    assert not (tmp_path / "review-ranking-study.json").exists()
 
 
 def test_shadow_review_completion_cli_rejects_incomplete_packet_without_traceback(
@@ -321,8 +350,8 @@ def _machine_packet_for_completed_packet(
     selection_form["reviewer_id"] = None
     selection_form["human_selected_record_ids"] = []
     selection_form["duplicate_suggestion_ids"] = []
-    selection_form["explanation_quality_score"] = None
-    selection_form["high_severity_overclaim_count"] = None
+    selection_form["explanation_assessment"] = None
+    selection_form["high_severity_overclaim_findings"] = None
     selection_form["reviewer_notes"] = None
     for ranking_form in machine_packet["review_ranking_forms"]:
         ranking_form["outcome"] = None
@@ -340,17 +369,21 @@ def _write_completed_packet(
     path: Path,
     packet: dict[str, object],
 ) -> Path:
+    machine_packet = _machine_packet_for_completed_packet(packet)
+    packet["machine_packet_sha256"] = machine_packet["machine_packet_sha256"]
+    packet["machine_packet_signature"] = machine_packet["machine_packet_signature"]
     path.write_text(json.dumps(packet))
     machine_packet_sidecar_path(path).write_text(
-        json.dumps(_machine_packet_for_completed_packet(packet)),
+        json.dumps(machine_packet),
     )
     return path
 
 
 def _completed_packet_payload() -> dict[str, object]:
     return {
-        "schema_version": "evidence_selection_shadow_review_packet.v1",
+        "schema_version": "evidence_selection_shadow_review_packet.v2",
         "study_id": "shadow-study-2026-07-07",
+        "study_type": "selection_and_review_ranking",
         "source_run_id": "00000000-0000-0000-0000-000000000048",
         "goal": "Review BRAF V600E treatment-response evidence.",
         "production_readiness_claim": False,
@@ -358,8 +391,8 @@ def _completed_packet_payload() -> dict[str, object]:
         "completion_required_fields": [
             "selection_review_forms[].reviewer_id",
             "selection_review_forms[].human_selected_record_ids",
-            "selection_review_forms[].explanation_quality_score",
-            "selection_review_forms[].high_severity_overclaim_count",
+            "selection_review_forms[].explanation_assessment",
+            "selection_review_forms[].high_severity_overclaim_findings",
             "review_ranking_forms[].reviewer_id",
             "review_ranking_forms[].outcome",
         ],
@@ -377,8 +410,10 @@ def _completed_packet_payload() -> dict[str, object]:
                 "harness_deferred_record_ids": [],
                 "human_selected_record_ids": ["pubmed:search-1:0"],
                 "duplicate_suggestion_ids": [],
-                "explanation_quality_score": 4,
-                "high_severity_overclaim_count": 0,
+                "explanation_assessment": (
+                    adequate_explanation_assessment().model_dump(mode="json")
+                ),
+                "high_severity_overclaim_findings": [],
                 "reviewer_notes": "Looks specific.",
             },
         ],

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_packet.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_packet.py
@@ -71,7 +71,8 @@ def test_shadow_review_packet_creates_incomplete_human_label_forms() -> None:
     )
 
     payload = packet.model_dump(mode="json")
-    assert payload["schema_version"] == "evidence_selection_shadow_review_packet.v1"
+    assert payload["schema_version"] == "evidence_selection_shadow_review_packet.v2"
+    assert payload["study_type"] == "selection_and_review_ranking"
     assert payload["production_readiness_claim"] is False
     assert payload["completion_status"] == "requires_human_labels"
     assert "selection_reviews" not in payload
@@ -88,8 +89,8 @@ def test_shadow_review_packet_creates_incomplete_human_label_forms() -> None:
         f"clinvar:{_SEARCH_ID}:2",
     ]
     assert selection_form["human_selected_record_ids"] == []
-    assert selection_form["explanation_quality_score"] is None
-    assert selection_form["high_severity_overclaim_count"] is None
+    assert selection_form["explanation_assessment"] is None
+    assert selection_form["high_severity_overclaim_findings"] is None
     assert "selection_review_forms[].human_selected_record_ids" in payload[
         "completion_required_fields"
     ]
@@ -138,6 +139,29 @@ def test_shadow_review_packet_forms_do_not_validate_as_completed_expert_labels()
         )
 
 
+def test_shadow_packet_without_ranking_items_is_explicitly_selection_only() -> None:
+    packet_module = _packet_module()
+
+    packet = packet_module.build_evidence_selection_shadow_review_packet(
+        packet_module.EvidenceSelectionShadowReviewPacketRequest(
+            study_id="selection-only-study",
+            run_id=_RUN_ID,
+            goal=_GOAL,
+            selected_records=(
+                _decision(source_key="pubmed", decision="selected", record_index=0),
+            ),
+        ),
+    )
+    payload = packet.model_dump(mode="json")
+
+    assert payload["study_type"] == "selection_relevance"
+    assert payload["review_ranking_forms"] == []
+    assert all(
+        not field.startswith("review_ranking_forms")
+        for field in payload["completion_required_fields"]
+    )
+
+
 def test_shadow_review_packet_counts_shadow_mode_recommendations_as_harness_selected() -> None:
     packet_module = _packet_module()
 
@@ -183,8 +207,9 @@ def test_shadow_review_packet_schema_enforces_incomplete_collection_invariants()
     with pytest.raises(ValidationError):
         EvidenceSelectionShadowReviewPacket.model_validate(
             {
-                "schema_version": "evidence_selection_shadow_review_packet.v1",
+                "schema_version": "evidence_selection_shadow_review_packet.v2",
                 "study_id": "shadow-study-2026-07-07",
+                "study_type": "selection_relevance",
                 "source_run_id": _RUN_ID,
                 "goal": _GOAL,
                 "production_readiness_claim": True,

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_packet_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_packet_cli.py
@@ -38,7 +38,7 @@ def test_shadow_review_packet_cli_writes_collection_packet(tmp_path: Path) -> No
 
     assert exit_code == 0
     packet = json.loads(output_path.read_text())
-    assert packet["schema_version"] == "evidence_selection_shadow_review_packet.v1"
+    assert packet["schema_version"] == "evidence_selection_shadow_review_packet.v2"
     assert packet["source_run_id"] == _RUN_ID
     assert packet["production_readiness_claim"] is False
     assert packet["machine_packet_sha256"]

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_packet_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_packet_cli.py
@@ -189,7 +189,7 @@ def test_shadow_review_packet_cli_derives_ranking_forms_from_shadow_candidates(
     ]
 
 
-def test_shadow_review_packet_cli_rejects_result_without_rankable_items(
+def test_shadow_review_packet_cli_writes_selection_only_packet_without_ranking_items(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -197,8 +197,6 @@ def test_shadow_review_packet_cli_rejects_result_without_rankable_items(
     run_result_path = tmp_path / "evidence-selection-result.json"
     output_path = tmp_path / "shadow-review-packet.json"
     payload = _run_result_payload()
-    payload["selected_records"] = []
-    payload["skipped_records"] = []
     payload["deferred_records"] = []
     payload.pop("review_ranking_items")
     run_result_path.write_text(json.dumps(payload))
@@ -215,10 +213,13 @@ def test_shadow_review_packet_cli_rejects_result_without_rankable_items(
     )
 
     captured = capsys.readouterr()
-    assert exit_code == 1
-    assert "no rankable items" in captured.err
-    assert not output_path.exists()
-    assert not machine_packet_sidecar_path(output_path).exists()
+    assert exit_code == 0
+    assert captured.err == ""
+    packet = json.loads(output_path.read_text())
+    assert packet["study_type"] == "selection_relevance"
+    assert packet["review_ranking_forms"] == []
+    assert packet["candidate_records"]
+    assert machine_packet_sidecar_path(output_path).exists()
 
 
 def test_shadow_review_packet_cli_rejects_invalid_run_result_without_traceback(

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_batch.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_batch.py
@@ -13,6 +13,9 @@ from artana_evidence_api.evidence_selection.shadow_review_completion import (
     machine_packet_sidecar_path,
 )
 
+from services.artana_evidence_api.tests.unit.evidence_selection_review_fixtures import (
+    inadequate_explanation_assessment,
+)
 from services.artana_evidence_api.tests.unit.test_evidence_selection_shadow_review_study_pipeline import (  # noqa: E501
     _completed_packet,
     _machine_packet_for_completed_packet,
@@ -80,7 +83,10 @@ def test_shadow_review_study_batch_aggregates_passed_and_failed_gates(
         output_dir / "weak-study" / "evidence-selection-expert-study.json"
     )
     report = result.to_json()
-    assert report["schema_version"] == "evidence_selection_shadow_review_study_batch_report.v1"
+    assert (
+        report["schema_version"]
+        == "evidence_selection_shadow_review_study_batch_report.v1"
+    )
     assert report["passed"] is False
     assert report["passed_entry_count"] == 1
     assert report["failed_entry_count"] == 1
@@ -381,13 +387,11 @@ def test_shadow_review_study_batch_requires_per_source_ranking_outcomes(
         "review_item": ["negative"],
     }
     assert any(
-        "negative reviewer outcome is required for source kind proposal"
-        in reason
+        "negative reviewer outcome is required for source kind proposal" in reason
         for reason in result.suite_gate["blocking_reasons"]
     )
     assert any(
-        "positive reviewer outcome is required for source kind review_item"
-        in reason
+        "positive reviewer outcome is required for source kind review_item" in reason
         for reason in result.suite_gate["blocking_reasons"]
     )
 
@@ -808,7 +812,7 @@ def test_shadow_review_study_batch_quality_gate_uses_unrounded_metrics() -> None
     metrics = batch._BatchQualityMetrics(  # noqa: SLF001
         suite_mean_precision=0.79996,
         suite_mean_recall=0.79996,
-        suite_mean_explanation_quality=2.99996,
+        suite_explanation_adequacy_rate=0.79996,
         max_review_ranking_expected_calibration_error=0.05,
     )
 
@@ -819,7 +823,7 @@ def test_shadow_review_study_batch_quality_gate_uses_unrounded_metrics() -> None
 
     assert any("suite mean precision" in reason for reason in reasons)
     assert any("suite mean recall" in reason for reason in reasons)
-    assert any("suite mean explanation quality" in reason for reason in reasons)
+    assert any("explanation adequacy rate" in reason for reason in reasons)
 
 
 def test_shadow_review_study_batch_rolls_back_published_entries_after_later_failure(
@@ -869,7 +873,9 @@ def test_shadow_review_study_batch_rolls_back_published_entries_after_later_fail
             min_distinct_evidence_shapes=2,
         ),
     )
-    original_gate_report = batch.build_evidence_selection_shadow_review_study_gate_report
+    original_gate_report = (
+        batch.build_evidence_selection_shadow_review_study_gate_report
+    )
     call_count = 0
 
     def _fail_second_gate_report(*args: object, **kwargs: object) -> object:
@@ -933,7 +939,9 @@ def test_shadow_review_study_batch_rejects_duplicate_output_subdirs(
     tmp_path: Path,
 ) -> None:
     batch = _batch_module()
-    first_packet_path = _write_packet(tmp_path, "first-packet.json", _completed_packet())
+    first_packet_path = _write_packet(
+        tmp_path, "first-packet.json", _completed_packet()
+    )
     second_packet_path = _write_packet(
         tmp_path,
         "second-packet.json",
@@ -995,11 +1003,13 @@ def test_shadow_review_study_batch_rejects_nested_output_subdirs() -> None:
         "min_passed_entry_rate",
         "min_suite_mean_precision",
         "min_suite_mean_recall",
-        "min_suite_mean_explanation_quality",
+        "min_suite_explanation_adequacy_rate",
         "max_suite_expected_calibration_error",
     ],
 )
-@pytest.mark.parametrize("non_finite_value", [float("nan"), float("inf"), float("-inf")])
+@pytest.mark.parametrize(
+    "non_finite_value", [float("nan"), float("inf"), float("-inf")]
+)
 def test_shadow_review_study_batch_rejects_non_finite_suite_thresholds(
     threshold_name: str,
     non_finite_value: float,
@@ -1021,7 +1031,9 @@ def test_shadow_review_study_batch_rejects_duplicate_export_ids(
     tmp_path: Path,
 ) -> None:
     batch = _batch_module()
-    first_packet_path = _write_packet(tmp_path, "first-packet.json", _completed_packet())
+    first_packet_path = _write_packet(
+        tmp_path, "first-packet.json", _completed_packet()
+    )
     second_packet_path = _write_packet(
         tmp_path,
         "second-packet.json",
@@ -1127,7 +1139,9 @@ def test_shadow_review_study_batch_rejects_cross_entry_packet_artifact_collision
     colliding_packet_path.parent.mkdir(parents=True)
     colliding_packet_path.write_text(json.dumps(_completed_packet()))
     original_packet_text = colliding_packet_path.read_text()
-    second_packet_path = _write_packet(tmp_path, "second-packet.json", _completed_packet())
+    second_packet_path = _write_packet(
+        tmp_path, "second-packet.json", _completed_packet()
+    )
 
     manifest = batch.EvidenceSelectionShadowReviewStudyBatchManifest.model_validate(
         {
@@ -1169,6 +1183,167 @@ def test_shadow_review_study_batch_rejects_cross_entry_packet_artifact_collision
     assert not (output_dir / "first" / "selection-review-labels.json").exists()
 
 
+def test_shadow_review_study_batch_passes_all_selection_suite_without_ranking(
+    tmp_path: Path,
+) -> None:
+    batch = _batch_module()
+    packet_specs = (
+        (
+            "one",
+            "11111111-1111-4111-8111-111111111111",
+            "Assess BRAF targeted therapy evidence.",
+        ),
+        (
+            "two",
+            "22222222-2222-4222-8222-222222222222",
+            "Assess EGFR resistance evidence.",
+        ),
+        (
+            "three",
+            "33333333-3333-4333-8333-333333333333",
+            "Assess BRCA1 pathogenicity evidence.",
+        ),
+    )
+    packet_paths = tuple(
+        _write_packet(
+            tmp_path,
+            f"selection-{label}.json",
+            _selection_only_packet_for_batch(
+                study_id=f"selection-study-{label}",
+                source_run_id=source_run_id,
+                goal=goal,
+            ),
+        )
+        for label, source_run_id, goal in packet_specs
+    )
+    output_dir = tmp_path / "selection-batch-output"
+
+    result = batch.build_evidence_selection_shadow_review_study_batch(
+        batch.EvidenceSelectionShadowReviewStudyBatchRequest(
+            manifest=batch.EvidenceSelectionShadowReviewStudyBatchManifest.model_validate(
+                {
+                    "schema_version": (
+                        "evidence_selection_shadow_review_study_batch.v1"
+                    ),
+                    "batch_id": "selection-only-batch-2026-07-13",
+                    "entries": [
+                        _manifest_entry(
+                            entry_id=f"selection-{index}",
+                            packet_path=packet_path,
+                            output_subdir=f"selection-{index}",
+                            export_id=f"selection-export-{index}",
+                        )
+                        for index, packet_path in enumerate(packet_paths, start=1)
+                    ],
+                },
+            ),
+            output_dir=output_dir,
+            thresholds=batch.EvidenceSelectionShadowReviewStudyBatchThresholds(
+                min_selection_review_count=1,
+                min_distinct_selection_goals=1,
+            ),
+        ),
+    )
+
+    assert result.passed is True
+    assert result.suite_gate["summary"]["combined_study_count"] == 0
+    assert result.suite_gate["summary"]["total_review_ranking_decision_count"] == 0
+    assert all(entry.artifact_result.review_ranking_path is None for entry in result.entries)
+    assert all(
+        entry.artifact_result.review_ranking_export_path is None
+        for entry in result.entries
+    )
+
+
+def test_shadow_review_study_batch_applies_ranking_gates_only_to_combined_studies(
+    tmp_path: Path,
+) -> None:
+    batch = _batch_module()
+    selection_packets = (
+        _selection_only_packet_for_batch(
+            study_id="selection-study-one",
+            source_run_id="11111111-1111-4111-8111-111111111111",
+            goal="Assess BRAF targeted therapy evidence.",
+        ),
+        _selection_only_packet_for_batch(
+            study_id="selection-study-two",
+            source_run_id="22222222-2222-4222-8222-222222222222",
+            goal="Assess EGFR resistance evidence.",
+        ),
+    )
+    combined_packet = _completed_packet_for_batch(
+        study_id="combined-study-three",
+        source_run_id="33333333-3333-4333-8333-333333333333",
+        goal="Assess BRCA1 pathogenicity evidence.",
+        first_shape="gene_disease_association",
+        second_shape="variant_pathogenicity",
+        review_ranking_decision_count=10,
+    )
+    ranking_forms = combined_packet["review_ranking_forms"]
+    assert isinstance(ranking_forms, list)
+    ranking_goals = (
+        "Assess BRCA1 pathogenicity evidence.",
+        "Assess BRCA1 treatment evidence.",
+        "Assess BRCA1 mechanism evidence.",
+    )
+    evidence_shapes = (
+        "gene_disease_association",
+        "variant_pathogenicity",
+        "treatment_response",
+    )
+    for index, form in enumerate(ranking_forms):
+        assert isinstance(form, dict)
+        source_kind = "proposal" if index % 2 == 0 else "review_item"
+        positive = index % 4 in (0, 3)
+        form["source_kind"] = source_kind
+        form["outcome"] = "positive" if positive else "negative"
+        form["ranking_score"] = 1.0 if positive else 0.0
+        form["goal"] = ranking_goals[index % len(ranking_goals)]
+        form["evidence_shape"] = evidence_shapes[index % len(evidence_shapes)]
+    packets = (*selection_packets, combined_packet)
+    packet_paths = tuple(
+        _write_packet(tmp_path, f"mixed-{index}.json", packet)
+        for index, packet in enumerate(packets, start=1)
+    )
+
+    result = batch.build_evidence_selection_shadow_review_study_batch(
+        batch.EvidenceSelectionShadowReviewStudyBatchRequest(
+            manifest=batch.EvidenceSelectionShadowReviewStudyBatchManifest.model_validate(
+                {
+                    "schema_version": (
+                        "evidence_selection_shadow_review_study_batch.v1"
+                    ),
+                    "batch_id": "mixed-study-batch-2026-07-13",
+                    "entries": [
+                        _manifest_entry(
+                            entry_id=f"mixed-{index}",
+                            packet_path=packet_path,
+                            output_subdir=f"mixed-{index}",
+                            export_id=f"mixed-export-{index}",
+                        )
+                        for index, packet_path in enumerate(packet_paths, start=1)
+                    ],
+                },
+            ),
+            output_dir=tmp_path / "mixed-batch-output",
+            thresholds=batch.EvidenceSelectionShadowReviewStudyBatchThresholds(
+                min_selection_review_count=1,
+                min_distinct_selection_goals=1,
+                min_review_ranking_sample_count=4,
+                min_distinct_ranking_goals=1,
+                min_distinct_evidence_shapes=2,
+            ),
+        ),
+    )
+
+    assert result.passed is True
+    assert result.suite_gate["summary"]["combined_study_count"] == 1
+    assert result.suite_gate["summary"]["total_review_ranking_decision_count"] == 10
+    assert result.entries[0].artifact_result.review_ranking_path is None
+    assert result.entries[1].artifact_result.review_ranking_path is None
+    assert result.entries[2].artifact_result.review_ranking_path is not None
+
+
 def _batch_module() -> object:
     try:
         return importlib.import_module(
@@ -1195,6 +1370,7 @@ def _manifest_entry(
         "exported_at": "2026-07-07T14:00:00Z",
         "exporter_id": "review-ops-a",
         "redaction_statement": "No PHI or raw patient text included.",
+        "study_evidence_kind": "real_shadow_review",
         "description": f"{entry_id} completed shadow-review packet.",
     }
 
@@ -1215,7 +1391,9 @@ def _low_quality_packet() -> dict[str, object]:
     assert isinstance(selection_forms, list)
     first_form = selection_forms[0]
     assert isinstance(first_form, dict)
-    first_form["explanation_quality_score"] = 2
+    first_form["explanation_assessment"] = (
+        inadequate_explanation_assessment().model_dump(mode="json")
+    )
     return packet
 
 
@@ -1238,7 +1416,30 @@ def _low_quality_packet_for_batch(
     assert isinstance(selection_forms, list)
     first_form = selection_forms[0]
     assert isinstance(first_form, dict)
-    first_form["explanation_quality_score"] = 2
+    first_form["explanation_assessment"] = (
+        inadequate_explanation_assessment().model_dump(mode="json")
+    )
+    return packet
+
+
+def _selection_only_packet_for_batch(
+    *,
+    study_id: str,
+    source_run_id: str,
+    goal: str,
+) -> dict[str, object]:
+    packet = _completed_packet_for_batch(
+        study_id=study_id,
+        source_run_id=source_run_id,
+        goal=goal,
+        first_shape="unused_selection_shape",
+        second_shape="unused_selection_context",
+    )
+    packet["study_type"] = "selection_relevance"
+    completion_required_fields = packet["completion_required_fields"]
+    assert isinstance(completion_required_fields, list)
+    packet["completion_required_fields"] = completion_required_fields[:4]
+    packet["review_ranking_forms"] = []
     return packet
 
 

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_batch_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_batch_cli.py
@@ -12,6 +12,9 @@ from artana_evidence_api.evidence_selection.shadow_review_completion import (
     machine_packet_sidecar_path,
 )
 
+from services.artana_evidence_api.tests.unit.evidence_selection_review_fixtures import (
+    inadequate_explanation_assessment,
+)
 from services.artana_evidence_api.tests.unit.test_evidence_selection_shadow_review_study_pipeline import (  # noqa: E501
     _completed_packet,
     _machine_packet_for_completed_packet,
@@ -54,10 +57,7 @@ def test_shadow_review_study_batch_cli_writes_reports_and_fails_on_failed_entry(
     assert batch_report["failed_entry_count"] == 1
     assert (output_dir / "shadow-review-study-batch.md").exists()
     assert (
-        output_dir
-        / "good-study"
-        / "gate"
-        / "evidence_selection_expert_study_gate.json"
+        output_dir / "good-study" / "gate" / "evidence_selection_expert_study_gate.json"
     ).exists()
     weak_gate_report = json.loads(
         (
@@ -70,10 +70,7 @@ def test_shadow_review_study_batch_cli_writes_reports_and_fails_on_failed_entry(
     assert weak_gate_report["gate"]["passed"] is False
     assert weak_gate_report["gate"]["blocking_reasons"]
     assert (
-        output_dir
-        / "weak-study"
-        / "gate"
-        / "evidence_selection_expert_study_gate.md"
+        output_dir / "weak-study" / "gate" / "evidence_selection_expert_study_gate.md"
     ).exists()
 
 
@@ -114,7 +111,10 @@ def test_shadow_review_study_batch_cli_allows_failed_gate_when_requested(
 
 @pytest.mark.parametrize(
     "failing_writer",
-    ["_write_entry_gate_reports", "write_evidence_selection_shadow_review_study_batch_report"],
+    [
+        "_write_entry_gate_reports",
+        "write_evidence_selection_shadow_review_study_batch_report",
+    ],
 )
 def test_shadow_review_study_batch_cli_rolls_back_report_phase_failures(
     tmp_path: Path,
@@ -253,7 +253,10 @@ def test_shadow_review_study_batch_cli_relaxed_entry_thresholds_still_need_suite
         (output_dir / "shadow-review-study-batch.json").read_text(),
     )
     assert batch_report["passed"] is False
-    assert batch_report["suite_gate"]["summary"]["total_review_ranking_decision_count"] == 6
+    assert (
+        batch_report["suite_gate"]["summary"]["total_review_ranking_decision_count"]
+        == 6
+    )
     assert any(
         "review-ranking decisions" in reason
         for reason in batch_report["suite_gate"]["blocking_reasons"]
@@ -274,7 +277,9 @@ def test_shadow_review_study_batch_cli_help_mentions_suite_gate_override(
     assert "entry or suite gate fails" in normalized_help
 
 
-def test_shadow_review_study_batch_markdown_marks_missing_production_floor_unknown() -> None:
+def test_shadow_review_study_batch_markdown_marks_missing_production_floor_unknown() -> (
+    None
+):
     cli = _cli_module()
 
     markdown = cli.render_evidence_selection_shadow_review_study_batch_markdown(
@@ -325,8 +330,8 @@ def test_shadow_review_study_batch_cli_relaxed_quality_thresholds_still_need_sui
             "0",
             "--min-mean-recall",
             "0",
-            "--min-mean-explanation-quality",
-            "1",
+            "--min-explanation-adequacy-rate",
+            "0",
         ),
     )
 
@@ -338,7 +343,23 @@ def test_shadow_review_study_batch_cli_relaxed_quality_thresholds_still_need_sui
     summary = batch_report["suite_gate"]["summary"]
     assert summary["suite_mean_precision"] == 0.0
     assert summary["suite_mean_recall"] == 0.0
-    assert summary["suite_mean_explanation_quality"] == 1.0
+    assert summary["suite_explanation_adequacy_rate"] == 0.0
+    assert summary["all_entry_observed_quality"] == {
+        "suite_mean_precision": 0.0,
+        "suite_mean_recall": 0.0,
+        "suite_explanation_adequacy_rate": 0.0,
+        "max_review_ranking_expected_calibration_error": 0.0,
+    }
+    assert summary["passed_entry_production_quality"] == {
+        "suite_mean_precision": 0.0,
+        "suite_mean_recall": 0.0,
+        "suite_explanation_adequacy_rate": 0.0,
+        "max_review_ranking_expected_calibration_error": 0.0,
+    }
+    markdown_report = (output_dir / "shadow-review-study-batch.md").read_text()
+    assert "Passed-entry production mean precision" in markdown_report
+    assert "All-entry observed mean precision" in markdown_report
+    assert "All-entry observed explanation adequacy rate" in markdown_report
     assert any(
         "suite mean precision" in reason
         for reason in batch_report["suite_gate"]["blocking_reasons"]
@@ -663,6 +684,7 @@ def _manifest_entry(
         "exported_at": "2026-07-07T14:00:00Z",
         "exporter_id": "review-ops-a",
         "redaction_statement": "No PHI or raw patient text included.",
+        "study_evidence_kind": "real_shadow_review",
         "description": f"{entry_id} completed shadow-review packet.",
     }
 
@@ -673,7 +695,9 @@ def _low_quality_packet() -> dict[str, object]:
     assert isinstance(selection_forms, list)
     first_form = selection_forms[0]
     assert isinstance(first_form, dict)
-    first_form["explanation_quality_score"] = 2
+    first_form["explanation_assessment"] = (
+        inadequate_explanation_assessment().model_dump(mode="json")
+    )
     return packet
 
 
@@ -699,7 +723,9 @@ def _completed_packet_for_cli_batch(
         form["goal"] = goal
         if bad_quality:
             form["human_selected_record_ids"] = ["pubmed:search-1:1"]
-            form["explanation_quality_score"] = 1
+            form["explanation_assessment"] = (
+                inadequate_explanation_assessment().model_dump(mode="json")
+            )
     ranking_forms = packet["review_ranking_forms"]
     assert isinstance(ranking_forms, list)
     shapes = (first_shape, second_shape)

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_batch_manifest.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_batch_manifest.py
@@ -17,6 +17,7 @@ from services.artana_evidence_api.tests.unit.test_evidence_selection_shadow_revi
 )
 from services.artana_evidence_api.tests.unit.test_evidence_selection_shadow_review_study_pipeline import (  # noqa: E501
     _machine_packet_for_completed_packet,
+    _selection_only_completed_packet,
 )
 
 
@@ -50,21 +51,20 @@ def test_shadow_review_study_batch_manifest_builder_derives_strict_entries(
         ),
     )
 
-    manifest = (
-        manifest_builder.build_evidence_selection_shadow_review_study_batch_manifest(
-            manifest_builder.EvidenceSelectionShadowReviewStudyBatchManifestBuildRequest(
-                batch_id="real-shadow-review-batch-2026-07-07",
-                packet_paths=(first_packet_path, second_packet_path),
-                manifest_path=manifest_path,
-                adjudication_note="Reviewer adjudicated every packet.",
-                source_system="artana-shadow-review",
-                export_id_prefix="real-shadow-2026-07-07",
-                exported_at="2026-07-07T14:00:00Z",
-                exporter_id="review-ops-a",
-                redaction_statement="No PHI or raw patient text included.",
-                description="Completed real shadow-review packet.",
-            ),
-        )
+    manifest = manifest_builder.build_evidence_selection_shadow_review_study_batch_manifest(
+        manifest_builder.EvidenceSelectionShadowReviewStudyBatchManifestBuildRequest(
+            batch_id="real-shadow-review-batch-2026-07-07",
+            packet_paths=(first_packet_path, second_packet_path),
+            manifest_path=manifest_path,
+            adjudication_note="Reviewer adjudicated every packet.",
+            source_system="artana-shadow-review",
+            export_id_prefix="real-shadow-2026-07-07",
+            exported_at="2026-07-07T14:00:00Z",
+            exporter_id="review-ops-a",
+            redaction_statement="No PHI or raw patient text included.",
+            study_evidence_kind="real_shadow_review",
+            description="Completed real shadow-review packet.",
+        ),
     )
 
     assert manifest.schema_version == "evidence_selection_shadow_review_study_batch.v1"
@@ -130,8 +130,36 @@ def test_shadow_review_study_batch_manifest_builder_rejects_incomplete_packet(
                 exported_at="2026-07-07T14:00:00Z",
                 exporter_id="review-ops-a",
                 redaction_statement="No PHI or raw patient text included.",
+                study_evidence_kind="real_shadow_review",
             ),
         )
+
+
+def test_shadow_review_study_batch_manifest_builder_accepts_selection_only_without_note(
+    tmp_path: Path,
+) -> None:
+    manifest_builder = _manifest_builder_module()
+    packet_path = _write_packet(
+        tmp_path,
+        "selection-only.json",
+        _selection_only_completed_packet(),
+    )
+
+    manifest = manifest_builder.build_evidence_selection_shadow_review_study_batch_manifest(
+        manifest_builder.EvidenceSelectionShadowReviewStudyBatchManifestBuildRequest(
+            batch_id="selection-only-batch-2026-07-13",
+            packet_paths=(packet_path,),
+            manifest_path=tmp_path / "batch-manifest.json",
+            source_system="artana-shadow-review",
+            export_id_prefix="selection-only-2026-07-13",
+            exported_at="2026-07-13T14:00:00Z",
+            exporter_id="review-ops-a",
+            redaction_statement="No PHI or raw patient text included.",
+            study_evidence_kind="real_shadow_review",
+        ),
+    )
+
+    assert manifest.entries[0].adjudication_note is None
 
 
 def _manifest_builder_module() -> object:

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_batch_manifest_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_batch_manifest_cli.py
@@ -16,6 +16,7 @@ from services.artana_evidence_api.tests.unit.test_evidence_selection_shadow_revi
 )
 from services.artana_evidence_api.tests.unit.test_evidence_selection_shadow_review_study_pipeline import (  # noqa: E501
     _machine_packet_for_completed_packet,
+    _selection_only_completed_packet,
 )
 
 
@@ -70,6 +71,8 @@ def test_shadow_review_study_batch_manifest_cli_writes_strict_manifest(
             "review-ops-a",
             "--redaction-statement",
             "No PHI or raw patient text included.",
+            "--study-evidence-kind",
+            "real_shadow_review",
             "--description",
             "Completed real shadow-review packet.",
         ),
@@ -77,7 +80,9 @@ def test_shadow_review_study_batch_manifest_cli_writes_strict_manifest(
 
     assert exit_code == 0
     manifest = json.loads(output_path.read_text(encoding="utf-8"))
-    assert manifest["schema_version"] == "evidence_selection_shadow_review_study_batch.v1"
+    assert (
+        manifest["schema_version"] == "evidence_selection_shadow_review_study_batch.v1"
+    )
     assert manifest["batch_id"] == "real-shadow-review-batch-2026-07-07"
     assert [entry["entry_id"] for entry in manifest["entries"]] == [
         "01-shadow-study-one",
@@ -127,6 +132,8 @@ def test_shadow_review_study_batch_manifest_cli_rejects_source_overwrite(
             "review-ops-a",
             "--redaction-statement",
             "No PHI or raw patient text included.",
+            "--study-evidence-kind",
+            "real_shadow_review",
         ),
     )
 
@@ -134,6 +141,45 @@ def test_shadow_review_study_batch_manifest_cli_rejects_source_overwrite(
     assert exit_code == 1
     assert "must not overwrite source packet" in captured.err
     assert packet_path.read_text(encoding="utf-8") == original_packet
+
+
+def test_shadow_review_study_batch_manifest_cli_accepts_selection_only_without_note(
+    tmp_path: Path,
+) -> None:
+    cli = _cli_module()
+    packet_path = _write_packet(
+        tmp_path,
+        "selection-only.json",
+        _selection_only_completed_packet(),
+    )
+    output_path = tmp_path / "selection-only-manifest.json"
+
+    exit_code = cli.main(
+        (
+            "--batch-id",
+            "selection-only-batch-2026-07-13",
+            "--packet",
+            str(packet_path),
+            "--output",
+            str(output_path),
+            "--source-system",
+            "artana-shadow-review",
+            "--export-id-prefix",
+            "selection-only-2026-07-13",
+            "--exported-at",
+            "2026-07-13T14:00:00Z",
+            "--exporter-id",
+            "review-ops-a",
+            "--redaction-statement",
+            "No PHI or raw patient text included.",
+            "--study-evidence-kind",
+            "real_shadow_review",
+        ),
+    )
+
+    assert exit_code == 0
+    manifest = json.loads(output_path.read_text(encoding="utf-8"))
+    assert manifest["entries"][0]["adjudication_note"] is None
 
 
 def _cli_module() -> object:

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_pipeline.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_pipeline.py
@@ -16,6 +16,8 @@ from artana_evidence_api.evidence_selection.shadow_review_packet import (
     machine_packet_digest,
 )
 
+from .evidence_selection_review_fixtures import adequate_explanation_assessment
+
 _RUN_ID = "00000000-0000-0000-0000-000000000049"
 _GOAL = "Review BRAF V600E treatment-response evidence."
 
@@ -37,6 +39,7 @@ def test_shadow_review_study_pipeline_builds_bundle_ready_artifacts(
             exported_at="2026-07-07T14:00:00Z",
             exporter_id="review-ops-a",
             redaction_statement="No PHI or raw patient text included.",
+            study_evidence_kind="real_shadow_review",
             description="Completed shadow-review packet pipeline fixture.",
         ),
     )
@@ -47,7 +50,9 @@ def test_shadow_review_study_pipeline_builds_bundle_ready_artifacts(
     assert result.selection_reviews_path == output_dir / "selection-review-labels.json"
     assert result.review_ranking_path == output_dir / "review-ranking-study.json"
     assert result.selection_export_path == output_dir / "selection-review-export.json"
-    assert result.review_ranking_export_path == output_dir / "review-ranking-export.json"
+    assert (
+        result.review_ranking_export_path == output_dir / "review-ranking-export.json"
+    )
     assert result.bundle_path == output_dir / "evidence-selection-expert-study.json"
 
     selection_input = json.loads(result.selection_reviews_path.read_text())
@@ -62,7 +67,8 @@ def test_shadow_review_study_pipeline_builds_bundle_ready_artifacts(
     assert ranking_export["schema_version"] == (
         "evidence_selection_review_ranking_export.v1"
     )
-    assert bundle["schema_version"] == "evidence_selection_expert_study.v1"
+    assert bundle["schema_version"] == "evidence_selection_expert_study.v2"
+    assert bundle["study_type"] == "selection_and_review_ranking"
     assert bundle["study_evidence_kind"] == "real_shadow_review"
     assert bundle["source_manifest"]["export_id"] == "shadow-export-2026-07-07"
     source_artifact_uris = {
@@ -74,6 +80,48 @@ def test_shadow_review_study_pipeline_builds_bundle_ready_artifacts(
         "review-ranking-export": str(result.review_ranking_export_path),
     }
     assert all(Path(uri).exists() for uri in source_artifact_uris.values())
+
+
+def test_selection_only_pipeline_does_not_fabricate_ranking_artifacts(
+    tmp_path: Path,
+) -> None:
+    pipeline = _pipeline_module()
+    completed_packet = _selection_only_completed_packet()
+    machine_packet = _machine_packet_for_completed_packet(completed_packet)
+    completed_packet["machine_packet_sha256"] = machine_packet["machine_packet_sha256"]
+    completed_packet["machine_packet_signature"] = machine_packet[
+        "machine_packet_signature"
+    ]
+    output_dir = tmp_path / "selection-only-study"
+
+    result = pipeline.build_evidence_selection_shadow_review_study_artifacts(
+        pipeline.EvidenceSelectionShadowReviewStudyArtifactRequest(
+            machine_packet=machine_packet,
+            packet=completed_packet,
+            output_dir=output_dir,
+            adjudication_note=None,
+            source_system="artana-shadow-review",
+            export_id="selection-only-export-2026-07-07",
+            exported_at="2026-07-07T14:00:00Z",
+            exporter_id="review-ops-a",
+            redaction_statement="No PHI or raw patient text included.",
+            study_evidence_kind="real_shadow_review",
+        ),
+    )
+
+    bundle = json.loads(result.bundle_path.read_text())
+    assert result.review_ranking_path is None
+    assert result.review_ranking_export_path is None
+    assert result.review_ranking_decision_count == 0
+    assert result.source_artifact_count == 1
+    assert not (output_dir / "review-ranking-study.json").exists()
+    assert not (output_dir / "review-ranking-export.json").exists()
+    assert bundle["study_type"] == "selection_relevance"
+    assert "review_ranking" not in bundle
+    assert [
+        artifact["artifact_kind"]
+        for artifact in bundle["source_manifest"]["source_artifacts"]
+    ] == ["selection_review_export"]
 
 
 def test_shadow_review_study_pipeline_rejects_file_output_dir(
@@ -95,6 +143,7 @@ def test_shadow_review_study_pipeline_rejects_file_output_dir(
                 exported_at="2026-07-07T14:00:00Z",
                 exporter_id="review-ops-a",
                 redaction_statement="No PHI or raw patient text included.",
+                study_evidence_kind="real_shadow_review",
             ),
         )
 
@@ -124,6 +173,7 @@ def test_shadow_review_study_pipeline_rejects_packet_output_collision(
                 exported_at="2026-07-07T14:00:00Z",
                 exporter_id="review-ops-a",
                 redaction_statement="No PHI or raw patient text included.",
+                study_evidence_kind="real_shadow_review",
             ),
         )
 
@@ -158,6 +208,7 @@ def test_shadow_review_study_pipeline_removes_staged_artifacts_after_failure(
                 exported_at="2026-07-07T14:00:00Z",
                 exporter_id="review-ops-a",
                 redaction_statement="No PHI or raw patient text included.",
+                study_evidence_kind="real_shadow_review",
             ),
         )
 
@@ -186,6 +237,14 @@ def _machine_packet() -> dict[str, object]:
     return _machine_packet_for_completed_packet(_completed_packet_payload())
 
 
+def _selection_only_completed_packet() -> dict[str, object]:
+    packet = _completed_packet_payload()
+    packet["study_type"] = "selection_relevance"
+    packet["completion_required_fields"] = packet["completion_required_fields"][:4]
+    packet["review_ranking_forms"] = []
+    return packet
+
+
 def _machine_packet_for_completed_packet(
     completed_packet: dict[str, object],
 ) -> dict[str, object]:
@@ -194,8 +253,8 @@ def _machine_packet_for_completed_packet(
     selection_form["reviewer_id"] = None
     selection_form["human_selected_record_ids"] = []
     selection_form["duplicate_suggestion_ids"] = []
-    selection_form["explanation_quality_score"] = None
-    selection_form["high_severity_overclaim_count"] = None
+    selection_form["explanation_assessment"] = None
+    selection_form["high_severity_overclaim_findings"] = None
     selection_form["reviewer_notes"] = None
     for ranking_form in packet["review_ranking_forms"]:
         ranking_form["outcome"] = None
@@ -211,8 +270,9 @@ def _machine_packet_for_completed_packet(
 
 def _completed_packet_payload() -> dict[str, object]:
     return {
-        "schema_version": "evidence_selection_shadow_review_packet.v1",
+        "schema_version": "evidence_selection_shadow_review_packet.v2",
         "study_id": "shadow-study-2026-07-07",
+        "study_type": "selection_and_review_ranking",
         "source_run_id": _RUN_ID,
         "goal": _GOAL,
         "production_readiness_claim": False,
@@ -220,8 +280,8 @@ def _completed_packet_payload() -> dict[str, object]:
         "completion_required_fields": [
             "selection_review_forms[].reviewer_id",
             "selection_review_forms[].human_selected_record_ids",
-            "selection_review_forms[].explanation_quality_score",
-            "selection_review_forms[].high_severity_overclaim_count",
+            "selection_review_forms[].explanation_assessment",
+            "selection_review_forms[].high_severity_overclaim_findings",
             "review_ranking_forms[].reviewer_id",
             "review_ranking_forms[].outcome",
         ],
@@ -239,8 +299,10 @@ def _completed_packet_payload() -> dict[str, object]:
                 "harness_deferred_record_ids": [],
                 "human_selected_record_ids": ["pubmed:search-1:0"],
                 "duplicate_suggestion_ids": [],
-                "explanation_quality_score": 5,
-                "high_severity_overclaim_count": 0,
+                "explanation_assessment": (
+                    adequate_explanation_assessment().model_dump(mode="json")
+                ),
+                "high_severity_overclaim_findings": [],
                 "reviewer_notes": "Specific relation with direct support.",
             },
         ],

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_pipeline.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_pipeline.py
@@ -63,7 +63,7 @@ def test_shadow_review_study_pipeline_builds_bundle_ready_artifacts(
 
     assert selection_input["selection_reviews"][0]["reviewer_id"] == "reviewer-a"
     assert ranking_input["study_id"] == "shadow-study-2026-07-07"
-    assert selection_export["schema_version"] == "evidence_selection_review_export.v1"
+    assert selection_export["schema_version"] == "evidence_selection_review_export.v2"
     assert ranking_export["schema_version"] == (
         "evidence_selection_review_ranking_export.v1"
     )

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_pipeline_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_shadow_review_study_pipeline_cli.py
@@ -14,6 +14,7 @@ from artana_evidence_api.evidence_selection.shadow_review_completion import (
 from services.artana_evidence_api.tests.unit.test_evidence_selection_shadow_review_study_pipeline import (  # noqa: E501
     _completed_packet,
     _machine_packet_for_completed_packet,
+    _selection_only_completed_packet,
 )
 
 
@@ -43,6 +44,8 @@ def test_shadow_review_study_pipeline_cli_writes_artifacts_but_blocks_thin_gate(
             "review-ops-a",
             "--redaction-statement",
             "No PHI or raw patient text included.",
+            "--study-evidence-kind",
+            "real_shadow_review",
             "--min-selection-review-count",
             "1",
             "--min-distinct-selection-goals",
@@ -57,7 +60,9 @@ def test_shadow_review_study_pipeline_cli_writes_artifacts_but_blocks_thin_gate(
     )
 
     assert exit_code == 1
-    bundle = json.loads((output_dir / "evidence-selection-expert-study.json").read_text())
+    bundle = json.loads(
+        (output_dir / "evidence-selection-expert-study.json").read_text()
+    )
     gate_report = json.loads(
         (output_dir / "gate" / "evidence_selection_expert_study_gate.json").read_text(),
     )
@@ -68,6 +73,49 @@ def test_shadow_review_study_pipeline_cli_writes_artifacts_but_blocks_thin_gate(
         for reason in gate_report["gate"]["blocking_reasons"]
     )
     assert (output_dir / "gate" / "evidence_selection_expert_study_gate.md").exists()
+
+
+def test_shadow_review_study_pipeline_cli_runs_selection_only_without_ranking_artifacts(
+    tmp_path: Path,
+) -> None:
+    cli = _cli_module()
+    packet_path = tmp_path / "completed-selection-packet.json"
+    output_dir = tmp_path / "selection-study"
+    _write_completed_packet(packet_path, _selection_only_completed_packet())
+
+    exit_code = cli.main(
+        (
+            "--packet",
+            str(packet_path),
+            "--output-dir",
+            str(output_dir),
+            "--source-system",
+            "artana-shadow-review",
+            "--export-id",
+            "selection-export-2026-07-13",
+            "--exported-at",
+            "2026-07-13T14:00:00Z",
+            "--exporter-id",
+            "review-ops-a",
+            "--redaction-statement",
+            "No PHI or raw patient text included.",
+            "--study-evidence-kind",
+            "real_shadow_review",
+            "--min-selection-review-count",
+            "1",
+            "--min-distinct-selection-goals",
+            "1",
+        ),
+    )
+
+    assert exit_code == 0
+    bundle = json.loads(
+        (output_dir / "evidence-selection-expert-study.json").read_text()
+    )
+    assert bundle["study_type"] == "selection_relevance"
+    assert "review_ranking" not in bundle
+    assert not (output_dir / "review-ranking-study.json").exists()
+    assert not (output_dir / "review-ranking-export.json").exists()
 
 
 def test_shadow_review_study_pipeline_cli_returns_nonzero_but_keeps_failed_gate_report(
@@ -96,6 +144,8 @@ def test_shadow_review_study_pipeline_cli_returns_nonzero_but_keeps_failed_gate_
             "review-ops-a",
             "--redaction-statement",
             "No PHI or raw patient text included.",
+            "--study-evidence-kind",
+            "real_shadow_review",
         ),
     )
 
@@ -145,6 +195,8 @@ def test_shadow_review_study_pipeline_cli_removes_artifacts_when_gate_report_fai
             "review-ops-a",
             "--redaction-statement",
             "No PHI or raw patient text included.",
+            "--study-evidence-kind",
+            "real_shadow_review",
         ),
     )
 
@@ -180,6 +232,8 @@ def test_shadow_review_study_pipeline_cli_rejects_file_output_dir_without_traceb
             "review-ops-a",
             "--redaction-statement",
             "No PHI or raw patient text included.",
+            "--study-evidence-kind",
+            "real_shadow_review",
         ),
     )
 
@@ -219,6 +273,8 @@ def test_shadow_review_study_pipeline_cli_rejects_packet_output_collision(
             "review-ops-a",
             "--redaction-statement",
             "No PHI or raw patient text included.",
+            "--study-evidence-kind",
+            "real_shadow_review",
         ),
     )
 
@@ -238,8 +294,11 @@ def _cli_module() -> object:
         pytest.fail(f"shadow review study pipeline CLI is missing: {exc}")
 
 
-def _write_completed_packet(packet_path: Path) -> Path:
-    packet = _completed_packet()
+def _write_completed_packet(
+    packet_path: Path,
+    packet: dict[str, object] | None = None,
+) -> Path:
+    packet = packet or _completed_packet()
     machine_packet = _machine_packet_for_completed_packet(packet)
     packet["machine_packet_sha256"] = machine_packet["machine_packet_sha256"]
     packet["machine_packet_signature"] = machine_packet["machine_packet_signature"]

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_source_export_writer.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_source_export_writer.py
@@ -13,6 +13,8 @@ from artana_evidence_api.evidence_selection.study_bundle import (
     build_evidence_selection_expert_study_bundle,
 )
 
+from .evidence_selection_review_fixtures import adequate_explanation_assessment
+
 
 def test_source_export_writer_creates_builder_ready_exports(tmp_path: Path) -> None:
     writer = _writer_module()
@@ -51,6 +53,7 @@ def test_source_export_writer_creates_builder_ready_exports(tmp_path: Path) -> N
     bundle = build_evidence_selection_expert_study_bundle(
         EvidenceSelectionExpertStudyBundleRequest(
             study_id="shadow-study-2026-07-07",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="synthetic_fixture",
             selection_reviews_path=selection_export_path,
             review_ranking_path=ranking_export_path,
@@ -334,8 +337,10 @@ def _selection_reviews() -> list[dict[str, object]]:
                 f"record-{index}-b",
             ],
             "harness_skipped_record_ids": [f"record-{index}-c"],
-            "explanation_quality_score": 4,
-            "high_severity_overclaim_count": 0,
+            "explanation_assessment": (
+                adequate_explanation_assessment().model_dump(mode="json")
+            ),
+            "high_severity_overclaim_findings": [],
         }
         for index, goal in enumerate(goals)
     ]

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_source_export_writer.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_source_export_writer.py
@@ -43,7 +43,7 @@ def test_source_export_writer_creates_builder_ready_exports(tmp_path: Path) -> N
     assert result.review_ranking_decision_count == 10
     selection_export = json.loads(selection_export_path.read_text())
     ranking_export = json.loads(ranking_export_path.read_text())
-    assert selection_export["schema_version"] == "evidence_selection_review_export.v1"
+    assert selection_export["schema_version"] == "evidence_selection_review_export.v2"
     assert ranking_export["schema_version"] == (
         "evidence_selection_review_ranking_export.v1"
     )
@@ -328,6 +328,11 @@ def _selection_reviews() -> list[dict[str, object]]:
             "run_id": f"00000000-0000-0000-0000-00000000000{index + 1}",
             "goal": goal,
             "reviewer_id": "reviewer-a",
+            "candidate_record_ids": [
+                f"record-{index}-a",
+                f"record-{index}-b",
+                f"record-{index}-c",
+            ],
             "harness_selected_record_ids": [
                 f"record-{index}-a",
                 f"record-{index}-b",
@@ -338,7 +343,9 @@ def _selection_reviews() -> list[dict[str, object]]:
             ],
             "harness_skipped_record_ids": [f"record-{index}-c"],
             "explanation_assessment": (
-                adequate_explanation_assessment().model_dump(mode="json")
+                adequate_explanation_assessment(f"record-{index}-a").model_dump(
+                    mode="json",
+                )
             ),
             "high_severity_overclaim_findings": [],
         }

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_source_export_writer_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_source_export_writer_cli.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from .evidence_selection_review_fixtures import adequate_explanation_assessment
+
 
 def test_source_export_writer_cli_writes_both_exports(tmp_path: Path) -> None:
     cli = _cli_module()
@@ -17,6 +19,8 @@ def test_source_export_writer_cli_writes_both_exports(tmp_path: Path) -> None:
 
     exit_code = cli.main(
         (
+            "--study-type",
+            "selection_and_review_ranking",
             "--selection-reviews",
             str(selection_input_path),
             "--review-ranking",
@@ -43,6 +47,37 @@ def test_source_export_writer_cli_writes_both_exports(tmp_path: Path) -> None:
     assert json.loads(ranking_export_path.read_text())["review_ranking"]["decisions"]
 
 
+def test_source_export_writer_cli_writes_selection_only_export(tmp_path: Path) -> None:
+    cli = _cli_module()
+    selection_input_path, _ = _write_inputs(tmp_path)
+    selection_export_path = tmp_path / "selection-review-export.json"
+
+    exit_code = cli.main(
+        (
+            "--study-type",
+            "selection_relevance",
+            "--selection-reviews",
+            str(selection_input_path),
+            "--selection-export-output",
+            str(selection_export_path),
+            "--source-system",
+            "artana-shadow-review",
+            "--export-id",
+            "selection-export-2026-07-13",
+            "--exported-at",
+            "2026-07-13T07:00:00Z",
+            "--exporter-id",
+            "review-ops-a",
+            "--redaction-statement",
+            "No PHI or raw patient text included.",
+        ),
+    )
+
+    assert exit_code == 0
+    assert json.loads(selection_export_path.read_text())["selection_reviews"]
+    assert not (tmp_path / "review-ranking-export.json").exists()
+
+
 def test_source_export_writer_cli_rejects_invalid_identity_without_traceback(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -52,6 +87,8 @@ def test_source_export_writer_cli_rejects_invalid_identity_without_traceback(
 
     exit_code = cli.main(
         (
+            "--study-type",
+            "selection_and_review_ranking",
             "--selection-reviews",
             str(selection_input_path),
             "--review-ranking",
@@ -81,7 +118,9 @@ def test_source_export_writer_cli_rejects_invalid_identity_without_traceback(
 
 def _cli_module() -> object:
     try:
-        return importlib.import_module("scripts.build_evidence_selection_source_exports")
+        return importlib.import_module(
+            "scripts.build_evidence_selection_source_exports"
+        )
     except ModuleNotFoundError as exc:
         pytest.fail(f"source export writer CLI is missing: {exc}")
 
@@ -89,7 +128,9 @@ def _cli_module() -> object:
 def _write_inputs(tmp_path: Path) -> tuple[Path, Path]:
     selection_input_path = tmp_path / "selection-review-labels.json"
     ranking_input_path = tmp_path / "review-ranking-study.json"
-    selection_input_path.write_text(json.dumps({"selection_reviews": _selection_reviews()}))
+    selection_input_path.write_text(
+        json.dumps({"selection_reviews": _selection_reviews()})
+    )
     ranking_input_path.write_text(json.dumps(_review_ranking()))
     return selection_input_path, ranking_input_path
 
@@ -103,8 +144,10 @@ def _selection_reviews() -> list[dict[str, object]]:
             "harness_selected_record_ids": [f"record-{index}-a"],
             "human_selected_record_ids": [f"record-{index}-a"],
             "harness_skipped_record_ids": [f"record-{index}-b"],
-            "explanation_quality_score": 4,
-            "high_severity_overclaim_count": 0,
+            "explanation_assessment": (
+                adequate_explanation_assessment().model_dump(mode="json")
+            ),
+            "high_severity_overclaim_findings": [],
         }
         for index in range(3)
     ]

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_source_export_writer_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_source_export_writer_cli.py
@@ -43,7 +43,9 @@ def test_source_export_writer_cli_writes_both_exports(tmp_path: Path) -> None:
     )
 
     assert exit_code == 0
-    assert json.loads(selection_export_path.read_text())["selection_reviews"]
+    selection_export = json.loads(selection_export_path.read_text())
+    assert selection_export["schema_version"] == "evidence_selection_review_export.v2"
+    assert selection_export["selection_reviews"]
     assert json.loads(ranking_export_path.read_text())["review_ranking"]["decisions"]
 
 
@@ -74,7 +76,9 @@ def test_source_export_writer_cli_writes_selection_only_export(tmp_path: Path) -
     )
 
     assert exit_code == 0
-    assert json.loads(selection_export_path.read_text())["selection_reviews"]
+    selection_export = json.loads(selection_export_path.read_text())
+    assert selection_export["schema_version"] == "evidence_selection_review_export.v2"
+    assert selection_export["selection_reviews"]
     assert not (tmp_path / "review-ranking-export.json").exists()
 
 
@@ -141,11 +145,14 @@ def _selection_reviews() -> list[dict[str, object]]:
             "run_id": f"00000000-0000-0000-0000-00000000000{index + 1}",
             "goal": f"review goal {index}",
             "reviewer_id": "reviewer-a",
+            "candidate_record_ids": [f"record-{index}-a", f"record-{index}-b"],
             "harness_selected_record_ids": [f"record-{index}-a"],
             "human_selected_record_ids": [f"record-{index}-a"],
             "harness_skipped_record_ids": [f"record-{index}-b"],
             "explanation_assessment": (
-                adequate_explanation_assessment().model_dump(mode="json")
+                adequate_explanation_assessment(f"record-{index}-a").model_dump(
+                    mode="json",
+                )
             ),
             "high_severity_overclaim_findings": [],
         }

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_study_bundle.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_study_bundle.py
@@ -53,6 +53,58 @@ def test_build_derives_source_manifest_identity_from_source_exports(
     assert source_manifest.redaction_statement == "No PHI or raw patient text included."
 
 
+def test_build_rejects_legacy_numeric_selection_export_version(tmp_path: Path) -> None:
+    selection_path = tmp_path / "selection-reviews.json"
+    ranking_path = tmp_path / "review-ranking.json"
+    selection_export = _selection_review_export()
+    selection_export["schema_version"] = "evidence_selection_review_export.v1"
+    selection_path.write_text(json.dumps(selection_export))
+    ranking_path.write_text(json.dumps(_review_ranking_export()))
+
+    with pytest.raises(ValidationError, match="schema_version"):
+        build_evidence_selection_expert_study_bundle(
+            EvidenceSelectionExpertStudyBundleRequest(
+                study_id="legacy-selection-export",
+                study_type="selection_and_review_ranking",
+                study_evidence_kind="synthetic_fixture",
+                selection_reviews_path=selection_path,
+                review_ranking_path=ranking_path,
+            ),
+        )
+
+
+def test_build_rejects_direct_review_citation_outside_candidate_universe(
+    tmp_path: Path,
+) -> None:
+    selection_path = tmp_path / "selection-reviews.json"
+    ranking_path = tmp_path / "review-ranking.json"
+    selection_export = _selection_review_export()
+    selection_reviews = selection_export["selection_reviews"]
+    assert isinstance(selection_reviews, list)
+    first_review = selection_reviews[0]
+    assert isinstance(first_review, dict)
+    explanation_assessment = first_review["explanation_assessment"]
+    assert isinstance(explanation_assessment, dict)
+    cited_evidence = explanation_assessment["cited_evidence"]
+    assert isinstance(cited_evidence, list)
+    first_citation = cited_evidence[0]
+    assert isinstance(first_citation, dict)
+    first_citation["record_id"] = "unknown-record"
+    selection_path.write_text(json.dumps(selection_export))
+    ranking_path.write_text(json.dumps(_review_ranking_export()))
+
+    with pytest.raises(ValidationError, match="unknown candidate record IDs"):
+        build_evidence_selection_expert_study_bundle(
+            EvidenceSelectionExpertStudyBundleRequest(
+                study_id="unbound-direct-review-citation",
+                study_type="selection_and_review_ranking",
+                study_evidence_kind="synthetic_fixture",
+                selection_reviews_path=selection_path,
+                review_ranking_path=ranking_path,
+            ),
+        )
+
+
 def test_bundle_output_rejects_hard_link_to_source_artifact(tmp_path: Path) -> None:
     source_path = tmp_path / "selection-review-export.json"
     output_path = tmp_path / "expert-study.json"
@@ -491,6 +543,11 @@ def _selection_reviews() -> list[dict[str, object]]:
             "run_id": f"00000000-0000-0000-0000-00000000000{index + 1}",
             "goal": goal,
             "reviewer_id": "reviewer-a",
+            "candidate_record_ids": [
+                f"record-{index}-a",
+                f"record-{index}-b",
+                f"record-{index}-c",
+            ],
             "harness_selected_record_ids": [
                 f"record-{index}-a",
                 f"record-{index}-b",
@@ -501,7 +558,9 @@ def _selection_reviews() -> list[dict[str, object]]:
             ],
             "harness_skipped_record_ids": [f"record-{index}-c"],
             "explanation_assessment": (
-                adequate_explanation_assessment().model_dump(mode="json")
+                adequate_explanation_assessment(f"record-{index}-a").model_dump(
+                    mode="json",
+                )
             ),
             "high_severity_overclaim_findings": [],
         }
@@ -524,7 +583,7 @@ def _selection_review_export(
     selection_reviews: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
     return {
-        "schema_version": "evidence_selection_review_export.v1",
+        "schema_version": "evidence_selection_review_export.v2",
         **_source_export_identity(),
         "selection_reviews": selection_reviews or _selection_reviews(),
     }

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_study_bundle.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_study_bundle.py
@@ -22,6 +22,8 @@ from artana_evidence_api.evidence_selection_validation import (
 )
 from pydantic import ValidationError
 
+from .evidence_selection_review_fixtures import adequate_explanation_assessment
+
 
 def test_build_derives_source_manifest_identity_from_source_exports(
     tmp_path: Path,
@@ -34,6 +36,7 @@ def test_build_derives_source_manifest_identity_from_source_exports(
     bundle = build_evidence_selection_expert_study_bundle(
         EvidenceSelectionExpertStudyBundleRequest(
             study_id="shadow-study-2026-07-07",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="synthetic_fixture",
             selection_reviews_path=selection_path,
             review_ranking_path=ranking_path,
@@ -77,6 +80,7 @@ def test_build_rejects_mismatched_source_export_identity(
         build_evidence_selection_expert_study_bundle(
             EvidenceSelectionExpertStudyBundleRequest(
                 study_id="mismatched-shadow-study",
+                study_type="selection_and_review_ranking",
                 study_evidence_kind="synthetic_fixture",
                 selection_reviews_path=selection_path,
                 review_ranking_path=ranking_path,
@@ -104,6 +108,7 @@ def test_build_rejects_source_export_without_timezone(
         build_evidence_selection_expert_study_bundle(
             EvidenceSelectionExpertStudyBundleRequest(
                 study_id="naive-timestamp-shadow-study",
+                study_type="selection_and_review_ranking",
                 study_evidence_kind="synthetic_fixture",
                 selection_reviews_path=selection_path,
                 review_ranking_path=ranking_path,
@@ -125,6 +130,7 @@ def test_build_rejects_noncanonical_source_export_timestamp_offset(
         build_evidence_selection_expert_study_bundle(
             EvidenceSelectionExpertStudyBundleRequest(
                 study_id="offset-timestamp-shadow-study",
+                study_type="selection_and_review_ranking",
                 study_evidence_kind="synthetic_fixture",
                 selection_reviews_path=selection_path,
                 review_ranking_path=ranking_path,
@@ -156,6 +162,7 @@ def test_build_rejects_alternate_utc_source_export_timestamp_spellings(
         build_evidence_selection_expert_study_bundle(
             EvidenceSelectionExpertStudyBundleRequest(
                 study_id="alternate-timestamp-shadow-study",
+                study_type="selection_and_review_ranking",
                 study_evidence_kind="synthetic_fixture",
                 selection_reviews_path=selection_path,
                 review_ranking_path=ranking_path,
@@ -182,6 +189,7 @@ def test_build_rejects_source_export_identity_field_with_outer_whitespace(
         build_evidence_selection_expert_study_bundle(
             EvidenceSelectionExpertStudyBundleRequest(
                 study_id="whitespace-identity-shadow-study",
+                study_type="selection_and_review_ranking",
                 study_evidence_kind="synthetic_fixture",
                 selection_reviews_path=selection_path,
                 review_ranking_path=ranking_path,
@@ -192,13 +200,13 @@ def test_build_rejects_source_export_identity_field_with_outer_whitespace(
 @pytest.mark.parametrize(
     ("override_field", "override_value"),
     [
-            ("source_system", "other-system"),
-            ("export_id", "other-export"),
-            ("exported_at", "2026-07-07T08:00:00Z"),
-            ("exporter_id", "other-exporter"),
-            ("redaction_statement", "Different redaction statement."),
-        ],
-    )
+        ("source_system", "other-system"),
+        ("export_id", "other-export"),
+        ("exported_at", "2026-07-07T08:00:00Z"),
+        ("exporter_id", "other-exporter"),
+        ("redaction_statement", "Different redaction statement."),
+    ],
+)
 def test_build_rejects_source_identity_override_mismatch(
     tmp_path: Path,
     override_field: str,
@@ -210,6 +218,7 @@ def test_build_rejects_source_identity_override_mismatch(
     ranking_path.write_text(json.dumps(_review_ranking_export()))
     request_kwargs: dict[str, object] = {
         "study_id": "override-mismatch-shadow-study",
+        "study_type": "selection_and_review_ranking",
         "study_evidence_kind": "synthetic_fixture",
         "selection_reviews_path": selection_path,
         "review_ranking_path": ranking_path,
@@ -235,6 +244,7 @@ def test_build_rejects_noncanonical_source_identity_override_timestamp(
         build_evidence_selection_expert_study_bundle(
             EvidenceSelectionExpertStudyBundleRequest(
                 study_id="override-noncanonical-shadow-study",
+                study_type="selection_and_review_ranking",
                 study_evidence_kind="synthetic_fixture",
                 selection_reviews_path=selection_path,
                 review_ranking_path=ranking_path,
@@ -260,6 +270,7 @@ def test_builds_expert_study_bundle_with_computed_source_manifest(
     bundle = build_evidence_selection_expert_study_bundle(
         EvidenceSelectionExpertStudyBundleRequest(
             study_id="shadow-study-2026-07-07",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="synthetic_fixture",
             selection_reviews_path=selection_path,
             review_ranking_path=ranking_path,
@@ -270,7 +281,7 @@ def test_builds_expert_study_bundle_with_computed_source_manifest(
 
     source_manifest = bundle.source_manifest
     assert source_manifest is not None
-    assert bundle.schema_version == "evidence_selection_expert_study.v1"
+    assert bundle.schema_version == "evidence_selection_expert_study.v2"
     assert bundle.study_id == "shadow-study-2026-07-07"
     assert tuple(source_manifest.selection_review_run_ids) == tuple(
         UUID(review["run_id"]) for review in _selection_reviews()
@@ -329,6 +340,7 @@ def test_build_preserves_duplicate_selection_run_ids_for_gate_detection(
     bundle = build_evidence_selection_expert_study_bundle(
         EvidenceSelectionExpertStudyBundleRequest(
             study_id="duplicate-shadow-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews_path=selection_path,
             review_ranking_path=ranking_path,
@@ -375,6 +387,7 @@ def test_build_preserves_duplicate_review_ranking_keys_for_gate_detection(
     bundle = build_evidence_selection_expert_study_bundle(
         EvidenceSelectionExpertStudyBundleRequest(
             study_id="duplicate-ranking-shadow-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews_path=selection_path,
             review_ranking_path=ranking_path,
@@ -432,6 +445,7 @@ def test_build_hashes_same_bytes_used_to_parse_source_exports(
     bundle = build_evidence_selection_expert_study_bundle(
         EvidenceSelectionExpertStudyBundleRequest(
             study_id="read-once-shadow-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="synthetic_fixture",
             selection_reviews_path=selection_path,
             review_ranking_path=ranking_path,
@@ -458,6 +472,7 @@ def test_build_rejects_selection_export_without_reviews(tmp_path: Path) -> None:
         build_evidence_selection_expert_study_bundle(
             EvidenceSelectionExpertStudyBundleRequest(
                 study_id="bad-shadow-study",
+                study_type="selection_and_review_ranking",
                 study_evidence_kind="real_shadow_review",
                 selection_reviews_path=selection_path,
                 review_ranking_path=ranking_path,
@@ -485,8 +500,10 @@ def _selection_reviews() -> list[dict[str, object]]:
                 f"record-{index}-b",
             ],
             "harness_skipped_record_ids": [f"record-{index}-c"],
-            "explanation_quality_score": 4,
-            "high_severity_overclaim_count": 0,
+            "explanation_assessment": (
+                adequate_explanation_assessment().model_dump(mode="json")
+            ),
+            "high_severity_overclaim_findings": [],
         }
         for index, goal in enumerate(goals)
     ]

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_study_bundle_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_study_bundle_cli.py
@@ -501,7 +501,7 @@ def _source_export_identity() -> dict[str, object]:
 
 def _selection_review_export() -> dict[str, object]:
     return {
-        "schema_version": "evidence_selection_review_export.v1",
+        "schema_version": "evidence_selection_review_export.v2",
         **_source_export_identity(),
         "selection_reviews": _selection_reviews(),
     }
@@ -526,6 +526,11 @@ def _selection_reviews() -> list[dict[str, object]]:
             "run_id": f"00000000-0000-0000-0000-00000000000{index + 1}",
             "goal": goal,
             "reviewer_id": "reviewer-a",
+            "candidate_record_ids": [
+                f"record-{index}-a",
+                f"record-{index}-b",
+                f"record-{index}-c",
+            ],
             "harness_selected_record_ids": [
                 f"record-{index}-a",
                 f"record-{index}-b",
@@ -536,7 +541,9 @@ def _selection_reviews() -> list[dict[str, object]]:
             ],
             "harness_skipped_record_ids": [f"record-{index}-c"],
             "explanation_assessment": (
-                adequate_explanation_assessment().model_dump(mode="json")
+                adequate_explanation_assessment(f"record-{index}-a").model_dump(
+                    mode="json",
+                )
             ),
             "high_severity_overclaim_findings": [],
         }

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_study_bundle_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_study_bundle_cli.py
@@ -14,6 +14,8 @@ from scripts.run_evidence_selection_expert_study_gate import (
     build_evidence_selection_expert_study_gate_report,
 )
 
+from .evidence_selection_review_fixtures import adequate_explanation_assessment
+
 
 def test_expert_study_bundle_builder_cli_writes_gate_compatible_bundle(
     tmp_path: Path,
@@ -31,7 +33,7 @@ def test_expert_study_bundle_builder_cli_writes_gate_compatible_bundle(
 
     assert exit_code == 0
     payload = json.loads(output_path.read_text())
-    assert payload["schema_version"] == "evidence_selection_expert_study.v1"
+    assert payload["schema_version"] == "evidence_selection_expert_study.v2"
     assert payload["study_evidence_kind"] == "synthetic_fixture"
     assert payload["source_manifest"]["source_artifacts"] == [
         {
@@ -416,6 +418,8 @@ def _base_args(
     args = [
         "--study-id",
         "shadow-study-2026-07-07",
+        "--study-type",
+        "selection_and_review_ranking",
         "--study-evidence-kind",
         "synthetic_fixture",
         "--selection-reviews",
@@ -450,6 +454,8 @@ def _base_args_without_source_identity(
     args = [
         "--study-id",
         "shadow-study-2026-07-07",
+        "--study-type",
+        "selection_and_review_ranking",
         "--study-evidence-kind",
         "synthetic_fixture",
         "--selection-reviews",
@@ -474,7 +480,9 @@ def _write_source_exports(
     selection_path = tmp_path / "selection-reviews.json"
     ranking_path = tmp_path / "review-ranking.json"
     adjudication_path = tmp_path / "adjudication-log.txt"
-    selection_path.write_text(json.dumps(selection_export or _selection_review_export()))
+    selection_path.write_text(
+        json.dumps(selection_export or _selection_review_export())
+    )
     ranking_path.write_text(json.dumps(ranking_export or _review_ranking_export()))
     if include_adjudication:
         adjudication_path.write_text("reviewer-a accepted all calibration labels\n")
@@ -527,8 +535,10 @@ def _selection_reviews() -> list[dict[str, object]]:
                 f"record-{index}-b",
             ],
             "harness_skipped_record_ids": [f"record-{index}-c"],
-            "explanation_quality_score": 4,
-            "high_severity_overclaim_count": 0,
+            "explanation_assessment": (
+                adequate_explanation_assessment().model_dump(mode="json")
+            ),
+            "high_severity_overclaim_findings": [],
         }
         for index, goal in enumerate(goals)
     ]

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_validation.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_validation.py
@@ -19,6 +19,12 @@ from artana_evidence_api.evidence_selection_validation import (
 )
 from pydantic import ValidationError
 
+from .evidence_selection_review_fixtures import (
+    adequate_explanation_assessment,
+    high_severity_overclaim_finding,
+    inadequate_explanation_assessment,
+)
+
 
 def test_compare_evidence_selection_review_records_shadow_review_metrics() -> None:
     run_id = uuid4()
@@ -32,8 +38,8 @@ def test_compare_evidence_selection_review_records_shadow_review_metrics() -> No
             harness_skipped_record_ids=("clinvar:VCV3",),
             duplicate_suggestion_ids=("clinvar:VCV2", "clinvar:VCV2"),
             reviewer_id="reviewer-a",
-            explanation_quality_score=4,
-            high_severity_overclaim_count=0,
+            explanation_assessment=adequate_explanation_assessment(),
+            high_severity_overclaim_findings=(),
             reviewer_notes="One useful record missed.",
         ),
     )
@@ -48,7 +54,7 @@ def test_compare_evidence_selection_review_records_shadow_review_metrics() -> No
     assert report.duplicate_suggestion_ids == ("clinvar:VCV2",)
     assert report.precision == 0.5
     assert report.recall == 0.5
-    assert report.explanation_quality_score == 4
+    assert report.explanation_adequacy == "adequate"
     assert report.overclaim_gate_passed is True
 
 
@@ -59,7 +65,7 @@ def test_compare_evidence_selection_review_flags_overclaim_gate_failure() -> Non
             goal="Find MED13 treatment evidence.",
             harness_selected_record_ids=("pubmed:PMID1",),
             human_selected_record_ids=("pubmed:PMID1",),
-            high_severity_overclaim_count=1,
+            high_severity_overclaim_findings=(high_severity_overclaim_finding(),),
         ),
     )
 
@@ -67,14 +73,14 @@ def test_compare_evidence_selection_review_flags_overclaim_gate_failure() -> Non
     assert report.high_severity_overclaim_count == 1
 
 
-def test_evidence_selection_review_input_rejects_invalid_scores() -> None:
+def test_evidence_selection_review_input_rejects_numeric_explanation_scores() -> None:
     with pytest.raises(ValidationError):
         EvidenceSelectionReviewInput(
             run_id=uuid4(),
             goal="Find MED13 evidence.",
             harness_selected_record_ids=(),
             human_selected_record_ids=(),
-            explanation_quality_score=6,
+            explanation_assessment=6,
         )
 
 
@@ -110,9 +116,7 @@ def test_evidence_selection_review_input_accepts_documented_audit_notes() -> Non
     )
 
     assert review.false_positive_notes == {}
-    assert review.false_negative_notes == {
-        "record-b": "Relevant record was omitted."
-    }
+    assert review.false_negative_notes == {"record-b": "Relevant record was omitted."}
 
 
 @pytest.mark.parametrize(
@@ -141,8 +145,9 @@ def test_evidence_selection_review_input_rejects_invalid_audit_notes(
 
 def test_expert_study_ids_are_normalized_before_binding() -> None:
     study = EvidenceSelectionExpertStudyInput(
-        schema_version="evidence_selection_expert_study.v1",
+        schema_version="evidence_selection_expert_study.v2",
         study_id="  balanced-shadow-study  ",
+        study_type="selection_and_review_ranking",
         study_evidence_kind="real_shadow_review",
         selection_reviews=_selection_reviews(),
         review_ranking=_review_ranking_study("balanced-shadow-study"),
@@ -161,8 +166,9 @@ def test_review_ranking_study_rejects_blank_study_ids(study_id: str) -> None:
 def test_expert_study_rejects_blank_outer_study_id() -> None:
     with pytest.raises(ValidationError, match="study_id must not be blank"):
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="  ",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews=_selection_reviews(),
             review_ranking=_review_ranking_study("balanced-shadow-study"),
@@ -174,8 +180,9 @@ def test_evidence_selection_expert_study_gate_passes_balanced_study() -> None:
     review_ranking = _review_ranking_study("balanced-shadow-study")
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="balanced-shadow-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews=selection_reviews,
             review_ranking=review_ranking,
@@ -188,7 +195,7 @@ def test_evidence_selection_expert_study_gate_passes_balanced_study() -> None:
             min_selection_reviewer_count=1,
             min_mean_precision=0.8,
             min_mean_recall=0.8,
-            min_mean_explanation_quality=3.0,
+            min_explanation_adequacy_rate=0.8,
         ),
     )
 
@@ -213,8 +220,9 @@ def test_evidence_selection_expert_study_gate_passes_balanced_study() -> None:
 def test_evidence_selection_expert_study_gate_blocks_missing_source_manifest() -> None:
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="missing-source-manifest",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews=_selection_reviews(),
             review_ranking=_review_ranking_study("missing-source-manifest"),
@@ -225,42 +233,41 @@ def test_evidence_selection_expert_study_gate_blocks_missing_source_manifest() -
             min_selection_reviewer_count=1,
             min_mean_precision=0.8,
             min_mean_recall=0.8,
-            min_mean_explanation_quality=3.0,
+            min_explanation_adequacy_rate=0.8,
         ),
     )
 
     assert report.passed is False
     assert report.provenance_summary["source_manifest_present"] is False
-    assert any(
-        "source manifest" in reason for reason in report.blocking_reasons
-    )
+    assert any("source manifest" in reason for reason in report.blocking_reasons)
 
 
-def test_evidence_selection_expert_study_gate_blocks_incomplete_source_manifest() -> None:
+def test_evidence_selection_expert_study_gate_blocks_incomplete_source_manifest() -> (
+    None
+):
     selection_reviews = _selection_reviews()
     review_ranking = _review_ranking_study("incomplete-source-manifest")
     manifest = _source_manifest_payload(selection_reviews=selection_reviews)
     manifest["source_artifacts"] = manifest["source_artifacts"][:1]
     manifest["selection_review_run_ids"] = manifest["selection_review_run_ids"][:2]
-    manifest["review_ranking_decision_keys"] = (
-        manifest["review_ranking_decision_keys"][:9]
-        + ["review_item:unexpected-ranking-item"]
-    )
+    manifest["review_ranking_decision_keys"] = manifest["review_ranking_decision_keys"][
+        :9
+    ] + ["review_item:unexpected-ranking-item"]
     manifest["reviewer_roster"] = ["other-reviewer"]
 
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput.model_validate(
             {
-                "schema_version": "evidence_selection_expert_study.v1",
-                    "study_id": "incomplete-source-manifest",
-                    "study_evidence_kind": "real_shadow_review",
-                    "selection_reviews": [
-                        review.model_dump(mode="json")
-                        for review in selection_reviews
-                    ],
-                    "review_ranking": review_ranking.model_dump(mode="json"),
-                    "source_manifest": manifest,
-                },
+                "schema_version": "evidence_selection_expert_study.v2",
+                "study_id": "incomplete-source-manifest",
+                "study_type": "selection_and_review_ranking",
+                "study_evidence_kind": "real_shadow_review",
+                "selection_reviews": [
+                    review.model_dump(mode="json") for review in selection_reviews
+                ],
+                "review_ranking": review_ranking.model_dump(mode="json"),
+                "source_manifest": manifest,
+            },
         ),
         thresholds=EvidenceSelectionExpertStudyGateThresholds(
             min_selection_review_count=3,
@@ -268,7 +275,7 @@ def test_evidence_selection_expert_study_gate_blocks_incomplete_source_manifest(
             min_selection_reviewer_count=1,
             min_mean_precision=0.8,
             min_mean_recall=0.8,
-            min_mean_explanation_quality=3.0,
+            min_explanation_adequacy_rate=0.8,
             min_source_artifact_count=3,
         ),
     )
@@ -279,12 +286,18 @@ def test_evidence_selection_expert_study_gate_blocks_incomplete_source_manifest(
     assert report.provenance_summary["extra_review_ranking_decision_key_count"] == 1
     assert report.provenance_summary["unknown_reviewer_id_count"] == 1
     assert any("source artifacts" in reason for reason in report.blocking_reasons)
-    assert any("selection review run IDs" in reason for reason in report.blocking_reasons)
-    assert any("review-ranking decision keys" in reason for reason in report.blocking_reasons)
+    assert any(
+        "selection review run IDs" in reason for reason in report.blocking_reasons
+    )
+    assert any(
+        "review-ranking decision keys" in reason for reason in report.blocking_reasons
+    )
     assert any("reviewer roster" in reason for reason in report.blocking_reasons)
 
 
-def test_evidence_selection_expert_study_gate_blocks_duplicate_selection_run_ids() -> None:
+def test_evidence_selection_expert_study_gate_blocks_duplicate_selection_run_ids() -> (
+    None
+):
     shared_run_id = uuid4()
     reviews = tuple(
         EvidenceSelectionReviewInput(
@@ -293,8 +306,8 @@ def test_evidence_selection_expert_study_gate_blocks_duplicate_selection_run_ids
             reviewer_id="reviewer-a",
             harness_selected_record_ids=(f"record-{index}",),
             human_selected_record_ids=(f"record-{index}",),
-            explanation_quality_score=4,
-            high_severity_overclaim_count=0,
+            explanation_assessment=adequate_explanation_assessment(),
+            high_severity_overclaim_findings=(),
         )
         for index, goal in enumerate(
             (
@@ -307,8 +320,9 @@ def test_evidence_selection_expert_study_gate_blocks_duplicate_selection_run_ids
 
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="duplicate-selection-run-ids",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews=reviews,
             review_ranking=_review_ranking_study("duplicate-selection-run-ids"),
@@ -320,16 +334,21 @@ def test_evidence_selection_expert_study_gate_blocks_duplicate_selection_run_ids
             min_selection_reviewer_count=1,
             min_mean_precision=0.8,
             min_mean_recall=0.8,
-            min_mean_explanation_quality=3.0,
+            min_explanation_adequacy_rate=0.8,
         ),
     )
 
     assert report.passed is False
     assert report.provenance_summary["duplicate_selection_run_id_count"] == 1
-    assert any("Selection review run IDs must be unique" in reason for reason in report.blocking_reasons)
+    assert any(
+        "Selection review run IDs must be unique" in reason
+        for reason in report.blocking_reasons
+    )
 
 
-def test_evidence_selection_expert_study_gate_requires_source_export_artifacts() -> None:
+def test_evidence_selection_expert_study_gate_requires_source_export_artifacts() -> (
+    None
+):
     selection_reviews = _selection_reviews()
     manifest = _source_manifest_payload(selection_reviews=selection_reviews)
     manifest["source_artifacts"] = [
@@ -345,12 +364,12 @@ def test_evidence_selection_expert_study_gate_requires_source_export_artifacts()
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput.model_validate(
             {
-                "schema_version": "evidence_selection_expert_study.v1",
+                "schema_version": "evidence_selection_expert_study.v2",
                 "study_id": "missing-source-export-artifacts",
+                "study_type": "selection_and_review_ranking",
                 "study_evidence_kind": "real_shadow_review",
                 "selection_reviews": [
-                    review.model_dump(mode="json")
-                    for review in selection_reviews
+                    review.model_dump(mode="json") for review in selection_reviews
                 ],
                 "review_ranking": _review_ranking_study(
                     "missing-source-export-artifacts",
@@ -364,7 +383,7 @@ def test_evidence_selection_expert_study_gate_requires_source_export_artifacts()
             min_selection_reviewer_count=1,
             min_mean_precision=0.8,
             min_mean_recall=0.8,
-            min_mean_explanation_quality=3.0,
+            min_explanation_adequacy_rate=0.8,
             min_source_artifact_count=3,
         ),
     )
@@ -375,7 +394,9 @@ def test_evidence_selection_expert_study_gate_requires_source_export_artifacts()
         "review_ranking_export": 0,
         "selection_review_export": 0,
     }
-    assert any("selection_review_export" in reason for reason in report.blocking_reasons)
+    assert any(
+        "selection_review_export" in reason for reason in report.blocking_reasons
+    )
     assert any("review_ranking_export" in reason for reason in report.blocking_reasons)
 
 
@@ -386,12 +407,12 @@ def test_evidence_selection_expert_study_input_rejects_blank_source_identity() -
     manifest["exporter_id"] = " "
     manifest["redaction_statement"] = " "
     payload = {
-        "schema_version": "evidence_selection_expert_study.v1",
+        "schema_version": "evidence_selection_expert_study.v2",
         "study_id": "blank-source-identity",
+        "study_type": "selection_and_review_ranking",
         "study_evidence_kind": "real_shadow_review",
         "selection_reviews": [
-            review.model_dump(mode="json")
-            for review in _selection_reviews()
+            review.model_dump(mode="json") for review in _selection_reviews()
         ],
         "review_ranking": _review_ranking_study(
             "blank-source-identity",
@@ -420,12 +441,12 @@ def test_evidence_selection_expert_study_input_rejects_invalid_source_hash() -> 
     manifest["source_artifacts"][0]["sha256"] = "not-a-sha"
 
     payload = {
-        "schema_version": "evidence_selection_expert_study.v1",
+        "schema_version": "evidence_selection_expert_study.v2",
         "study_id": "invalid-source-hash",
+        "study_type": "selection_and_review_ranking",
         "study_evidence_kind": "real_shadow_review",
         "selection_reviews": [
-            review.model_dump(mode="json")
-            for review in _selection_reviews()
+            review.model_dump(mode="json") for review in _selection_reviews()
         ],
         "review_ranking": _review_ranking_study(
             "invalid-source-hash",
@@ -480,8 +501,9 @@ def test_source_manifest_rejects_noncanonical_export_timestamps(
 def test_evidence_selection_expert_study_gate_blocks_synthetic_studies() -> None:
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="synthetic-shadow-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="synthetic_fixture",
             selection_reviews=_selection_reviews(),
             review_ranking=_review_ranking_study("synthetic-shadow-study"),
@@ -494,15 +516,89 @@ def test_evidence_selection_expert_study_gate_blocks_synthetic_studies() -> None
             min_selection_reviewer_count=1,
             min_mean_precision=0.8,
             min_mean_recall=0.8,
-            min_mean_explanation_quality=3.0,
+            min_explanation_adequacy_rate=0.8,
         ),
     )
 
     assert report.passed is False
-    assert any("real shadow-review evidence" in reason for reason in report.blocking_reasons)
+    assert any(
+        "real shadow-review evidence" in reason for reason in report.blocking_reasons
+    )
 
 
-def test_evidence_selection_expert_study_gate_blocks_partially_unlabeled_reviews() -> None:
+def test_selection_relevance_study_passes_without_ranking_artifacts() -> None:
+    selection_reviews = _selection_reviews()
+    manifest = _source_manifest_payload(selection_reviews=selection_reviews)
+    manifest["source_artifacts"] = [manifest["source_artifacts"][0]]
+    manifest["review_ranking_decision_keys"] = []
+
+    report = evaluate_evidence_selection_expert_study_gate(
+        EvidenceSelectionExpertStudyInput(
+            schema_version="evidence_selection_expert_study.v2",
+            study_id="selection-only-shadow-study",
+            study_type="selection_relevance",
+            study_evidence_kind="real_shadow_review",
+            selection_reviews=selection_reviews,
+            source_manifest=manifest,
+        ),
+    )
+
+    assert report.passed is True
+    assert report.study_type == "selection_relevance"
+    assert report.review_ranking_gate is None
+    assert report.provenance_summary["artifact_count"] == 1
+    assert report.provenance_summary["missing_required_source_artifact_kinds"] == []
+
+
+def test_ai_reviewer_simulation_cannot_support_production_readiness() -> None:
+    selection_reviews = _selection_reviews()
+    manifest = _source_manifest_payload(selection_reviews=selection_reviews)
+    manifest["source_artifacts"] = [manifest["source_artifacts"][0]]
+    manifest["review_ranking_decision_keys"] = []
+
+    report = evaluate_evidence_selection_expert_study_gate(
+        EvidenceSelectionExpertStudyInput(
+            schema_version="evidence_selection_expert_study.v2",
+            study_id="ai-selection-simulation",
+            study_type="selection_relevance",
+            study_evidence_kind="ai_reviewer_simulation",
+            selection_reviews=selection_reviews,
+            source_manifest=manifest,
+        ),
+    )
+
+    assert report.passed is False
+    assert any(
+        "real shadow-review evidence" in reason for reason in report.blocking_reasons
+    )
+
+
+def test_selection_relevance_study_rejects_ranking_input() -> None:
+    with pytest.raises(ValidationError, match="must not include review_ranking"):
+        EvidenceSelectionExpertStudyInput(
+            schema_version="evidence_selection_expert_study.v2",
+            study_id="selection-only-shadow-study",
+            study_type="selection_relevance",
+            study_evidence_kind="real_shadow_review",
+            selection_reviews=_selection_reviews(),
+            review_ranking=_review_ranking_study("selection-only-shadow-study"),
+        )
+
+
+def test_combined_study_requires_ranking_input() -> None:
+    with pytest.raises(ValidationError, match="require review_ranking"):
+        EvidenceSelectionExpertStudyInput(
+            schema_version="evidence_selection_expert_study.v2",
+            study_id="combined-shadow-study",
+            study_type="selection_and_review_ranking",
+            study_evidence_kind="real_shadow_review",
+            selection_reviews=_selection_reviews(),
+        )
+
+
+def test_evidence_selection_expert_study_gate_blocks_partially_unlabeled_reviews() -> (
+    None
+):
     reviews = list(_selection_reviews())
     first_review = reviews[0]
     reviews[0] = EvidenceSelectionReviewInput(
@@ -512,8 +608,8 @@ def test_evidence_selection_expert_study_gate_blocks_partially_unlabeled_reviews
         harness_selected_record_ids=first_review.harness_selected_record_ids,
         human_selected_record_ids=first_review.human_selected_record_ids,
         harness_skipped_record_ids=first_review.harness_skipped_record_ids,
-        explanation_quality_score=first_review.explanation_quality_score,
-        high_severity_overclaim_count=first_review.high_severity_overclaim_count,
+        explanation_assessment=first_review.explanation_assessment,
+        high_severity_overclaim_findings=first_review.high_severity_overclaim_findings,
     )
     second_review = reviews[1]
     reviews[1] = EvidenceSelectionReviewInput(
@@ -523,14 +619,15 @@ def test_evidence_selection_expert_study_gate_blocks_partially_unlabeled_reviews
         harness_selected_record_ids=second_review.harness_selected_record_ids,
         human_selected_record_ids=second_review.human_selected_record_ids,
         harness_skipped_record_ids=second_review.harness_skipped_record_ids,
-        explanation_quality_score=second_review.explanation_quality_score,
-        high_severity_overclaim_count=second_review.high_severity_overclaim_count,
+        explanation_assessment=second_review.explanation_assessment,
+        high_severity_overclaim_findings=second_review.high_severity_overclaim_findings,
     )
 
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="partially-unlabeled-shadow-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews=tuple(reviews),
             review_ranking=_review_ranking_study("partially-unlabeled-shadow-study"),
@@ -542,18 +639,26 @@ def test_evidence_selection_expert_study_gate_blocks_partially_unlabeled_reviews
             min_selection_reviewer_count=1,
             min_mean_precision=0.8,
             min_mean_recall=0.8,
-            min_mean_explanation_quality=3.0,
+            min_explanation_adequacy_rate=0.8,
         ),
     )
 
     assert report.passed is False
     assert report.selection_summary["missing_reviewer_id_count"] == 1
     assert report.selection_summary["missing_goal_count"] == 1
-    assert any("Every selection review must include a reviewer ID" in reason for reason in report.blocking_reasons)
-    assert any("Every selection review must include a research goal" in reason for reason in report.blocking_reasons)
+    assert any(
+        "Every selection review must include a reviewer ID" in reason
+        for reason in report.blocking_reasons
+    )
+    assert any(
+        "Every selection review must include a research goal" in reason
+        for reason in report.blocking_reasons
+    )
 
 
-def test_evidence_selection_expert_study_gate_blocks_unmeasurable_selection_metrics() -> None:
+def test_evidence_selection_expert_study_gate_blocks_unmeasurable_selection_metrics() -> (
+    None
+):
     reviews = list(_selection_reviews())
     for index in (0, 1):
         review = reviews[index]
@@ -564,14 +669,15 @@ def test_evidence_selection_expert_study_gate_blocks_unmeasurable_selection_metr
             harness_selected_record_ids=(),
             human_selected_record_ids=(),
             harness_skipped_record_ids=review.harness_skipped_record_ids,
-            explanation_quality_score=None,
-            high_severity_overclaim_count=0,
+            explanation_assessment=None,
+            high_severity_overclaim_findings=(),
         )
 
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="unmeasurable-shadow-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews=tuple(reviews),
             review_ranking=_review_ranking_study("unmeasurable-shadow-study"),
@@ -583,17 +689,20 @@ def test_evidence_selection_expert_study_gate_blocks_unmeasurable_selection_metr
             min_selection_reviewer_count=1,
             min_mean_precision=0.8,
             min_mean_recall=0.8,
-            min_mean_explanation_quality=3.0,
+            min_explanation_adequacy_rate=0.8,
         ),
     )
 
     assert report.passed is False
     assert report.selection_summary["unmeasurable_precision_count"] == 2
     assert report.selection_summary["unmeasurable_recall_count"] == 2
-    assert report.selection_summary["missing_explanation_quality_count"] == 2
+    assert report.selection_summary["missing_explanation_assessment_count"] == 2
     assert any("measurable precision" in reason for reason in report.blocking_reasons)
     assert any("measurable recall" in reason for reason in report.blocking_reasons)
-    assert any("explanation-quality score" in reason for reason in report.blocking_reasons)
+    assert any(
+        "categorical explanation assessment" in reason
+        for reason in report.blocking_reasons
+    )
 
 
 def test_evidence_selection_expert_study_gate_blocks_missing_overclaim_labels() -> None:
@@ -606,13 +715,14 @@ def test_evidence_selection_expert_study_gate_blocks_missing_overclaim_labels() 
         harness_selected_record_ids=first_review.harness_selected_record_ids,
         human_selected_record_ids=first_review.human_selected_record_ids,
         harness_skipped_record_ids=first_review.harness_skipped_record_ids,
-        explanation_quality_score=first_review.explanation_quality_score,
+        explanation_assessment=first_review.explanation_assessment,
     )
 
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="missing-overclaim-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews=tuple(reviews),
             review_ranking=_review_ranking_study("missing-overclaim-study"),
@@ -620,8 +730,10 @@ def test_evidence_selection_expert_study_gate_blocks_missing_overclaim_labels() 
     )
 
     assert report.passed is False
-    assert report.selection_summary["missing_high_severity_overclaim_count"] == 1
-    assert any("overclaim count" in reason for reason in report.blocking_reasons)
+    assert (
+        report.selection_summary["missing_high_severity_overclaim_findings_count"] == 1
+    )
+    assert any("overclaim findings" in reason for reason in report.blocking_reasons)
 
 
 def test_evidence_selection_expert_study_gate_blocks_duplicate_run_ids() -> None:
@@ -630,8 +742,9 @@ def test_evidence_selection_expert_study_gate_blocks_duplicate_run_ids() -> None
 
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="duplicate-runs-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews=tuple(reviews),
             review_ranking=_review_ranking_study("duplicate-runs-study"),
@@ -643,7 +756,9 @@ def test_evidence_selection_expert_study_gate_blocks_duplicate_run_ids() -> None
     assert any("run IDs must be unique" in reason for reason in report.blocking_reasons)
 
 
-def test_evidence_selection_expert_study_gate_blocks_weak_or_underreviewed_study() -> None:
+def test_evidence_selection_expert_study_gate_blocks_weak_or_underreviewed_study() -> (
+    None
+):
     weak_reviews = (
         EvidenceSelectionReviewInput(
             run_id=uuid4(),
@@ -651,15 +766,18 @@ def test_evidence_selection_expert_study_gate_blocks_weak_or_underreviewed_study
             reviewer_id=None,
             harness_selected_record_ids=("record-fp",),
             human_selected_record_ids=("record-tp",),
-            explanation_quality_score=2,
-            high_severity_overclaim_count=1,
+            explanation_assessment=inadequate_explanation_assessment().model_copy(
+                update={"unsupported_material_claim_present": "yes"},
+            ),
+            high_severity_overclaim_findings=(high_severity_overclaim_finding(),),
         ),
     )
 
     report = evaluate_evidence_selection_expert_study_gate(
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="weak-shadow-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews=weak_reviews,
             review_ranking=ReviewRankingCalibrationStudyInput(
@@ -679,28 +797,35 @@ def test_evidence_selection_expert_study_gate_blocks_weak_or_underreviewed_study
             min_selection_reviewer_count=1,
             min_mean_precision=0.8,
             min_mean_recall=0.8,
-            min_mean_explanation_quality=3.0,
+            min_explanation_adequacy_rate=0.8,
         ),
     )
 
     assert report.passed is False
     assert report.status == "failed"
     assert any("selection review runs" in reason for reason in report.blocking_reasons)
-    assert any("distinct selection goals" in reason for reason in report.blocking_reasons)
+    assert any(
+        "distinct selection goals" in reason for reason in report.blocking_reasons
+    )
     assert any("selection reviewer" in reason for reason in report.blocking_reasons)
-    assert any("mean selection precision" in reason for reason in report.blocking_reasons)
+    assert any(
+        "mean selection precision" in reason for reason in report.blocking_reasons
+    )
     assert any("mean selection recall" in reason for reason in report.blocking_reasons)
-    assert any("explanation quality" in reason for reason in report.blocking_reasons)
+    assert any("explanation adequacy" in reason for reason in report.blocking_reasons)
     assert any("overclaim" in reason for reason in report.blocking_reasons)
-    assert any("Review-ranking gate failed" in reason for reason in report.blocking_reasons)
+    assert any(
+        "Review-ranking gate failed" in reason for reason in report.blocking_reasons
+    )
 
 
 def test_evidence_selection_expert_study_input_rejects_extra_fields() -> None:
     with pytest.raises(ValidationError):
         EvidenceSelectionExpertStudyInput.model_validate(
             {
-                "schema_version": "evidence_selection_expert_study.v1",
+                "schema_version": "evidence_selection_expert_study.v2",
                 "study_id": "extra-field",
+                "study_type": "selection_and_review_ranking",
                 "study_evidence_kind": "real_shadow_review",
                 "selection_reviews": [],
                 "review_ranking": {
@@ -718,8 +843,9 @@ def test_evidence_selection_expert_study_input_rejects_extra_fields() -> None:
 def test_evidence_selection_expert_study_input_binds_ranking_study_id() -> None:
     with pytest.raises(ValidationError, match="review_ranking study_id must match"):
         EvidenceSelectionExpertStudyInput(
-            schema_version="evidence_selection_expert_study.v1",
+            schema_version="evidence_selection_expert_study.v2",
             study_id="selection-study",
+            study_type="selection_and_review_ranking",
             study_evidence_kind="real_shadow_review",
             selection_reviews=_selection_reviews(),
             review_ranking=_review_ranking_study("different-ranking-study"),
@@ -728,8 +854,9 @@ def test_evidence_selection_expert_study_input_binds_ranking_study_id() -> None:
 
 def test_evidence_selection_expert_study_input_rejects_extra_selection_fields() -> None:
     payload = {
-        "schema_version": "evidence_selection_expert_study.v1",
+        "schema_version": "evidence_selection_expert_study.v2",
         "study_id": "extra-selection-field",
+        "study_type": "selection_and_review_ranking",
         "study_evidence_kind": "real_shadow_review",
         "selection_reviews": [
             {
@@ -766,8 +893,8 @@ def _selection_reviews() -> tuple[EvidenceSelectionReviewInput, ...]:
             harness_selected_record_ids=(f"record-{index}-a", f"record-{index}-b"),
             human_selected_record_ids=(f"record-{index}-a", f"record-{index}-b"),
             harness_skipped_record_ids=(f"record-{index}-c",),
-            explanation_quality_score=4,
-            high_severity_overclaim_count=0,
+            explanation_assessment=adequate_explanation_assessment(),
+            high_severity_overclaim_findings=(),
         )
         for index, goal in enumerate(goals)
     )
@@ -785,7 +912,8 @@ def _review_ranking_study(study_id: str) -> ReviewRankingCalibrationStudyInput:
 def _source_manifest(
     *,
     selection_reviews: tuple[EvidenceSelectionReviewInput, ...] | None = None,
-    review_ranking_decisions: tuple[ReviewRankingCalibrationDecision, ...] | None = None,
+    review_ranking_decisions: tuple[ReviewRankingCalibrationDecision, ...]
+    | None = None,
 ) -> object:
     return _source_manifest_payload(
         selection_reviews=selection_reviews,
@@ -796,7 +924,8 @@ def _source_manifest(
 def _source_manifest_payload(
     *,
     selection_reviews: tuple[EvidenceSelectionReviewInput, ...] | None = None,
-    review_ranking_decisions: tuple[ReviewRankingCalibrationDecision, ...] | None = None,
+    review_ranking_decisions: tuple[ReviewRankingCalibrationDecision, ...]
+    | None = None,
 ) -> dict[str, object]:
     active_selection_reviews = selection_reviews or _selection_reviews()
     active_ranking_decisions = review_ranking_decisions or _review_ranking_decisions()

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_validation.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_validation.py
@@ -33,12 +33,18 @@ def test_compare_evidence_selection_review_records_shadow_review_metrics() -> No
         EvidenceSelectionReviewInput(
             run_id=run_id,
             goal="Find MED13 congenital heart disease evidence.",
+            candidate_record_ids=(
+                "clinvar:VCV1",
+                "clinvar:VCV2",
+                "clinvar:VCV3",
+                "pubmed:PMID1",
+            ),
             harness_selected_record_ids=("clinvar:VCV1", "clinvar:VCV2"),
             human_selected_record_ids=("clinvar:VCV1", "pubmed:PMID1"),
             harness_skipped_record_ids=("clinvar:VCV3",),
             duplicate_suggestion_ids=("clinvar:VCV2", "clinvar:VCV2"),
             reviewer_id="reviewer-a",
-            explanation_assessment=adequate_explanation_assessment(),
+            explanation_assessment=adequate_explanation_assessment("clinvar:VCV1"),
             high_severity_overclaim_findings=(),
             reviewer_notes="One useful record missed.",
         ),
@@ -63,9 +69,12 @@ def test_compare_evidence_selection_review_flags_overclaim_gate_failure() -> Non
         EvidenceSelectionReviewInput(
             run_id=uuid4(),
             goal="Find MED13 treatment evidence.",
+            candidate_record_ids=("pubmed:PMID1",),
             harness_selected_record_ids=("pubmed:PMID1",),
             human_selected_record_ids=("pubmed:PMID1",),
-            high_severity_overclaim_findings=(high_severity_overclaim_finding(),),
+            high_severity_overclaim_findings=(
+                high_severity_overclaim_finding("pubmed:PMID1"),
+            ),
         ),
     )
 
@@ -78,6 +87,7 @@ def test_evidence_selection_review_input_rejects_numeric_explanation_scores() ->
         EvidenceSelectionReviewInput(
             run_id=uuid4(),
             goal="Find MED13 evidence.",
+            candidate_record_ids=(),
             harness_selected_record_ids=(),
             human_selected_record_ids=(),
             explanation_assessment=6,
@@ -89,6 +99,7 @@ def test_evidence_selection_review_input_rejects_selected_skipped_overlap() -> N
         EvidenceSelectionReviewInput(
             run_id=uuid4(),
             goal="Find MED13 evidence.",
+            candidate_record_ids=("clinvar:VCV1",),
             harness_selected_record_ids=("clinvar:VCV1",),
             human_selected_record_ids=(),
             harness_skipped_record_ids=("clinvar:VCV1",),
@@ -100,6 +111,7 @@ def test_evidence_selection_review_input_rejects_blank_record_ids() -> None:
         EvidenceSelectionReviewInput(
             run_id=uuid4(),
             goal="Find MED13 evidence.",
+            candidate_record_ids=("record-a",),
             harness_selected_record_ids=("   ",),
             human_selected_record_ids=("record-a",),
         )
@@ -109,6 +121,7 @@ def test_evidence_selection_review_input_accepts_documented_audit_notes() -> Non
     review = EvidenceSelectionReviewInput(
         run_id=uuid4(),
         goal="Find MED13 evidence.",
+        candidate_record_ids=("record-a", "record-b"),
         harness_selected_record_ids=("record-a",),
         human_selected_record_ids=("record-a",),
         false_positive_notes={},
@@ -134,6 +147,7 @@ def test_evidence_selection_review_input_rejects_invalid_audit_notes(
     payload: dict[str, object] = {
         "run_id": uuid4(),
         "goal": "Find MED13 evidence.",
+        "candidate_record_ids": ("record-a",),
         "harness_selected_record_ids": (),
         "human_selected_record_ids": (),
         field_name: notes,
@@ -304,9 +318,12 @@ def test_evidence_selection_expert_study_gate_blocks_duplicate_selection_run_ids
             run_id=shared_run_id,
             goal=goal,
             reviewer_id="reviewer-a",
+            candidate_record_ids=(f"record-{index}",),
             harness_selected_record_ids=(f"record-{index}",),
             human_selected_record_ids=(f"record-{index}",),
-            explanation_assessment=adequate_explanation_assessment(),
+            explanation_assessment=adequate_explanation_assessment(
+                f"record-{index}",
+            ),
             high_severity_overclaim_findings=(),
         )
         for index, goal in enumerate(
@@ -550,6 +567,33 @@ def test_selection_relevance_study_passes_without_ranking_artifacts() -> None:
     assert report.provenance_summary["missing_required_source_artifact_kinds"] == []
 
 
+def test_selection_relevance_study_rejects_stray_ranking_provenance() -> None:
+    selection_reviews = _selection_reviews()
+    manifest = _source_manifest_payload(selection_reviews=selection_reviews)
+    manifest["source_artifacts"] = [manifest["source_artifacts"][0]]
+    manifest["review_ranking_decision_keys"] = ["proposal:unrelated-item"]
+
+    report = evaluate_evidence_selection_expert_study_gate(
+        EvidenceSelectionExpertStudyInput(
+            schema_version="evidence_selection_expert_study.v2",
+            study_id="selection-only-with-stray-ranking-provenance",
+            study_type="selection_relevance",
+            study_evidence_kind="real_shadow_review",
+            selection_reviews=selection_reviews,
+            source_manifest=manifest,
+        ),
+    )
+
+    assert report.passed is False
+    assert report.provenance_summary[
+        "extra_review_ranking_decision_key_count"
+    ] == 1
+    assert any(
+        "review-ranking decision keys" in reason
+        for reason in report.blocking_reasons
+    )
+
+
 def test_ai_reviewer_simulation_cannot_support_production_readiness() -> None:
     selection_reviews = _selection_reviews()
     manifest = _source_manifest_payload(selection_reviews=selection_reviews)
@@ -605,6 +649,7 @@ def test_evidence_selection_expert_study_gate_blocks_partially_unlabeled_reviews
         run_id=first_review.run_id,
         goal=first_review.goal,
         reviewer_id=None,
+        candidate_record_ids=first_review.candidate_record_ids,
         harness_selected_record_ids=first_review.harness_selected_record_ids,
         human_selected_record_ids=first_review.human_selected_record_ids,
         harness_skipped_record_ids=first_review.harness_skipped_record_ids,
@@ -616,6 +661,7 @@ def test_evidence_selection_expert_study_gate_blocks_partially_unlabeled_reviews
         run_id=second_review.run_id,
         goal="   ",
         reviewer_id=second_review.reviewer_id,
+        candidate_record_ids=second_review.candidate_record_ids,
         harness_selected_record_ids=second_review.harness_selected_record_ids,
         human_selected_record_ids=second_review.human_selected_record_ids,
         harness_skipped_record_ids=second_review.harness_skipped_record_ids,
@@ -666,6 +712,7 @@ def test_evidence_selection_expert_study_gate_blocks_unmeasurable_selection_metr
             run_id=review.run_id,
             goal=review.goal,
             reviewer_id=review.reviewer_id,
+            candidate_record_ids=review.candidate_record_ids,
             harness_selected_record_ids=(),
             human_selected_record_ids=(),
             harness_skipped_record_ids=review.harness_skipped_record_ids,
@@ -712,6 +759,7 @@ def test_evidence_selection_expert_study_gate_blocks_missing_overclaim_labels() 
         run_id=first_review.run_id,
         goal=first_review.goal,
         reviewer_id=first_review.reviewer_id,
+        candidate_record_ids=first_review.candidate_record_ids,
         harness_selected_record_ids=first_review.harness_selected_record_ids,
         human_selected_record_ids=first_review.human_selected_record_ids,
         harness_skipped_record_ids=first_review.harness_skipped_record_ids,
@@ -764,12 +812,15 @@ def test_evidence_selection_expert_study_gate_blocks_weak_or_underreviewed_study
             run_id=uuid4(),
             goal="Find MED13 congenital heart disease evidence.",
             reviewer_id=None,
+            candidate_record_ids=("record-fp", "record-tp"),
             harness_selected_record_ids=("record-fp",),
             human_selected_record_ids=("record-tp",),
-            explanation_assessment=inadequate_explanation_assessment().model_copy(
-                update={"unsupported_material_claim_present": "yes"},
+            explanation_assessment=inadequate_explanation_assessment(
+                "record-fp",
+            ).model_copy(update={"unsupported_material_claim_present": "yes"}),
+            high_severity_overclaim_findings=(
+                high_severity_overclaim_finding("record-fp"),
             ),
-            high_severity_overclaim_findings=(high_severity_overclaim_finding(),),
         ),
     )
 
@@ -890,10 +941,17 @@ def _selection_reviews() -> tuple[EvidenceSelectionReviewInput, ...]:
             run_id=uuid4(),
             goal=goal,
             reviewer_id="reviewer-a",
+            candidate_record_ids=(
+                f"record-{index}-a",
+                f"record-{index}-b",
+                f"record-{index}-c",
+            ),
             harness_selected_record_ids=(f"record-{index}-a", f"record-{index}-b"),
             human_selected_record_ids=(f"record-{index}-a", f"record-{index}-b"),
             harness_skipped_record_ids=(f"record-{index}-c",),
-            explanation_assessment=adequate_explanation_assessment(),
+            explanation_assessment=adequate_explanation_assessment(
+                f"record-{index}-a",
+            ),
             high_severity_overclaim_findings=(),
         )
         for index, goal in enumerate(goals)

--- a/tests/unit/test_run_evidence_selection_expert_study_gate.py
+++ b/tests/unit/test_run_evidence_selection_expert_study_gate.py
@@ -102,8 +102,8 @@ def test_evidence_selection_expert_study_gate_runner_fails_closed(
     first_review["reviewer_id"] = ""
     first_review["harness_selected_record_ids"] = ["record-fp"]
     first_review["human_selected_record_ids"] = ["record-tp"]
-    first_review["explanation_quality_score"] = 2
-    first_review["high_severity_overclaim_count"] = 1
+    first_review["explanation_assessment"] = _inadequate_explanation_assessment()
+    first_review["high_severity_overclaim_findings"] = [_overclaim_finding()]
     payload["review_ranking"]["decisions"] = payload["review_ranking"]["decisions"][:2]
     payload["review_ranking"].pop("adjudication_note")
     input_path = tmp_path / "weak-study.json"
@@ -202,8 +202,9 @@ def _balanced_study_payload() -> dict[str, object]:
         "Find NTRK fusion treatment evidence.",
     ]
     return {
-        "schema_version": "evidence_selection_expert_study.v1",
+        "schema_version": "evidence_selection_expert_study.v2",
         "study_id": "balanced-shadow-study",
+        "study_type": "selection_and_review_ranking",
         "study_evidence_kind": "real_shadow_review",
         "description": "Multi-goal expert shadow-review study fixture.",
         "selection_reviews": [
@@ -220,8 +221,10 @@ def _balanced_study_payload() -> dict[str, object]:
                     f"record-{index}-b",
                 ],
                 "harness_skipped_record_ids": [f"record-{index}-c"],
-                "explanation_quality_score": 4,
-                "high_severity_overclaim_count": 0,
+                "explanation_assessment": _adequate_explanation_assessment(
+                    f"record-{index}-a",
+                ),
+                "high_severity_overclaim_findings": [],
             }
             for index, goal in enumerate(goals)
         ],
@@ -268,6 +271,38 @@ def _ranking_decisions(goals: list[str]) -> list[dict[str, object]]:
         for index in range(5)
     ]
     return positive_decisions + negative_decisions
+
+
+def _adequate_explanation_assessment(record_id: str) -> dict[str, object]:
+    return {
+        "literal_citation_present": "yes",
+        "citation_entails_claim": "yes",
+        "all_required_criteria_addressed": "yes",
+        "unsupported_material_claim_present": "no",
+        "cited_evidence": [
+            {
+                "record_id": record_id,
+                "source_locator": f"candidate:{record_id}:abstract",
+                "quoted_text": "Literal evidence supporting the decision.",
+            },
+        ],
+        "reviewer_explanation": "The source addresses every required criterion.",
+    }
+
+
+def _inadequate_explanation_assessment() -> dict[str, object]:
+    assessment = _adequate_explanation_assessment("record-fp")
+    assessment["unsupported_material_claim_present"] = "yes"
+    return assessment
+
+
+def _overclaim_finding() -> dict[str, object]:
+    return {
+        "record_id": "record-fp",
+        "material_claim": "The intervention is universally safe.",
+        "reviewer_explanation": "The source does not support universal safety.",
+        "cited_evidence": [],
+    }
 
 
 def _source_manifest(goals: list[str]) -> dict[str, object]:

--- a/tests/unit/test_run_evidence_selection_expert_study_gate.py
+++ b/tests/unit/test_run_evidence_selection_expert_study_gate.py
@@ -81,6 +81,7 @@ def test_evidence_selection_expert_study_gate_accepts_documented_note_objects(
     first_review["false_negative_notes"] = {
         "record-missed": "Reviewer expected this record."
     }
+    first_review["candidate_record_ids"].append("record-missed")
     input_path = tmp_path / "documented-notes-study.json"
     input_path.write_text(json.dumps(payload) + "\n")
 
@@ -100,6 +101,11 @@ def test_evidence_selection_expert_study_gate_runner_fails_closed(
     payload["selection_reviews"] = payload["selection_reviews"][:1]
     first_review = payload["selection_reviews"][0]
     first_review["reviewer_id"] = ""
+    first_review["candidate_record_ids"] = [
+        "record-fp",
+        "record-tp",
+        "record-0-c",
+    ]
     first_review["harness_selected_record_ids"] = ["record-fp"]
     first_review["human_selected_record_ids"] = ["record-tp"]
     first_review["explanation_assessment"] = _inadequate_explanation_assessment()
@@ -212,6 +218,11 @@ def _balanced_study_payload() -> dict[str, object]:
                 "run_id": f"00000000-0000-0000-0000-00000000000{index}",
                 "goal": goal,
                 "reviewer_id": "reviewer-a",
+                "candidate_record_ids": [
+                    f"record-{index}-a",
+                    f"record-{index}-b",
+                    f"record-{index}-c",
+                ],
                 "harness_selected_record_ids": [
                     f"record-{index}-a",
                     f"record-{index}-b",


### PR DESCRIPTION
## Summary

- replace reviewer-authored explanation scores with categorical findings, candidate-bound citations, and deterministic metrics
- distinguish selection-only studies from combined selection and ranking studies across packets, exports, bundles, pipelines, batches, reports, and CLIs
- require explicit evidence origin and prevent AI or synthetic review from passing production-style readiness gates
- add adversarial coverage for contradictory findings, overclaims, candidate binding, and selection-only/mixed batch behavior

## Validation

- all evidence-selection unit and gate regressions
- `make artana-evidence-api-service-checks`
- `make service-checks` (87.24% repository coverage; required floor 86%)
- `pre-commit run --all-files`

## What this proves

The evaluation contract now derives numeric precision, recall, adequacy, overclaim counts, calibration, and readiness decisions deterministically from categorical reviewer evidence. Selection-only evidence no longer fabricates ranking rows.

## What remains

This does not establish trusted-graph readiness. Follow-up work must add signed reviewer attestation, canonical source-text quote/locator verification, gate-time source digest verification, atomic artifact/report publication, and categorical-first ranking provenance. Live representative cases must still meet precision, recall, linking, specificity, and entailment gates.

Report: `docs/validation/reports/2026-07-13-pr-semantic-shadow-study-categorical-contract.md`