### PR TITLE
Exclude abstentions from held-out ranking coverage

### DIFF
--- a/services/artana_evidence_api/evidence_selection/ranking/calibration.py
+++ b/services/artana_evidence_api/evidence_selection/ranking/calibration.py
@@ -93,7 +93,7 @@ def build_ranking_probability_calibration_summary(
     decided_probability_decisions = tuple(
         decision
         for decision in probability_decisions
-        if decision.outcome != "abstained"
+        if decision.has_decided_outcome
     )
     availability = _calibration_availability(
         decisions=decisions,

--- a/services/artana_evidence_api/evidence_selection/ranking/contracts.py
+++ b/services/artana_evidence_api/evidence_selection/ranking/contracts.py
@@ -218,6 +218,11 @@ class ReviewRankingCalibrationDecision(BaseModel):
     goal: str | None = None
     evidence_shape: str | None = None
 
+    @property
+    def has_decided_outcome(self) -> bool:
+        """Return whether this decision contributes labeled calibration evidence."""
+        return self.outcome != "abstained"
+
     @field_validator("item_id", "research_question_id")
     @classmethod
     def _normalize_required_ids(cls, value: str, info: ValidationInfo) -> str:

--- a/services/artana_evidence_api/evidence_selection/ranking/gate_protocol.py
+++ b/services/artana_evidence_api/evidence_selection/ranking/gate_protocol.py
@@ -66,6 +66,7 @@ def calibration_protocol_blocking_reasons(
         decision.research_question_id
         for decision in decisions
         if decision.research_question_id in held_out_ids
+        and decision.has_decided_outcome
     }
     if (
         len(observed_held_out_ids)

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_ranking_policy.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_ranking_policy.py
@@ -377,6 +377,57 @@ def test_review_ranking_gate_counts_observed_held_out_questions() -> None:
     assert any("got 1" in reason for reason in report.blocking_reasons)
 
 
+def test_review_ranking_gate_excludes_abstained_only_questions_from_coverage() -> None:
+    identity = _identity()
+    protocol = _protocol(identity=identity).model_copy(
+        update={"held_out_research_question_ids": ("held-out-a", "held-out-b")},
+    )
+    decided = _decision(
+        "proposal",
+        "decided",
+        4.0,
+        "positive",
+        probability=_probability(identity=identity, value=0.8, status="diagnostic"),
+    )
+    abstained = _decision(
+        "proposal",
+        "abstained",
+        2.0,
+        "abstained",
+        probability=_probability(identity=identity, value=0.4, status="diagnostic"),
+    ).model_copy(update={"research_question_id": "held-out-b"})
+
+    report = evaluate_review_ranking_calibration_gate(
+        decisions=(decided, abstained),
+        calibration_protocol=protocol,
+        thresholds=ReviewRankingCalibrationGateThresholds(
+            min_sample_count=1,
+            min_roc_auc=0.0,
+            min_mean_operational_weight_separation=0.0,
+            min_distinct_goals=0,
+            min_distinct_evidence_shapes=0,
+            min_training_research_questions=1,
+            min_held_out_research_questions=2,
+            min_observed_held_out_research_questions=2,
+            require_calibrated_probabilities=False,
+            require_authenticated_protocol=False,
+            require_independent_expert_labels=False,
+            require_reviewer_ids=False,
+            require_adjudication_note=False,
+            require_proposal_and_review_item_sources=False,
+            require_positive_and_negative_outcomes=False,
+            require_positive_and_negative_per_source=False,
+        ),
+    )
+
+    assert report.calibration.decided_probability_count == 1
+    assert report.passed is False
+    assert any(
+        "held-out research questions; got 1" in reason
+        for reason in report.blocking_reasons
+    )
+
+
 def _decision(
     source_kind: str,
     item_id: str,


### PR DESCRIPTION
## Summary

- exclude abstained review-ranking decisions from observed held-out research-question coverage
- centralize decided-outcome semantics on `ReviewRankingCalibrationDecision`
- add regression coverage for a held-out question represented only by an abstention

## Root cause

The protocol gate and calibration metrics defined their eligible populations independently. Calibration metrics excluded abstentions, but held-out coverage counted every decision whose research-question ID was in the frozen partition. An abstained-only question could therefore satisfy the coverage threshold without contributing a labeled outcome to ECE or ROC.

The decision contract now owns the shared decided-outcome predicate, and both calibration metrics and protocol coverage consume it.

## Impact

Held-out coverage now measures research questions with positive or negative reviewer outcomes. Abstentions remain visible in calibration summaries but cannot inflate labeled-question coverage.

Follow-up to #148 and review thread https://github.com/med13foundation/artana-evidence-platform/pull/148#discussion_r3574988025.

## Validation

- `pytest services/artana_evidence_api/tests/unit/test_evidence_selection_ranking_policy.py -q` (17 passed)
- `make artana-evidence-api-lint`
- `make artana-evidence-api-type-check`
- configured pre-commit lint and type hooks for both backend services
