### PR TITLE
PR153: add blinded independent expert pilot packets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ ARTANA_EVIDENCE_API_LINT_PATHS := \
  scripts/run_evidence_selection_expert_study_gate.py \
  scripts/run_evidence_selection_review_calibration_gate.py \
  scripts/build_evidence_selection_shadow_review_packet.py \
+ scripts/build_evidence_selection_expert_pilot_packets.py \
  scripts/build_evidence_selection_shadow_review_source_inputs.py \
  scripts/build_evidence_selection_shadow_review_study_batch_manifest.py \
  scripts/build_evidence_selection_shadow_review_study_batch.py \
@@ -307,6 +308,7 @@ artana-evidence-api-type-check: ## Run strict mypy on evidence API package
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/run_evidence_selection_expert_study_gate.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/run_evidence_selection_review_calibration_gate.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/build_evidence_selection_shadow_review_packet.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
+	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/build_evidence_selection_expert_pilot_packets.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/build_evidence_selection_shadow_review_source_inputs.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/build_evidence_selection_shadow_review_study_batch_manifest.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/build_evidence_selection_shadow_review_study_batch.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)

--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -3399,6 +3399,48 @@ Remaining proof boundary:
   repair the AI-adjudicated fixture, or establish production/trusted-graph
   readiness.
 
+### 2026-07-14 - PR153 Independent Expert Pilot Packets
+
+Branch: `alvaro/evidence-pr153-expert-pilot`
+
+Goal: turn benchmark v2 into an executable blinded human-review handoff without
+letting agents, historical labels, or model outputs become expert evidence.
+
+Progress:
+
+- Added a frozen diagnostic-pilot protocol for three distinct questions, four
+  cases, 33 records, two independent reviewer slots, and third-reviewer
+  disagreement adjudication.
+- Froze categorical reviewer and packet-sufficiency findings. Numeric reviewer
+  judgments are forbidden; precision, recall, percent agreement, and overclaim
+  gates are deterministically computed later from categorical findings.
+- Added content-addressed NCBI PubMed metadata and abstracts for all 29 unique
+  sources used by the 33 records, without changing historical v1 bytes or
+  declaring any packet sufficient. Reviewer packets never substitute the
+  benchmark-authored excerpts for these independent source snapshots.
+- Added separately shuffled blinded reviewer packets. Reviewer artifacts expose
+  source content and criteria but omit model identity, expected labels, AI
+  diagnostics, harness decisions, ranking values, and private record mappings.
+- Added signed machine-only sidecars whose signatures cover packet identity,
+  source/protocol hashes, candidate order, and every candidate-to-record binding.
+- Added atomic, no-replace publication with a complete artifact manifest,
+  pre-publication signature verification, and no partial output on failure.
+- Production readiness and calibration remain false. The current pilot does not
+  meet the predeclared 20-question/200-record production-calibration scale.
+- Validation evidence:
+  `docs/validation/reports/2026-07-14-pr153-independent-expert-pilot-summary.md`.
+
+Remaining proof boundary:
+
+- Two real qualified humans must independently complete every packet, with a
+  third qualified human adjudicating disagreements.
+- A trusted external process must authenticate those identities and bind signed
+  attestations to the packet and source hashes.
+- Completed-packet import, attestation verification, adjudicated gold creation,
+  and deterministic metric calculation belong to the next PR. Until real
+  artifacts pass that boundary, benchmark v2 remains at zero expert-eligible
+  records.
+
 ## PR Update Template
 
 Copy this block when a PR is opened or merged.

--- a/docs/validation/evidence-selection-expert-pilot-runbook.md
+++ b/docs/validation/evidence-selection-expert-pilot-runbook.md
@@ -1,0 +1,96 @@
+# Evidence Selection Independent Expert Pilot Runbook
+
+Status: packet generation is implemented; independent human review has not
+started.
+
+This run is a diagnostic pilot over three distinct research questions, four
+benchmark cases, and 33 candidate records. It can correct the benchmark and
+support a new model-comparison decision. It cannot establish production
+calibration or trusted-graph readiness.
+
+## Frozen Inputs
+
+- Protocol:
+  `scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_protocol_v1.json`
+- Benchmark:
+  `scripts/validation/evidence_selection/fixtures/semantic_relevance_benchmark_v2.json`
+- Supplemental-source manifest:
+  `scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_supplement_manifest_v1.json`
+
+The historical v1 benchmark and its original source snapshots remain unchanged.
+The pilot freezes content-addressed NCBI PubMed metadata and abstracts for all
+29 unique sources used by the 33 benchmark records. Every reviewer candidate is
+built from that independent source inventory; benchmark-authored excerpts are
+never substituted into reviewer packets. These snapshots do not assert a label
+or claim that a packet is sufficient; sufficiency remains a human categorical
+finding.
+
+## Generate Packets
+
+Use a producer-held signing key that reviewers cannot access:
+
+```bash
+export ARTANA_EVIDENCE_SHADOW_REVIEW_PACKET_SIGNING_KEY=...
+uv run python scripts/build_evidence_selection_expert_pilot_packets.py \
+  --protocol scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_protocol_v1.json \
+  --output-dir reports/human-shadow-study/semantic-relevance-expert-pilot-v1
+```
+
+Publication is atomic and refuses to overwrite an existing directory. It emits:
+
+- `reviewer_packets/<reviewer-slot>/<blinded-case-id>.json`: blinded editable
+  packets with uniform source-section labels.
+- `machine_sidecars/<reviewer-slot>/<blinded-case-id>.json`: signed candidate
+  mappings to the private benchmark case and record identities.
+- `publication_manifest.json`: inventory hashes for all 16 packet and sidecar
+  artifacts. The signed machine sidecars, not the manifest, are the tamper
+  boundary.
+
+Distribute only each reviewer's own `reviewer_packets` directory. Keep machine
+sidecars with the study operator. First-pass reviewers must not receive the
+historical case identifiers, historical expected labels, AI diagnostics, model
+identity, harness decisions, ranking values, other reviewer packets, or
+sidecars.
+
+## Human Findings
+
+Each candidate requires these human-owned categorical findings:
+
+- `selection_label`: `select`, `reject`, or `abstain`.
+- `packet_sufficiency`: `sufficient` or `insufficient`.
+- literal supporting spans from the bounded packet.
+- a language explanation tied to the frozen inclusion and exclusion criteria.
+
+Reviewers must not provide confidence, relevance, explanation-quality, or
+readiness numbers. Agents may organize artifacts but cannot fill reviewer-owned
+fields or act as the gold-label author.
+
+Two externally authenticated, domain-qualified humans review every record
+independently. A third qualified human adjudicates every disagreement. External
+attestations must bind the real reviewer identity to reviewer slot, packet hash,
+case, candidate inventory, source hashes, completion timestamp, and categorical
+findings.
+
+## Predeclared Evaluation
+
+Deterministic code will compute metrics from categorical findings after
+attestation. The frozen pilot thresholds are:
+
+- adjudicated precision at least `0.80`;
+- adjudicated recall at least `0.80`;
+- first-pass percent agreement at least `0.80`;
+- high-severity overclaim count exactly `0`.
+
+No threshold may be changed after first-pass review begins. A threshold change
+requires a new protocol version and new first-pass reviews.
+
+## Scale Boundary
+
+This pilot has three distinct research questions and 33 records. Production
+calibration remains unavailable. A calibration study requires at least 20
+questions and 200 records, with at least 12 questions frozen for training and 8
+different questions held out before review begins.
+
+The next PR must implement completed-packet import and external attestation
+verification. Until that PR receives real reviewer artifacts, benchmark v2 must
+continue to report zero expert-eligible records.

--- a/docs/validation/evidence-selection-validation.md
+++ b/docs/validation/evidence-selection-validation.md
@@ -234,6 +234,22 @@ subdirectories from packet study IDs, stores packet paths relative to the
 manifest, derives unique source-export IDs from the export prefix, and refuses
 to overwrite a source packet.
 
+Semantic benchmark independent expert pilot packets:
+
+```bash
+export ARTANA_EVIDENCE_SHADOW_REVIEW_PACKET_SIGNING_KEY=...
+uv run python scripts/build_evidence_selection_expert_pilot_packets.py \
+  --protocol scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_protocol_v1.json \
+  --output-dir reports/human-shadow-study/semantic-relevance-expert-pilot-v1
+```
+
+This command produces separately ordered blinded packets for two reviewer slots
+and keeps signed candidate mappings in a machine-only directory. The current
+three-question, 33-record protocol is diagnostic and explicitly leaves
+production calibration and readiness unavailable. Follow
+`docs/validation/evidence-selection-expert-pilot-runbook.md` for distribution,
+reviewer independence, categorical findings, adjudication, and attestation.
+
 Full expert/shadow study gate:
 
 For a selection-only study, pass `--study-type selection_relevance` to the

--- a/docs/validation/reports/2026-07-14-pr153-independent-expert-pilot-summary.md
+++ b/docs/validation/reports/2026-07-14-pr153-independent-expert-pilot-summary.md
@@ -1,0 +1,83 @@
+# PR153 Independent Expert Pilot Validation
+
+Date: 2026-07-14
+
+Branch: `alvaro/evidence-pr153-expert-pilot`
+
+## Result
+
+PR153 implements a diagnostic-only, blinded expert-review handoff for benchmark
+v2. It does not create expert labels, production calibration, or a trusted-graph
+readiness claim.
+
+The generated pilot contains:
+
+- 3 distinct research questions;
+- 4 blinded cases;
+- 33 benchmark records;
+- 29 content-addressed NCBI PubMed source snapshots;
+- 2 independently ordered reviewer slots;
+- 8 reviewer packets and 8 signed machine sidecars;
+- 66 categorical candidate reviews awaiting qualified humans.
+
+Every reviewer candidate is built from the frozen PubMed source inventory. The
+builder has no benchmark-excerpt or agent-generated evidence fallback. Missing,
+extra, hash-drifted, or identity-drifted source snapshots fail before packet
+construction.
+
+## Trust Boundaries
+
+- Reviewer packets expose neutral case and candidate identifiers only.
+- Historical case IDs, expected labels, model identity, AI diagnostics, harness
+  decisions, rankings, and machine mappings remain outside reviewer packets.
+- Free-text criteria fail closed on known blinded-context markers.
+- Human findings are categorical. Agents cannot fill reviewer-owned labels or
+  author numeric judgments.
+- Signed sidecars bind the packet hash, protocol and source hashes, private case
+  identity, candidate order, and every candidate-to-record mapping.
+- Publication verifies every bundle, stages all artifacts, and uses an atomic
+  no-replace rename so failure or a racing destination cannot expose partial or
+  overwritten output.
+- `publication_manifest.json` is an inventory. Signed sidecars are the current
+  tamper boundary.
+
+## Validation Evidence
+
+- Focused benchmark, pilot, CLI, and CI-planner regressions: 59 passed.
+- Live packet generation: 8 packet/sidecar pairs and 66 candidate reviews.
+- Live packet parse, source binding, and signature verification: passed for all
+  8 pairs and all 66 reviews.
+- Reviewer blinding scan: no historical case IDs, expected-label keys, model or
+  ranking keys, harness keys, or historical excerpt markers.
+- Frozen benchmark v2 gate: passed; 33 visible records, 0 score-eligible records,
+  expert study still pending.
+- `make artana-evidence-api-service-checks`: passed, including Ruff, strict mypy
+  over 567 source files, boundary and contract checks, architecture checks,
+  migrations, and the full isolated-PostgreSQL Evidence API test suite.
+
+## Adversarial Loop
+
+The first independent review found historical case-name leakage, source-section
+priming, missing pre-publication verification, and a destination-replacement
+race. Those issues were fixed with reviewer-specific neutral case IDs, uniform
+source presentation, bundle verification, and atomic no-replace publication.
+
+The second review found that uniform presentation still mixed 30
+benchmark-authored excerpts with 3 independent PubMed abstracts. PR153 then
+replaced that mixed path with complete content-addressed PubMed coverage for all
+29 unique sources and added a hard complete-inventory gate. It also added a
+producer-side narrative leakage check.
+
+The final independent review found no remaining merge blocker.
+
+## Remaining Work
+
+Two real, externally authenticated domain experts must independently review all
+records, and a third qualified human must adjudicate disagreements. A follow-up
+PR must verify external attestations, import completed categorical findings,
+compute deterministic metrics, and keep benchmark records ineligible unless the
+entire trust chain passes.
+
+Shared-HMAC producer custody and external attestation verification remain
+explicit next-boundary work. Until real human artifacts pass that boundary,
+production readiness and production calibration remain false.

--- a/scripts/build_evidence_selection_expert_pilot_packets.py
+++ b/scripts/build_evidence_selection_expert_pilot_packets.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Build blinded semantic benchmark packets for independent expert review."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from pydantic import ValidationError
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SERVICES_ROOT = _REPO_ROOT / "services"
+for _path in (_REPO_ROOT, _SERVICES_ROOT):
+    _path_text = str(_path)
+    if _path_text not in sys.path:
+        sys.path.insert(0, _path_text)
+
+from artana_evidence_api.evidence_selection.cli_errors import (  # noqa: E402
+    cli_error_message,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2 import (  # noqa: E402
+    load_expert_pilot,
+    publish_expert_pilot_packets,
+)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Publish blinded reviewer packets and separately signed machine "
+            "sidecars for the semantic benchmark expert pilot."
+        )
+    )
+    parser.add_argument("--protocol", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build an atomic packet publication and return a process-style status."""
+
+    args = parse_args(argv)
+    try:
+        loaded = load_expert_pilot(
+            protocol_path=args.protocol,
+            repository_root=Path.cwd(),
+        )
+        manifest = publish_expert_pilot_packets(
+            loaded=loaded,
+            output_dir=args.output_dir,
+        )
+    except (OSError, ValueError, ValidationError) as exc:
+        print(f"error: {cli_error_message(exc)}", file=sys.stderr)
+        return 1
+    print(
+        "evidence_selection_expert_pilot "
+        f"reviewers={manifest.independent_reviewer_count} "
+        f"packets={manifest.reviewer_packet_count} "
+        f"candidate_reviews={manifest.candidate_review_count} "
+        "production_readiness=false production_calibration=false"
+    )
+    print(f"Wrote expert-pilot packet publication: {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/plan_service_checks.py
+++ b/scripts/ci/plan_service_checks.py
@@ -41,6 +41,7 @@ EVIDENCE_API_FILES = (
     "docs/validation/reports/pr-semantic-pr2-agent-selector-evaluation.json",
     "docs/validation/reports/pr-semantic-pr2-agent-selector-evaluation.md",
     "scripts/build_evidence_selection_shadow_review_packet.py",
+    "scripts/build_evidence_selection_expert_pilot_packets.py",
     "scripts/build_evidence_selection_shadow_review_source_inputs.py",
     "scripts/build_evidence_selection_shadow_review_study_batch_manifest.py",
     "scripts/build_evidence_selection_shadow_review_study_batch.py",

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_17018160.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_17018160.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "17018160",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/17018160/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Contribution of germline BRCA1 and BRCA2 sequence alterations to breast cancer in Northern India.",
+  "doi": "10.1186/1471-2350-7-75",
+  "publication_types": [
+    "Journal Article",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "A large number of distinct mutations in the BRCA1 and BRCA2 genes have been reported worldwide, but little is known regarding the role of these inherited susceptibility genes in breast cancer risk among Indian women. We investigated the distribution and the nature of BRCA1 and BRCA2 germline mutations and polymorphisms in a cohort of 204 Indian breast cancer patients and 140 age-matched controls."
+    },
+    {
+      "section": "METHOD",
+      "text": "Cases were selected with regard to early onset disease (< or =40 years) and family history of breast and ovarian cancer. Two hundred four breast cancer cases along with 140 age-matched controls were analyzed for mutations. All coding regions and exon-intron boundaries of the BRCA1 and BRCA2 genes were screened by heteroduplex analysis followed by direct sequencing of detected variants."
+    },
+    {
+      "section": "RESULTS",
+      "text": "In total, 18 genetic alterations were identified. Three deleterious frame-shift mutations (185delAG in exon 2; 4184del4 and 3596del4 in exon 11) were identified in BRCA1, along with one missense mutation (K1667R), one 5'UTR alteration (22C>G), three intronic variants (IVS10-12delG, IVS13+2T>C, IVS7+38T>C) and one silent substitution (5154C>T). Similarly three pathogenic protein-truncating mutations (6376insAA in exon 11, 8576insC in exon19, and 9999delA in exon 27) along with one missense mutation (A2951T), four intronic alterations (IVS2+90T>A, IVS7+75A>T, IVS8+56C>T, IVS25+58insG) and one silent substitution (1593A>G) were identified in BRCA2. Four previously reported polymorphisms (K1183R, S1613G, and M1652I in BRCA1, and 7470A>G in BRCA2) were detected in both controls and breast cancer patients. Rare BRCA1/2 sequence alterations were observed in 15 out of 105 (14.2%) early-onset cases without family history and 11.7% (4/34) breast cancer cases with family history. Of these, six were pathogenic protein truncating mutations. In addition, several variants of uncertain clinical significance were identified. Among these are two missense variants, one alteration of a consensus splice donor sequence, and a variant that potentially disrupts translational initiation."
+    },
+    {
+      "section": "CONCLUSION",
+      "text": "BRCA1 and BRCA2 mutations appear to account for a lower proportion of breast cancer patients at increased risk of harboring such mutations in Northern India (6/204, 2.9%) than has been reported in other populations. However, given the limited extent of reported family history among these patients, the observed mutation frequency is not dissimilar from that reported in other cohorts of early onset breast cancer patients. Several of the identified mutations are unique and novel to Indian patients."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_21356067.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_21356067.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "21356067",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/21356067/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Screening for BRCA1, BRCA2, CHEK2, PALB2, BRIP1, RAD50, and CDH1 mutations in high-risk Finnish BRCA1/2-founder mutation-negative breast and/or ovarian cancer individuals.",
+  "doi": "10.1186/bcr2832",
+  "publication_types": [
+    "Journal Article",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "INTRODUCTION",
+      "text": "Two major high-penetrance breast cancer genes, BRCA1 and BRCA2, are responsible for approximately 20% of hereditary breast cancer (HBC) cases in Finland. Additionally, rare mutations in several other genes that interact with BRCA1 and BRCA2 increase the risk of HBC. Still, a majority of HBC cases remain unexplained which is challenging for genetic counseling. We aimed to analyze additional mutations in HBC-associated genes and to define the sensitivity of our current BRCA1/2 mutation analysis protocol used in genetic counseling."
+    },
+    {
+      "section": "METHODS",
+      "text": "Eighty-two well-characterized, high-risk hereditary breast and/or ovarian cancer (HBOC) BRCA1/2-founder mutation-negative Finnish individuals, were screened for germline alterations in seven breast cancer susceptibility genes, BRCA1, BRCA2, CHEK2, PALB2, BRIP1, RAD50, and CDH1. BRCA1/2 were analyzed by multiplex ligation-dependent probe amplification (MLPA) and direct sequencing. CHEK2 was analyzed by the high resolution melt (HRM) method and PALB2, RAD50, BRIP1 and CDH1 were analyzed by direct sequencing. Carrier frequencies between 82 (HBOC) BRCA1/2-founder mutation-negative Finnish individuals and 384 healthy Finnish population controls were compared by using Fisher's exact test. In silico prediction for novel missense variants effects was carried out by using Pathogenic-Or-Not -Pipeline (PON-P)."
+    },
+    {
+      "section": "RESULTS",
+      "text": "Three previously reported breast cancer-associated variants, BRCA1 c.5095C > T, CHEK2 c.470T > C, and CHEK2 c.1100delC, were observed in eleven (13.4%) individuals. Ten of these individuals (12.2%) had CHEK2 variants, c.470T > C and/or c.1100delC. Fourteen novel sequence alterations and nine individuals with more than one non-synonymous variant were identified. One of the novel variants, BRCA2 c.72A > T (Leu24Phe) was predicted to be likely pathogenic in silico. No large genomic rearrangements were detected in BRCA1/2 by multiplex ligation-dependent probe amplification (MLPA)."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "In this study, mutations in previously known breast cancer susceptibility genes can explain 13.4% of the analyzed high-risk BRCA1/2-negative HBOC individuals. CHEK2 mutations, c.470T > C and c.1100delC, make a considerable contribution (12.2%) to these high-risk individuals but further segregation analysis is needed to evaluate the clinical significance of these mutations before applying them in clinical use. Additionally, we identified novel variants that warrant additional studies. Our current genetic testing protocol for 28 Finnish BRCA1/2-founder mutations and protein truncation test (PTT) of the largest exons is sensitive enough for clinical use as a primary screening tool."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_22889855.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_22889855.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "22889855",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/22889855/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "BRCA1 R1699Q variant displaying ambiguous functional abrogation confers intermediate breast and ovarian cancer risk.",
+  "doi": "10.1136/jmedgenet-2012-101037",
+  "publication_types": [
+    "Comparative Study",
+    "Journal Article",
+    "Research Support, N.I.H., Extramural",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "Clinical classification of rare sequence changes identified in the breast cancer susceptibility genes BRCA1 and BRCA2 is essential for appropriate genetic counselling of individuals carrying these variants. We previously showed that variant BRCA1 c.5096G>A p.Arg1699Gln in the BRCA1 transcriptional transactivation domain demonstrated equivocal results from a series of functional assays, and proposed that this variant may confer low to moderate risk of cancer."
+    },
+    {
+      "section": "METHODS",
+      "text": "Measures of genetic risk (report of family history, segregation) were assessed for 68 BRCA1 c.5096G>A p.Arg1699Gln (R1699Q) families recruited through family cancer clinics, comparing results with 34 families carrying the previously classified pathogenic BRCA1 c.5095C>T p.Arg1699Trp (R1699W) mutation at the same residue, and to 243 breast cancer families with no BRCA1 pathogenic mutation (BRCA-X)."
+    },
+    {
+      "section": "RESULTS",
+      "text": "Comparison of BRCA1 carrier prediction scores of probands using the BOADICEA risk prediction tool revealed that BRCA1 c.5096G>A p.Arg1699Gln variant carriers had family histories that were less 'BRCA1-like' than BRCA1 c.5095C>T p.Arg1699Trp mutation carriers (p<0.00001), but more 'BRCA1-like' than BRCA-X families (p=0.0004). Further, modified segregation analysis of the subset of 30 families with additional genotyping showed that BRCA1 c.5096G >A p.Arg1699Gln had reduced penetrance compared with the average truncating BRCA1 mutation penetrance (p=0.0002), with estimated cumulative risks to age 70 of breast or ovarian cancer of 24%."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "Our results provide substantial evidence that the BRCA1 c.5096G>A p.Arg1699Gln (R1699Q) variant, demonstrating ambiguous functional deficiency across multiple assays, is associated with intermediate risk of breast and ovarian cancer, highlighting challenges for risk modelling and clinical management of patients of this and other potential moderate-risk variants."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_23985030.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_23985030.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "23985030",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/23985030/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "The role of afatinib in the management of non-small cell lung carcinoma.",
+  "doi": "10.1517/17425255.2013.832755",
+  "publication_types": [
+    "Journal Article",
+    "Research Support, Non-U.S. Gov't",
+    "Review"
+  ],
+  "abstract_sections": [
+    {
+      "section": "INTRODUCTION",
+      "text": "Despite initial patient benefit, drug resistance to first-generation EGFR tyrosine kinase inhibitors (TKIs) is inevitable. One of the key mechanisms responsible for the development of acquired drug resistance is the secondary T790M missense mutation in exon 20 of the EGFR kinase domain. Afatinib is an ATP-competitive small molecule inhibitor that potently and irreversibly inhibits EGFR and mutated EGFR including the T790M variant, as well as other members of the ErbB family in preclinical studies."
+    },
+    {
+      "section": "AREAS COVERED",
+      "text": "The authors describe the rationale and provide the preclinical background to afatinib and its potential as a NSCLC therapy. Specifically, the authors detail the drug's pharmaco-kinetic profile and review its clinical efficacy and toxicity profile."
+    },
+    {
+      "section": "EXPERT OPINION",
+      "text": "Afatinib is an effective treatment option for therapy-naive advanced NSCLC harboring an activating EGFR mutation. Furthermore, it is also of potential benefit to patients with acquired resistance to EGFR kinase inhibitors. In the future, the authors envision the clinical development of third-generation EGFR mutation-specific inhibitors in NSCLC, which may potentially spare normal tissue toxicity. Nevertheless, afatinib currently represents a bona fide treatment option in the NSCLC therapeutic armamentarium."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_25923549.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_25923549.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "25923549",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/25923549/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "AZD9291 in EGFR inhibitor-resistant non-small-cell lung cancer.",
+  "doi": "10.1056/NEJMoa1411817",
+  "publication_types": [
+    "Clinical Trial, Phase I",
+    "Journal Article",
+    "Multicenter Study",
+    "Randomized Controlled Trial",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "The EGFR T790M mutation is the most common mechanism of drug resistance to epidermal growth factor receptor (EGFR) tyrosine kinase inhibitors in patients who have lung cancer with an EGFR mutation (EGFR-mutated lung cancer). In preclinical models, the EGFR inhibitor AZD9291 has been shown to be effective against both EGFR tyrosine kinase inhibitor-sensitizing and T790M resistance mutations."
+    },
+    {
+      "section": "METHODS",
+      "text": "We administered AZD9291 at doses of 20 to 240 mg once daily in patients with advanced lung cancer who had radiologically documented disease progression after previous treatment with EGFR tyrosine kinase inhibitors. The study included dose-escalation cohorts and dose-expansion cohorts. In the expansion cohorts, prestudy tumor biopsies were required for central determination of EGFR T790M status. Patients were assessed for safety, pharmacokinetics, and efficacy."
+    },
+    {
+      "section": "RESULTS",
+      "text": "A total of 253 patients were treated. Among 31 patients enrolled in the dose-escalation cohorts, no dose-limiting toxic effects occurred at the doses evaluated. An additional 222 patients were treated in five expansion cohorts. The most common all-cause adverse events were diarrhea, rash, nausea, and decreased appetite. The overall objective tumor response rate was 51% (95% confidence interval [CI], 45 to 58). Among 127 patients with centrally confirmed EGFR T790M who could be evaluated for response, the response rate was 61% (95% CI, 52 to 70). In contrast, among 61 patients without centrally detectable EGFR T790M who could be evaluated for response, the response rate was 21% (95% CI, 12 to 34). The median progression-free survival was 9.6 months (95% CI, 8.3 to not reached) in EGFR T790M-positive patients and 2.8 months (95% CI, 2.1 to 4.3) in EGFR T790M-negative patients."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "AZD9291 was highly active in patients with lung cancer with the EGFR T790M mutation who had had disease progression during prior therapy with EGFR tyrosine kinase inhibitors. (Funded by AstraZeneca; ClinicalTrials.gov number, NCT01802632.)."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_26195121.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_26195121.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "26195121",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/26195121/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Breast cancer risk for Korean women with germline mutations in BRCA1 and BRCA2.",
+  "doi": "10.1007/s10549-015-3495-z",
+  "publication_types": [
+    "Journal Article",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "The average age-specific cumulative risk (penetrance) of breast cancer has been studied for BRCA1 and BRCA2 mutation carriers living in Western countries, but not for those living in East Asian countries where the population breast cancer incidence is lower. From 2007 to 2011, the Korean Hereditary Breast Cancer study identified 151 BRCA1 and 225 BRCA2 mutation-carrying families from family cancer clinics. We estimated the hazard ratio (HR) for female carriers relative to the population, and hence the penetrance, using a modified segregation analysis of cancer family histories conditioned on ascertainment. The breast cancer HR estimates [95 % confidence interval (CI)] for BRCA1 and BRCA2 mutation carriers were 18 (3-103) and 11 (5-27), respectively. The breast cancer penetrance estimates (95 % CI) to age 70 years were 49 % (11-98) and 35 % (16-65) for BRCA1 and BRCA2 mutation carriers, respectively. The breast cancer HR and penetrance estimates were similar for Korean and Western women (all P > 0.4). The point estimates of breast cancer penetrance were similar to age 50 years, though less for Korean carriers at older ages. Breast cancer risk for Korean and Western mutation carriers might reflect underlying population risks which in turn likely reflect differences in environmental and lifestyle factors. This raises the possibility of identifying modifiers of cancer risk for carriers with implications for prevention."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_26314834.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_26314834.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "26314834",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/26314834/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Afatinib: a second-generation EGF receptor and ErbB tyrosine kinase inhibitor for the treatment of advanced non-small-cell lung cancer.",
+  "doi": "10.2217/fon.15.183",
+  "publication_types": [
+    "Journal Article",
+    "Review"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "First-generation reversible EGF receptor (EGFR) tyrosine kinase inhibitors (TKIs) changed our understanding of advanced non-small-cell lung cancer biology and behavior. The presence of sensitizing EGFR mutations in advanced non-small-cell lung cancer defines a subset of patients with a better prognosis and sensitivity to EGFR-TKIs with a better response rate, progression-free survival, quality of life and symptom control than with chemotherapy in the first-line therapy setting. However, current EGFR-TKIs show minimal responses in EGFR wild-type patients or with acquired TKI resistance mediated through the EGFR T790M allele. Afatinib is an irreversible pan-ErbB-TKI, active against wild-type EGFR, sensitizing and T970M-mutant EGFR, ErbB2 and ErbB4 receptors, and represents a step change between reversible first-generation and future irreversible highly specific third-generation EGFR-TKIs. Here, we review the clinical development of afatinib through the LUX-Lung trials portfolio highlighting benefits and toxicities."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_26344711.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_26344711.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "26344711",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/26344711/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Does familial breast cancer and thymoma suggest a cancer syndrome? A family perspective.",
+  "doi": "10.1016/j.gene.2015.08.069",
+  "publication_types": [
+    "Journal Article",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "Concurrence of breast cancer or thymoma with other malignancies in individual families is often observed, but the familial concurrence of breast cancer and thymoma has not yet been reported. Herein we reported a family encompassing five breast/ovarian cancer patients and two thymoma patients. Whole genome linkage analysis detected no haplotype co-segregating with both types of the tumors. In all patients with breast/ovarian cancer, genetic analysis revealed a clinically untested variant c.5141T>G in exon 18 of the BRCA1 gene, which could be a cancer-causing variant based on the functional study of Lee et al. (2010) and our current pedigree analysis. In the two thymoma patients in our family, targeted sequencing of RAD51L1 and BMP2 genes in and near the translocation site of chromosome 14 and 20 previously reported in two thymoma families, did not find any pathogenic mutation. In the present study, we identified a clinically unconfirmed BRCA1 variant segregating with breast/ovarian cancer patients in an individual family, suggesting it to be clinically functional. Our evidence, however, did not support the notion that the concurrent appearance of breast cancer and thymoma in our family represents a familial cancer syndrome caused by the same genetic disorder."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_27393503.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_27393503.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "27393503",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/27393503/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Temporal changes of EGFR mutations and T790M levels in tumour and plasma DNA following AZD9291 treatment.",
+  "doi": "10.1016/j.lungcan.2016.05.003",
+  "publication_types": [
+    "Journal Article"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "AZD9291, a T790M specific epidermal growth factor receptor (EGFR) tyrosine kinase inhibitor (TKI), has demonstrated impressive response rates in tumours harbouring the EGFR T790M resistance mutation. Emergence of resistance to AZD9291 has been shown to occur through several different mechanisms including the development of new mutations (e.g. C797S) in the EGFR tyrosine kinase domain. We studied two patients with paired tumour biopsies and blood samples pre- and post-progression on AZD9291 to explore possible resistance mechanisms. Pre- and Post-AZD9291 tumour biopsies as well as serial plasma samples were collected from two patients on the AURA clinical study (AZD9291 First Time in Patients Ascending Dose study). Droplet digital PCR (ddPCR) assays were used to quantify T790M, the driver EGFR mutation, and the C797S mutation in genomic DNA from paired tumour biopsies and plasma cell-free DNA. In the first patient, both EGFR T790M and L858R became undetectable in the plasma within 1 month after treatment with AZD9291. However, the T790M and the original L858R mutation re-emerged with radiologically confirmed resistance to AZD9291. In patient two, the levels of T790M were undetectable at the time of radiological resistance to AZD9291 but increasing levels of the original EGFR exon 19 deletion was detected. MET amplification was detected in a biopsy performed on progression. The EGFR C797S mutation was not detected in either patient at the time of relapse. ddPCR of cell free DNA enables real time monitoring of patients on 3rd generation TKIs. As resistance mechanisms are variable, monitoring levels of the initial activating EGFR mutation may facilitate more reliable detection of progression."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_27913932.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_27913932.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "27913932",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/27913932/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Almost 2% of Spanish breast cancer families are associated to germline pathogenic mutations in the ATM gene.",
+  "doi": "10.1007/s10549-016-4058-7",
+  "publication_types": [
+    "Journal Article",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "PURPOSE",
+      "text": "There is still a considerable percentage of hereditary breast and ovarian cancer (HBOC) cases not explained by BRCA1 and BRCA2 genes. In this report, next-generation sequencing (NGS) techniques were applied to identify novel variants and/or genes involved in HBOC susceptibility."
+    },
+    {
+      "section": "METHODS",
+      "text": "Using whole exome sequencing, we identified a novel germline mutation in the moderate-risk gene ATM (c.5441delT; p.Leu1814Trpfs*14) in a family negative for mutations in BRCA1/2 (BRCAX). A case-control association study was performed to establish its prevalence in Spanish population, in a series of 1477 BRCAX families and 589 controls further screened, and NGS panels were used for ATM mutational screening in a cohort of 392 HBOC Spanish BRCAX families and 350 patients affected with diseases not related to breast cancer."
+    },
+    {
+      "section": "RESULTS",
+      "text": "Although the interrogated mutation was not prevalent in case-control association study, a comprehensive mutational analysis of the ATM gene revealed 1.78% prevalence of mutations in the ATM gene in HBOC and 1.94% in breast cancer-only BRCAX families in Spanish population, where data about ATM mutations were very limited."
+    },
+    {
+      "section": "CONCLUSION",
+      "text": "ATM mutation prevalence in Spanish population highlights the importance of considering ATM pathogenic variants linked to breast cancer susceptibility."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_27959700.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_27959700.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "27959700",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/27959700/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Osimertinib or Platinum-Pemetrexed in EGFR T790M-Positive Lung Cancer.",
+  "doi": "10.1056/NEJMoa1612674",
+  "publication_types": [
+    "Clinical Trial, Phase III",
+    "Comparative Study",
+    "Journal Article",
+    "Multicenter Study",
+    "Randomized Controlled Trial",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "Osimertinib is an epidermal growth factor receptor tyrosine kinase inhibitor (EGFR-TKI) that is selective for both EGFR-TKI sensitizing and T790M resistance mutations in patients with non-small-cell lung cancer. The efficacy of osimertinib as compared with platinum-based therapy plus pemetrexed in such patients is unknown."
+    },
+    {
+      "section": "METHODS",
+      "text": "In this randomized, international, open-label, phase 3 trial, we assigned 419 patients with T790M-positive advanced non-small-cell lung cancer, who had disease progression after first-line EGFR-TKI therapy, in a 2:1 ratio to receive either oral osimertinib (at a dose of 80 mg once daily) or intravenous pemetrexed (500 mg per square meter of body-surface area) plus either carboplatin (target area under the curve, 5 [AUC5]) or cisplatin (75 mg per square meter) every 3 weeks for up to six cycles; maintenance pemetrexed was allowed. In all the patients, disease had progressed during receipt of first-line EGFR-TKI therapy. The primary end point was investigator-assessed progression-free survival."
+    },
+    {
+      "section": "RESULTS",
+      "text": "The median duration of progression-free survival was significantly longer with osimertinib than with platinum therapy plus pemetrexed (10.1 months vs. 4.4 months; hazard ratio; 0.30; 95% confidence interval [CI], 0.23 to 0.41; P<0.001). The objective response rate was significantly better with osimertinib (71%; 95% CI, 65 to 76) than with platinum therapy plus pemetrexed (31%; 95% CI, 24 to 40) (odds ratio for objective response, 5.39; 95% CI, 3.47 to 8.48; P<0.001). Among 144 patients with metastases to the central nervous system (CNS), the median duration of progression-free survival was longer among patients receiving osimertinib than among those receiving platinum therapy plus pemetrexed (8.5 months vs. 4.2 months; hazard ratio, 0.32; 95% CI, 0.21 to 0.49). The proportion of patients with adverse events of grade 3 or higher was lower with osimertinib (23%) than with platinum therapy plus pemetrexed (47%)."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "Osimertinib had significantly greater efficacy than platinum therapy plus pemetrexed in patients with T790M-positive advanced non-small-cell lung cancer (including those with CNS metastases) in whom disease had progressed during first-line EGFR-TKI therapy. (Funded by AstraZeneca; AURA3 ClinicalTrials.gov number, NCT02151981 .)."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_30191368.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_30191368.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "30191368",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/30191368/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "A tandem duplication of BRCA1 exons 1-19 through DHX8 exon 2 in four families with hereditary breast and ovarian cancer syndrome.",
+  "doi": "10.1007/s10549-018-4957-x",
+  "publication_types": [
+    "Journal Article"
+  ],
+  "abstract_sections": [
+    {
+      "section": "PURPOSE",
+      "text": "The purpose of this study is to characterize a novel structural variant, a large duplication involving exons 1-19 of the BRCA1 gene in four independent families, and to provide diagnostically valuable information including the position of the breakpoints as well as clues to its clinical significance."
+    },
+    {
+      "section": "METHODS",
+      "text": "The duplication of exons 1-19 of the BRCA1 gene was initially detected by routine laboratory testing including MLPA analysis and next generation sequencing. For detailed characterization we performed array-comparative genome hybridization analysis, fluorescent in situ hybridization, next generation mapping, and long-distance PCR for break-point sequencing."
+    },
+    {
+      "section": "RESULTS",
+      "text": "Our data revealed a tandem duplication on chromosome 17 that encompassed 357 kb and included exons 1-19 of the BRCA1 gene and the genes NBR2, NBR1, TMEM106A, LOC100130581, ARL4D, MIR2117 up to parts of the DHX8 gene. This structural variant appeared as a tandem duplication with breakpoints in intron 19 of the BRCA1 gene and in intron 3 of the DHX8 gene (HGVS:chr17(hg19):g.41210776_41568516dup). Segregation analysis indicated that this structural rearrangement is phased in trans with a known pathogenic exon deletion of the BRCA1 gene in one family."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "The copy number variation initially recognized as duplication of exon 1-19 of the BRCA1 gene by MLPA analysis is a structural variation with breakpoints in the BRCA1 and DHX8 genes. Although currently to be classified as a variant of unknown significance, our family data indicates that this duplication may be a benign variation or at least of markedly reduced penetrance since it occurs in trans with another known fully pathogenic variant in the BRCA1 gene."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_30610487.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_30610487.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "30610487",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/30610487/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Clinical implications of germline mutations in breast cancer genes: RECQL.",
+  "doi": "10.1007/s10549-018-05096-6",
+  "publication_types": [
+    "Journal Article",
+    "Review"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "The identification of new hereditary breast cancer genes is an area of highly active research. In 2015, two independent studies provided initial evidence for a novel breast cancer susceptibility gene, RECQL, a DNA helicase which plays an important role in the DNA damage response. Several subsequent studies in independent patient cohorts have provided further data on RECQL variant frequency in additional populations, some of which have brought in to question the increased breast cancer risk associated with RECQL mutations."
+    },
+    {
+      "section": "RESULTS",
+      "text": "The initial reports present findings from whole exome sequencing of high-risk familial breast cancer cases in the French-Canadian, Polish and Han Chinese populations and estimate the carrier frequency of pathogenic RECQL mutations in high-risk breast cancer patients who have previously tested negative for BRCA1 and BRCA2 mutations to be approximately 1-2%. Proposed founder mutations were identified in French-Canadian and Polish populations. Functional studies support loss of function of the helicase activity of RECQL for some of the reported pathogenic mutations. An additional study in a cohort of Southern Chinese high-risk breast cancer patients estimated the frequency of pathogenic RECQL mutations to be 0.54%. A possible Chinese founder mutation was identified, but only a small number of controls were sequenced. Subsequent case-control studies screening for the Polish founder mutation in patients from Germany and Belarus did not find any evidence for increased breast cancer risk for this variant. An Australian case-control study also failed to identify an increased risk of breast cancer associated with RECQL loss of function variants."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "RECQL plays an important role in DNA repair, and is a plausible candidate breast cancer susceptibility gene. Initial studies showed evidence of an association between variants in this gene and an increased breast cancer risk in three separate populations, and identified founder mutations with significantly increased odds ratios. However, several subsequent studies have failed to support the association. With the limited and conflicting evidence available, there remains debate as to whether there is an increased breast cancer risk in individuals carrying RECQL loss of function variants. Further studies are required to better quantify the risks associated with RECQL variants and the current evidence base is not sufficient to justify routine inclusion of RECQL on breast cancer gene panels in clinical use. Management of patients in whom RECQL variants have been identified should be based on clinician assessment, in the context of the family history. Further studies are required to better quantify the risks to RECQL mutation carriers and may also guide management and potential therapeutic targeting for patients."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_30657347.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_30657347.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "30657347",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/30657347/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Role of osimertinib in the treatment of EGFR-mutation positive non-small-cell lung cancer.",
+  "doi": "10.2217/fon-2018-0626",
+  "publication_types": [
+    "Journal Article",
+    "Review"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "Mutations in the EGFR occur in approximately 10-35% of non-small-cell lung cancer (NSCLC) patients. Osimertinib is a third-generation oral small molecule inhibitor of EGFR, active against the common targetable activating EGFR mutations in L858R and exon 19 deletion; it also inhibits the T790M mutation. It was initially developed and approved for the treatment of acquired resistance to EGFR inhibition mediated by the T790M pathway activation. Recently, the FLAURA trial showed significantly improved progression-free survival with osimertinib compared with the first generation EGFR tyrosine kinase inhibitors gefitinib or erlotinib; this has led to its approval by US FDA and European Medicines Agency (EMA) as frontline therapy. Ongoing studies will define the resistance mechanisms to osimertinib, novel combination approaches and role in earlier stages of NSCLC."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_31039766.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_31039766.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "31039766",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/31039766/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "The increase in activating EGFR mutation in plasma is an early biomarker to monitor response to osimertinib: a case report.",
+  "doi": "10.1186/s12885-019-5604-6",
+  "publication_types": [
+    "Case Reports",
+    "Journal Article"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "Systemic treatment of advanced non-small cell lung cancer (NSCLC) has changed dramatically since the introduction of targeted therapies. The analysis of circulating tumor DNA (ctDNA) is a valuable approach to monitor the clonal evolution of tumors during treatment with EGFR-tyrosine kinase inhibitors (TKIs) and to detect resistance mutations."
+    },
+    {
+      "section": "CASE PRESENTATION",
+      "text": "A NSCLC patient with exon 19 deletion (ex19del) of EGFR was treated with osimertinib after multiple lines of treatment and obtained a partial response that lasted over 26 months. Blood was collected at each visit and ctDNA was extracted to monitor ex19del by digital droplet PCR. Within a few weeks from the beginning of osimertinib, ex19del disappeared from plasma but appeared again and steadily increased a few months later anticipating tumor progression. Interestingly, the change in ex19del was much more pronounced than other mutations, since T790M appeared 3 months after the increase of ex19del, and C797S was detectable a few weeks before clinical disease progression. Then the patient received cytotoxic chemotherapy, which was associated with a decrease in ex19del and disappearance of T790M and C797S; however, at disease progression, all EGFR mutations increased again in plasma together with MET amplification which was detected by NGS."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "The measurement of ex19del changes in ctDNA is a simple and sensitive approach to monitor clinical outcome to osimertinib and, potentially, to other therapeutic interventions."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_31206626.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_31206626.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "31206626",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/31206626/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Pathogenic and likely pathogenic variants in PALB2, CHEK2, and other known breast cancer susceptibility genes among 1054 BRCA-negative Hispanics with breast cancer.",
+  "doi": "10.1002/cncr.32083",
+  "publication_types": [
+    "Journal Article",
+    "Research Support, N.I.H., Extramural",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "Breast cancer (BC) is the most common cancer and related cause of mortality among Hispanics, yet susceptibility has been understudied. BRCA1 and BRCA2 (BRCA) mutations explain less than one-half of hereditary BC, and the proportion associated with other BC susceptibility genes is unknown."
+    },
+    {
+      "section": "METHODS",
+      "text": "Germline DNA from 1054 BRCA-mutation-negative Hispanic women with hereditary BC (BC diagnosed at age <51 years, bilateral BC, breast and ovarian cancer, or BC diagnosed at ages 51-70 years with \u22652 first-degree or second-degree relatives who had BC diagnosed at age <70 years), 312 local controls, and 887 multiethnic cohort controls was sequenced and analyzed for 12 known and suspected, high-penetrance and moderate-penetrance cancer susceptibility genes (ataxia telangiectasia mutated [ATM], breast cancer 1 interacting protein C-terminal helicase 1 [BRIP1], cadherin 1 [CDH1], checkpoint kinase 2 [CHEK2], nibrin [NBN], neurofibromatosis type 1 [NF1], partner and localizer of BRCA2 [PALB2], phosphatase and tensin homolog [PTEN], RAD51 paralog 3 [RAD51C], RAD51D, serine/threonine kinase 11 [STK11], and TP53)."
+    },
+    {
+      "section": "RESULTS",
+      "text": "Forty-nine (4.6%) pathogenic or likely pathogenic variants (PVs) in 47 of 1054 participants (4.5%), including 21 truncating frameshift, 20 missense, 5 nonsense, and 4 splice variants, were identified in CHEK2 (n = 20), PALB2 (n = 18), ATM (n = 5), TP53 (n = 3), BRIP1 (n = 2), and CDH1 and NF1 (both n = 1) and none were identified in NBN, PTEN, STK11, RAD51C, or RAD51D. Nine participants carried the PALB2 c.2167_2168del PV (0.85%), and 14 carried the CHEK2 c.707T>C PV (1.32%)."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "Of 1054 BRCA-negative, high-risk Hispanic women, 4.5% carried a PV in a cancer susceptibility gene, increasing understanding of hereditary BC in this population. Recurrent PVs in PALB2 and CHEK2 represented 47% (23 of 49) of the total, suggesting a founder effect. Accurate classification of variants was enabled by carefully controlling for ancestry and the increased identification of at-risk Hispanics for screening and prevention."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_32658311.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_32658311.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "32658311",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/32658311/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Germline pathogenic variant spectrum in 25 cancer susceptibility genes in Turkish breast and colorectal cancer patients and elderly controls.",
+  "doi": "10.1002/ijc.33199",
+  "publication_types": [
+    "Journal Article",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "Inherited pathogenic variants account for 5% to 10% of all breast cancer (BC) and colorectal cancer (CRC) cases. Here, we sought to profile the pathogenic variants in 25 cancer susceptibility genes in Turkish population. Germline pathogenic variants were screened in 732 BC patients, 189 CRC patients and 490 cancer-free elderly controls, using next-generation sequencing-based multigene panel testing and multiplex ligation-dependent probe amplification testing. Pathogenic variants were detected in 17.2% of high-risk BC patients and 26.4% of high-risk CRC patients. More than 95% of these variants were clinically actionable. BRCA1/2 and mismatch repair genes (MLH1, MSH2 and MSH6) accounted for two-thirds of all pathogenic variants detected in high-risk BC and CRC patients, respectively. Pathogenic variants in PALB2, CHEK2, ATM and TP53 were also prevalent in high-risk BC patients (4.5%). BRCA1 exons 17-18 deletion and CHEK2 c.592+3A>T were the most common variants predisposing to BC, and they are likely to be founder variants. Three frequent MUTYH pathogenic variants (c.884C>T, c.1437_1439delGGA and c.1187G>A) were responsible for all MUTYH biallelic cases (4.4% of high-risk CRC patients). The total pathogenic variant frequency was very low in controls (2.4%) and in low-risk BC (3.9%) and CRC (6.1%) patients. Our study depicts the pathogenic variant spectrum and prevalence in Turkish BC and CRC patients, guiding clinicians and health authorities for genetic testing applications and variant classification in Turkish population."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_34237702.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_34237702.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "34237702",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/34237702/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "BRCA1 and BRCA2 whole cDNA analysis in unsolved hereditary breast/ovarian cancer patients.",
+  "doi": "10.1016/j.cancergen.2021.06.003",
+  "publication_types": [
+    "Journal Article",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "Germline pathogenic variants in BRCA1 and BRCA2 genes (BRCA1/2) explain an important fraction of hereditary breast/ovarian cancer (HBOC) cases. Genetic testing generally involves examining coding regions and exon/intron boundaries, thus the frequency of deleterious variants in non-coding regions is unknown. Here we analysed BRCA1/2 whole cDNA in a large cohort of 320 unsolved high-risk HBOC cases in order to identify potential splicing alterations explained by variants in BRCA1/2 deep intronic regions. Whole RNA splicing profiles were analysed by RT-PCR using Sanger sequencing or high-resolution electrophoresis in a QIAxcel instrument. Known predominant BRCA1/2 alternative splicing events were detected, together with two novel events BRCA1 \u25bc21 and BRCA2 \u039418q_27p. BRCA2 exon 3 skipping was detected in one patient (male) affected with breast cancer, caused by a known Portuguese founder mutation (c.156_157insAluYa5). An altered BRCA2 splicing pattern was detected in three patients, consisting in the up-regulation of \u25bc20A, \u039422 and \u25bc20A+\u039422 transcripts. In silico analysis and semi-quantitative data identified the polymorphism BRCA2 c.8755-66T>C as a potential modifier of \u039422 levels. Our findings suggest that mRNA alterations in BRCA1/2 caused by deep intronic variants are rare in Spanish population. However, RNA analysis complements DNA-based strategies allowing the identification of alterations that could go undetected by conventional testing."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_34642874.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_34642874.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "34642874",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/34642874/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Penetrance of male breast cancer susceptibility genes: a systematic review.",
+  "doi": "10.1007/s10549-021-06413-2",
+  "publication_types": [
+    "Journal Article",
+    "Systematic Review"
+  ],
+  "abstract_sections": [
+    {
+      "section": "PURPOSE",
+      "text": "Several male breast cancer (MBC) susceptibility genes have been identified, but the MBC risk for individuals with a pathogenic variant in each of these genes (i.e., penetrance) remains unclear. We conducted a systematic review of studies reporting the penetrance of MBC susceptibility genes to better summarize current estimates of penetrance."
+    },
+    {
+      "section": "METHODS",
+      "text": "A search query was developed to identify MBC-related papers indexed in PubMed/MEDLINE. A validated natural language processing method was applied to identify papers reporting penetrance estimates. These penetrance studies' bibliographies were reviewed to ensure comprehensiveness. We accessed the potential ascertainment bias for each enrolled study."
+    },
+    {
+      "section": "RESULTS",
+      "text": "Fifteen penetrance studies were identified from 12,182 abstracts, covering five purported MBC susceptibility genes: ATM, BRCA1, BRCA2, CHEK2, and PALB2. Cohort (n = 6, 40%) and case-control (n = 5, 33%) studies were the two most common study designs, followed by family-based (n = 3, 20%), and a kin-cohort study (n = 1, 7%). Seven of the 15 studies (47%) adjusted for ascertainment adequately and therefore the MBC risks reported by these seven studies can be considered applicable to the general population. Based on these seven studies, we found pathogenic variants in ATM, BRCA2, CHEK2 c.1100delC, and PALB2 show an increased risk for MBC. The association between BRCA1 and MBC was not statistically significant."
+    },
+    {
+      "section": "CONCLUSION",
+      "text": "This work supports the conclusion that pathogenic variants in ATM, BRCA2, CHEK2 c.1100delC, and PALB2 increase the risk of MBC, whereas pathogenic variants in BRCA1 may not be associated with increased MBC risk."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_35681464.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_35681464.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "35681464",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/35681464/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "CFTR Modulators in People with Cystic Fibrosis: Real-World Evidence in France.",
+  "doi": "10.3390/cells11111769",
+  "publication_types": [
+    "Journal Article",
+    "Review"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "Cystic fibrosis (CF) is a rare genetic multisystemic disease, the manifestations of which are due to mutations in the gene encoding the CF transmembrane conductance regulator (CFTR) protein and can lead to respiratory insufficiency and premature death. CFTR modulators, which were developed in the past decade, partially restore CFTR protein function. Their clinical efficacy has been demonstrated in phase 3 clinical trials, particularly in terms of lung function and pulmonary exacerbations, nutritional status, and quality of life in people with gating mutations (ivacaftor), homozygous for the F508del mutation (lumacaftor/ivacaftor and tezacaftor/ivacaftor), and in those with at least one F508del mutation (elexacaftor/tezacaftor/ivacaftor). However, many questions remain regarding their long-term safety and effectiveness, particularly in patients with advanced lung disease, liver disease, renal insufficiency, or problematic bacterial colonization. The impact of CFTR modulators on other important outcomes such as concurrent treatments, lung transplantation, chest imaging, or pregnancies also warrants further investigation. The French CF Reference Network includes 47 CF centers that contribute patient data to the comprehensive French CF Registry and have conducted nationwide real-world studies on CFTR modulators. This review seeks to summarize the results of these real-world studies and examine their findings against those of randomized control trials."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_35816621.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_35816621.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "35816621",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/35816621/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Efficacy and Safety of Elexacaftor/Tezacaftor/Ivacaftor in Children 6 Through 11 Years of Age with Cystic Fibrosis Heterozygous for F508del and a Minimal Function Mutation: A Phase 3b, Randomized, Placebo-controlled Study.",
+  "doi": "10.1164/rccm.202202-0392OC",
+  "publication_types": [
+    "Randomized Controlled Trial",
+    "Clinical Trial, Phase III",
+    "Journal Article",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "Rationale: The triple-combination regimen elexacaftor/tezacaftor/ivacaftor (ELX/TEZ/IVA) was shown to be safe and efficacious in children aged 6 through 11 years with cystic fibrosis and at least one F508del-CFTR allele in a phase 3, open-label, single-arm study. Objectives: To further evaluate the efficacy and safety of ELX/TEZ/IVA in children 6 through 11 years of age with cystic fibrosis heterozygous for F508del and a minimal function CFTR mutation (F/MF genotypes) in a randomized, double-blind, placebo-controlled phase 3b trial. Methods: Children were randomized to receive either ELX/TEZ/IVA (n = 60) or placebo (n = 61) during a 24-week treatment period. The dose of ELX/TEZ/IVA administered was based on weight at screening, with children <30 kg receiving ELX 100 mg once daily, TEZ 50 mg once daily, and IVA 75 mg every 12 hours, and children \u2a7e30 kg receiving ELX 200 mg once daily, TEZ 100 mg once daily, and IVA 150 mg every 12 hours (adult dose). Measurements and Main Results: The primary endpoint was absolute change in lung clearance index2.5 from baseline through Week 24. Children given ELX/TEZ/IVA had a mean decrease in lung clearance index2.5 of 2.29 units (95% confidence interval [CI], 1.97-2.60) compared with 0.02 units (95% CI, -0.29 to 0.34) in children given placebo (between-group treatment difference, -2.26 units; 95% CI, -2.71 to -1.81; P < 0.0001). ELX/TEZ/IVA treatment also led to improvements in the secondary endpoint of sweat chloride concentration (between-group treatment difference, -51.2 mmol/L; 95% CI, -55.3 to -47.1) and in the other endpoints of percent predicted FEV1 (between-group treatment difference, 11.0 percentage points; 95% CI, 6.9-15.1) and Cystic Fibrosis Questionnaire-Revised Respiratory domain score (between-group treatment difference, 5.5 points; 95% CI, 1.0-10.0) compared with placebo from baseline through Week 24. The most common adverse events in children receiving ELX/TEZ/IVA were headache and cough (30.0% and 23.3%, respectively); most adverse events were mild or moderate in severity. Conclusions: In this first randomized, controlled study of a cystic fibrosis transmembrane conductance regulator modulator conducted in children 6 through 11 years of age with F/MF genotypes, ELX/TEZ/IVA treatment led to significant improvements in lung function, as well as robust improvements in respiratory symptoms and cystic fibrosis transmembrane conductance regulator function. ELX/TEZ/IVA was generally safe and well tolerated in this pediatric population with no new safety findings."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_38198345.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_38198345.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "38198345",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/38198345/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Use of elexacaftor+tezacaftor+ivacaftor in individuals with cystic fibrosis and at least one F508del allele: a systematic review and meta-analysis.",
+  "doi": "10.36416/1806-3756/e20230187",
+  "publication_types": [
+    "Meta-Analysis",
+    "Systematic Review",
+    "Journal Article"
+  ],
+  "abstract_sections": [
+    {
+      "section": "OBJECTIVE",
+      "text": "To evaluate the effect of treatment with the combination of three cystic fibrosis transmembrane conductance regulator (CFTR) modulators-elexacaftor+tezacaftor+ivacaftor (ETI)-on important clinical endpoints in individuals with cystic fibrosis."
+    },
+    {
+      "section": "METHODS",
+      "text": "This was a systematic review and meta-analysis of randomized clinical trials that compared the use of ETI in individuals with CF and at least one F508del allele with that of placebo or with an active comparator such as other combinations of CFTR modulators, following the Preferred Reporting Items for Systematic Reviews and Meta-Analyses (PRISMA) recommendations and the Patients of interest, Intervention to be studied, Comparison of interventions, and Outcome of interest (PICO) methodology. We searched the following databases: MEDLINE, EMBASE, Cochrane Central Register of Controlled Trials, and ClinicalTrials.gov from their inception to December 26th, 2022. The risk of bias was assessed using the Cochrane risk-of-bias tool, and the quality of evidence was based on the Grading of Recommendations Assessment, Development and Evaluation (GRADE)."
+    },
+    {
+      "section": "RESULTS",
+      "text": "We retrieved 54 studies in the primary search. Of these, 6 met the inclusion criteria and were analyzed (1,127 patients; 577 and 550 in the intervention and control groups, respectively). The meta-analysis revealed that the use of ETI increased FEV1% [risk difference (RD), +10.47%; 95% CI, 6.88-14.06], reduced the number of acute pulmonary exacerbations (RD, -0.16; 95% CI, -0.28 to -0.04), and improved quality of life (RD, +14.93; 95% CI, 9.98-19.89) and BMI (RD, +1.07 kg/m2; 95% CI, 0.90-1.25). Adverse events did not differ between groups (RD, -0.03; 95% CI, -0.08 to 0.01), and none of the studies reported deaths."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "Our findings demonstrate that ETI treatment substantially improves clinically significant, patient-centered outcomes."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_39227072.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_39227072.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "39227072",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/39227072/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Impact of the expanded label for elexacaftor/tezacaftor/ivacaftor in people with cystic fibrosis with no F508del variant in the USA.",
+  "doi": "10.1183/13993003.01146-2024",
+  "publication_types": [
+    "Journal Article"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "Elexacaftor/tezacaftor/ivacaftor (ETI), which is approved for people with cystic fibrosis (pwCF) with a F508del variant, was further approved based on in vitro data in the USA for those carrying at least one of 177 rare CFTR (cystic fibrosis transmembrane conductance regulator) variants."
+    },
+    {
+      "section": "METHODS",
+      "text": "PwCF, aged \u22656 years, carrying no F508del variant but with at least one of these 177 rare variants, were identified within the US Cystic Fibrosis Foundation Patient Registry (CFFPR) between 2020 and 2022. The evolution of forced expiratory volume in 1 s (FEV1) percentage predicted and rates of pulmonary exacerbations were analysed over the first year following ETI initiation, using a linear regression with generalised estimating equations and a negative binomial model, respectively."
+    },
+    {
+      "section": "RESULTS",
+      "text": "A total of 1791 individuals aged \u22656 years with rare CFTR variants were eligible for ETI, corresponding to 5.2% of CFFPR participants. 815 individuals (45.5%), of which 57.9% were already treated with another CFTR modulator, initiated ETI within the first 2 years following approval. Individuals with more severe respiratory disease were more likely to initiate ETI, whereas those previously treated with another CFTR modulator or those with no private insurance coverage had less ETI initiation. ETI initiation was associated with an increase in mean FEV1 % pred by +3.39 (95% CI 2.14-4.64) and a decrease in the rates of pulmonary exacerbations (adjusted rate ratio 0.55, 95% CI 0.38-0.79). These effects were greater in individuals na\u00efve of previous CFTR modulators."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "Extension of the ETI label to rare CFTR variants is associated with meaningful improvements in lung function and a marked reduction in pulmonary exacerbations."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40209082.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40209082.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "40209082",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/40209082/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Long-Term Safety and Efficacy of Elexacaftor/Tezacaftor/Ivacaftor in Adults and Adolescents with Cystic Fibrosis and at Least One F508del Allele: A Phase 3 Open-Label Extension Study.",
+  "doi": "10.1164/rccm.202411-2231OC",
+  "publication_types": [
+    "Journal Article",
+    "Clinical Trial, Phase III",
+    "Multicenter Study",
+    "Research Support, Non-U.S. Gov't"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "Rationale: Clinical and real-world studies show that elexacaftor/tezacaftor/ivacaftor (ELX/TEZ/IVA) is efficacious and safe in people with cystic fibrosis (CF) \u2a7e12 years of age with at least one F508del allele. Objectives: Given the potential for lifelong ELX/TEZ/IVA use, the long-term safety and efficacy of ELX/TEZ/IVA was assessed. Methods: In this phase 3, open-label, single-arm extension study, participants with F508del-minimal function genotypes (from 24-wk parent study 445-102 [n = 399]) or with the F508del-F508del genotype (from 4-wk parent study 445-103 [n = 107]) received ELX/TEZ/IVA (ELX 200 mg once daily, TEZ 100 mg once daily, and IVA 150 mg every 12 h) over 192 weeks. Measurements and Main Results: The primary endpoint was safety and tolerability. Mean exposure to ELX/TEZ/IVA was 172.6 weeks. Most participants had adverse events classified as mild (12.8%) or moderate (60.7%) in severity. Eighteen participants (3.6%) had adverse events that led to treatment discontinuation. After starting ELX/TEZ/IVA, participants had consistent increases in percent predicted FEV1 (ppFEV1), Cystic Fibrosis Questionnaire-Revised respiratory domain score, and body mass index, with decreases in sweat chloride concentration and pulmonary exacerbation rates; these improvements were maintained through 192 weeks. The mean annualized rate of change in ppFEV1 was 0.02 percentage points (95% confidence interval, -0.14 to 0.19) after initiation of ELX/TEZ/IVA. Conclusions: During this 192-week open-label extension study, the longest clinical study of a CFTR (cystic fibrosis transmembrane conductance regulator) modulator to date, ELX/TEZ/IVA remained generally safe and well tolerated. Participants had sustained improvements in lung function, respiratory symptoms, CFTR function, pulmonary exacerbation rates, and nutritional status. The estimated annualized rate of change in ppFEV1 suggests no evidence of pulmonary function loss across the study population over the 4-year treatment period. These results confirm the favorable long-term safety profile and durable disease-modifying clinical benefits of ELX/TEZ/IVA in adolescents and adults with CF. Clinical trial registered with www.clinicaltrials.gov (NCT03525574)."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40210412.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40210412.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "40210412",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/40210412/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Elexacaftor/tezacaftor/ivacaftor in children aged \u22656 years with cystic fibrosis heterozygous for F508del and a minimal function mutation: results from a 96-week open-label extension study.",
+  "doi": "10.1183/13993003.02435-2024",
+  "publication_types": [
+    "Journal Article",
+    "Clinical Trial, Phase III",
+    "Multicenter Study",
+    "Randomized Controlled Trial"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "Elexacaftor/tezacaftor/ivacaftor (ELX/TEZ/IVA) was efficacious and safe in children aged 6-11 years with cystic fibrosis (CF) heterozygous for F508del and a minimal function CF transmembrane conductance regulator (CFTR) variant (F/MF genotypes) in a 24-week, placebo-controlled trial. We conducted a 96-week open-label extension study for children who completed the 24-week parent study."
+    },
+    {
+      "section": "METHODS",
+      "text": "In this phase 3b extension study, dosing was based on weight and age, with children weighing <30 kg and aged <12 years receiving ELX 100 mg once daily, TEZ 50 mg once daily and IVA 75 mg every 12 h, and children \u226530 kg or \u226512 years receiving ELX 200 mg once daily, TEZ 100 mg once daily and IVA 150 mg every 12 h. The primary end-point was safety and tolerability. Secondary and other efficacy end-points included absolute changes from parent study baseline in sweat chloride concentration, lung clearance index (LCI2.5), percentage predicted forced expiratory volume in 1 s (FEV1) and Cystic Fibrosis Questionnaire-Revised (CFQ-R) respiratory domain score."
+    },
+    {
+      "section": "RESULTS",
+      "text": "A total of 120 children were enrolled and dosed. 118 children (98.3%) had adverse events (AEs), which for most were mild (43.3%) or moderate (48.3%) in severity. The most common AEs (\u226520% of children) were COVID-19 (58.3%), cough (51.7%), nasopharyngitis (45.0%), pyrexia (40.0%), headache (37.5%), upper respiratory tract infection (30.8%), oropharyngeal pain (26.7%), rhinitis (24.2%), abdominal pain (22.5%) and vomiting (20.0%). Children who transitioned from the placebo and ELX/TEZ/IVA groups of the parent study had improvements from parent study baseline at Week 96 in mean sweat chloride concentration (-57.3 (95% CI -61.6- -52.9) and -57.5 (95% CI -62.0- -53.0) mmol\u00b7L-1), LCI2.5 (-1.74 (95% CI -2.09- -1.38) and -2.35 (95% CI -2.72- -1.97) units), FEV1 % pred (6.1 (95% CI 2.6-9.7) and 6.9 (95% CI 3.2-10.5) percentage points) and CFQ-R respiratory domain score (6.6 (95% CI 2.5-10.8) and 2.6 (95% CI -1.6-6.8) points)."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "ELX/TEZ/IVA treatment was generally safe and well tolerated, with a safety profile consistent with the parent study and older age groups. After starting ELX/TEZ/IVA, children had robust improvements in sweat chloride concentration and lung function that were maintained through 96 weeks. These results demonstrate the safety and durable efficacy of ELX/TEZ/IVA in this paediatric population."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40288678.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40288678.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "40288678",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/40288678/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Association of gene variant type and location with breast cancer risk in the general population.",
+  "doi": "10.1016/j.annonc.2025.04.010",
+  "publication_types": [
+    "Journal Article"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "Pathogenic variants (PVs) in ATM, BRCA1, BRCA2, CHEK2, and PALB2 are associated with increased breast cancer risk. It is unknown, however, whether this risk differs by PV type or location in carriers ascertained from the general population."
+    },
+    {
+      "section": "PATIENTS AND METHODS",
+      "text": "To evaluate breast cancer risks associated with PV type and location in ATM, BRCA1, BRCA2, CHEK2, and PALB2, we carried out age-adjusted case-control association analysis in 32 247 women with and 32 544 age-matched women without breast cancer from the CARRIERS Consortium. PVs were grouped by type and location within genes and assessed for risks of breast cancer [odds ratios (OR), 95% confidence intervals (CI), and P values] using logistic regression."
+    },
+    {
+      "section": "RESULTS",
+      "text": "Compared with women carrying BRCA2 exon 11 protein truncating variants (PTVs) in the CARRIERS population-based study, women with BRCA2 ex1-10 PTVs (OR = 13.5, 95% CI 6.0-38.7, P < 0.001) and ex13-27 PTVs (OR = 9.0, 95% CI 4.9-18.5, P < 0.001) had higher breast cancer risks, lower rates of estrogen receptor (ER)-negative breast cancer (ex13-27 OR = 0.5, 95% CI 0.2-0.9, P = 0.035; ex1-10 OR = 0.5, 95% CI 0.1-1.0, P = 0.065), and earlier age at breast cancer diagnosis (ex13-27 5.5 years, P < 0.001; ex1-10 2.4 years, P = 0.169). These associations with ER-negative breast cancer and age were replicated in a high-risk clinical cohort from Ambry Genetics and the population-based UK Biobank cohort. No differences in risk by gene region were observed for PTVs in other predisposition genes."
+    },
+    {
+      "section": "CONCLUSIONS",
+      "text": "Population-based and clinical high-risk cohorts establish that PTVs in exon 11 of BRCA2 are associated with reduced breast cancer risk, later age at diagnosis, and greater risk of ER-negative disease. These differential risks may improve individualized risk prediction and clinical management for women carrying BRCA2 PTVs."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40403695.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40403695.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "40403695",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/40403695/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Impact of germline variants on breast and ovarian cancer risk in Japanese women: an original cohort study and meta-analysis.",
+  "doi": "10.1016/j.ebiom.2025.105758",
+  "publication_types": [
+    "Journal Article",
+    "Meta-Analysis"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "Pathogenic variants (PVs) of BRCA1 and BRCA2 predispose individuals to a higher risk of breast and ovarian cancer; however, the precise risks posed by other cancer susceptibility genes remain unclear, particularly in Asian populations."
+    },
+    {
+      "section": "METHODS",
+      "text": "We executed a case-control study of 11 and 26 genes associated with breast and ovarian cancer susceptibility, respectively, in 7220 women with breast cancer, 2464 women with ovarian cancer, and 4032 controls from a multicentre, hospital-based registry in Japan. Furthermore, we conducted a meta-analysis of 23,193 patients with breast and/or ovarian cancer and 31,190 controls from six other hospital-based studies."
+    },
+    {
+      "section": "FINDINGS",
+      "text": "Overall, 395 (5.5%) patients with breast cancer and 331 (13.4%) patients with ovarian cancer harboured PVs. Meta-analyses revealed that PVs of BRCA1, BRCA2, CHEK2, PALB2, and TP53 were associated significantly with breast cancer risk (P < 0.001), while PVs of ATM, BRCA1, BRCA2, MSH6, and RAD51D were associated significantly with ovarian cancer risk (P < 0.001). PVs in the BRCA1 DNA-binding domain were associated with a younger age at diagnosis after adjusting for cancer type and family history (\u03b2 = -3.79, 95% CI = -7.16 to -0.41; P = 0.028)."
+    },
+    {
+      "section": "INTERPRETATION",
+      "text": "These results provide information about genes associated with breast and ovarian cancer risk in Asian women, as well as guidance for management of PV carriers."
+    },
+    {
+      "section": "FUNDING",
+      "text": "The study was funded by AMED (JP15ck010609, 19cm0106605h0003, 23ama221520h0001, and JP19kk0305010), by a Health Labour Sciences Research Grant (202108001B), by JSPS KAKENHI (JP18K16292, 20H03668, 23H02955, 17H06162, 20H03695, and 16H06277), and by a Grant-in-Aid for the Genome Research Project from Yamanashi Prefecture."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_41138737.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_41138737.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "41138737",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/41138737/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Effect of elexacaftor-tezacaftor-ivacaftor on bronchial dilatations in adolescents with cystic fibrosis: a multicentre prospective observational study.",
+  "doi": "10.1016/S2213-2600(25)00248-6",
+  "publication_types": [
+    "Journal Article",
+    "Multicenter Study",
+    "Observational Study"
+  ],
+  "abstract_sections": [
+    {
+      "section": "BACKGROUND",
+      "text": "Elexacaftor-tezacaftor-ivacaftor (ETI) is a cystic fibrosis transmembrane conductance regulator (CFTR) modulator that improves clinical outcomes in adolescents with cystic fibrosis. We aimed to investigate the effect of ETI on lung structural damage."
+    },
+    {
+      "section": "METHODS",
+      "text": "The Modul-CF prospective observational study is based at 33 paediatric cystic fibrosis reference centres in France. In the present analysis, we assessed the adolescent cohort of individuals with cystic fibrosis (aged 12-18 years) from the Modul-CF study who initiated treatment with ETI as part of routine care. These individuals were either homozygous for F508del and previously treated with lumacaftor-ivacaftor (LI), or F508del homozygous or compound heterozygous for F508del with a minimal function or residual function variant and naive to CFTR modulator treatment. The primary outcome measure was chest CT to investigate the effect of CFTR restoration on the natural history of cystic fibrosis lung disease. Secondary outcomes were sweat chloride, weight and height Z scores, quality of life, pulmonary function tests, lung clearance index at 2\u00b75% of starting concentration (LCI2\u00b75) from nitrogen multiple breath washout, and proinflammatory biomarkers in sputum (calprotectin, neutrophil elastase, IL-1\u03b2, IL-6, IL-8, and TNF-\u03b1) and blood (C-reactive protein and polymorphonuclear neutrophils). Outcome data were collected from baseline (in the 4 weeks before commencement of ETI [denoted month 0]) up to 1 year of ETI treatment (denoted month 12), with low-dose inspiratory-controlled chest CT done at month 0 and month 12. Changes in outcome measures from month 0 to month 12 were assessed with non-parametric Wilcoxon tests. Modul-CF was registered with ClinicalTrials.gov, NCT04301856, and is ongoing and open to recruitment. The data cutoff for the present analysis was July 28, 2023."
+    },
+    {
+      "section": "FINDINGS",
+      "text": "Between March 22, 2021, and May 25, 2022, a total of 330 adolescents with cystic fibrosis were enrolled in the study, of whom 320 were treated with ETI for 12 months and included in analyses (mean age at ETI initiation 14\u00b71 years [SD 1\u00b75]; 162 [51%] female and 158 [49%] male participants). Of the 320 participants, 112 (35%) were switched from LI to ETI, and 208 (65%) were CFTR modulator-naive. In the overall population, improvement in percent predicted FEV1 (ppFEV1) was observed from the first month of ETI treatment and was sustained at 12 months (mean absolute ppFEV1 change from month 0 to month 12, 14\u00b70% [95% CI 12\u00b74-15\u00b77], p<0\u00b70001, n=306). From month 0 to month 12, there were significant reductions in lung hyperinflation on plethysmography, and in mucus plugs, bronchial wall thickening, and bronchial dilatation on chest CT. Significant improvements were also observed in sweat chloride, weight Z score, LCI2.5, quality of life, and sputum and blood proinflammatory biomarkers. In 188 participants with available imaging analysis at both month 0 and month 12, the mean percentage of severely dilated bronchi (based on a bronchial outer diameter to adjacent artery diameter ratio [Bout/A] of \u22651\u00b75) in bronchial generations G1-6 decreased by 10\u00b77%, from 40\u00b73% (SD 18\u00b79) at month 0 to 29\u00b76% (16\u00b78) at month 12 (p<0\u00b70001). Based on median Bout/A values of bronchus-artery pairs in the G1-6 region, 32 (17%) of 188 participants improved from severe to moderate dilatation (Bout/A \u22651\u00b71 and <1\u00b75) and 19 (10%) from moderate to normal dilatation (Bout/A <1\u00b71) between month 0 and month 12. 14 (7%) participants progressed to a worse dilatation category. The changes in lung imaging metrics were correlated with the changes in sputum proinflammatory biomarkers."
+    },
+    {
+      "section": "INTERPRETATION",
+      "text": "Bronchial dilatations can reverse in adolescents with cystic fibrosis treated with ETI. The correlation with reduced airway inflammation provides insight into the effect of ETI on cystic fibrosis lung disease."
+    },
+    {
+      "section": "FUNDING",
+      "text": "Vaincre La Mucoviscidose, Mucoviscidose ABCF2, and the Cystic Fibrosis Foundation."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_41512290.json
+++ b/scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_41512290.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_source.v1",
+  "source_key": "pubmed",
+  "source_record_id": "41512290",
+  "source_url": "https://pubmed.ncbi.nlm.nih.gov/41512290/",
+  "retrieval_method": "ncbi_pubmed_efetch",
+  "retrieved_at": "2026-07-14T22:02:01Z",
+  "title": "Targeting common EGFR mutations in non-small cell lung cancer: a review of global phase 3 trials of third-generation inhibitors.",
+  "doi": "10.1093/jnci/djag008",
+  "publication_types": [
+    "Journal Article",
+    "Review"
+  ],
+  "abstract_sections": [
+    {
+      "section": "ABSTRACT",
+      "text": "Mutations of the gene EGFR are frequent oncogenic drivers in non-small cell lung cancer (NSCLC). Third-generation EGFR tyrosine kinase inhibitors, which target common EGFR mutations and the acquired T790M resistance mutation, offer improved inhibitory potency and selectivity. Our review critically assessed the evolving role of these agents for management of NSCLC harboring common EGFR mutations. Multiple global phase 3 trials have evaluated third-generation EGFR tyrosine kinase inhibitors in patients with NSCLC and common EGFR mutations. The addition of osimertinib to curative-intent strategies have demonstrated improvements in disease-free survival and overall survival as adjuvant therapy in patients with resected stage IB-IIIA tumors, major pathological responses compared with chemotherapy when used as neoadjuvant therapy, and progression-free survival compared with placebo when used as consolidation therapy in patients with unresectable stage III disease. Furthermore, third-generation EGFR tyrosine kinase inhibitor monotherapy improved progression-free survival compared with first-generation EGFR tyrosine kinase inhibitors in the first-line treatment of advanced disease. Intensification strategies, such as the addition of chemotherapy or a bispecific antibody, have further enhanced progression-free survival and overall survival outcomes. Several new therapeutic options are emerging for patients previously treated with third-generation EGFR tyrosine kinase inhibitors. Currently, subsequent treatment recommendations include chemotherapy or datopotamab deruxtecan following progression on a third-generation EGFR tyrosine kinase inhibitor combination and amivantamab plus platinum-based chemotherapy following progression on monotherapy. The treatment landscape for NSCLC with common EGFR mutations is rapidly evolving, and third-generation EGFR tyrosine kinase inhibitors play an integral role in both the curative-intent and palliative settings."
+    }
+  ]
+}

--- a/scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_protocol_v1.json
+++ b/scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_protocol_v1.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_protocol.v1",
+  "study_id": "semantic-relevance-expert-pilot-v1",
+  "study_tier": "diagnostic_pilot",
+  "benchmark_fixture": {
+    "path": "scripts/validation/evidence_selection/fixtures/semantic_relevance_benchmark_v2.json",
+    "sha256": "e6a17d2c94a4045da785942ac541d9fc1e45516b8b1f931de38a3f5ca88e9640"
+  },
+  "supplement_manifest": {
+    "path": "scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_supplement_manifest_v1.json",
+    "sha256": "b30b16acec09ef70ad7b5f78ace5033fbb0e2db031e60714956f58b2e3578ee0"
+  },
+  "expected_case_ids": [
+    "egfr_t790m_primary_evidence",
+    "brca1_risk_penetrance",
+    "cftr_f508del_eti_response",
+    "egfr_exclusion_token_canary"
+  ],
+  "expected_record_count": 33,
+  "diagnostic_pilot_question_count": 3,
+  "production_calibration_minimum_question_count": 20,
+  "production_calibration_minimum_record_count": 200,
+  "production_calibration_training_question_count": 12,
+  "production_calibration_held_out_question_count": 8,
+  "independent_reviewer_slots": [
+    "qualified-reviewer-slot-a",
+    "qualified-reviewer-slot-b"
+  ],
+  "adjudicator_slot": "qualified-adjudicator-slot-c",
+  "reviewer_qualification_requirement": "domain_qualified_human_bound_by_external_attestation",
+  "reviewer_identity_authentication": "external_signed_attestation_required",
+  "minimum_independent_reviewers_per_record": 2,
+  "disagreement_policy": "third_reviewer_adjudication",
+  "reviewer_labels": [
+    "select",
+    "reject",
+    "abstain"
+  ],
+  "packet_sufficiency_labels": [
+    "sufficient",
+    "insufficient"
+  ],
+  "reviewer_numeric_judgments_allowed": false,
+  "production_readiness_claim": false,
+  "production_calibration_claim": false,
+  "calibration_status": "unavailable_insufficient_independent_corpus",
+  "blinding": {
+    "hide_model_identity": true,
+    "hide_model_decisions": true,
+    "hide_ai_diagnostics": true,
+    "hide_ranking_values": true,
+    "candidate_order": "reviewer_specific_deterministic_shuffle"
+  },
+  "acceptance_thresholds": {
+    "metric_origin": "deterministic_from_categorical_human_findings",
+    "minimum_adjudicated_precision": 0.8,
+    "minimum_adjudicated_recall": 0.8,
+    "minimum_first_pass_percent_agreement": 0.8,
+    "maximum_high_severity_overclaim_count": 0
+  }
+}

--- a/scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_supplement_manifest_v1.json
+++ b/scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_supplement_manifest_v1.json
@@ -1,0 +1,179 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_supplements.v1",
+  "supplements": [
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_17018160.json",
+      "sha256": "0e64c0ae03f045e488c3382be92971a247ce3d957808ccc212a972bd089b7949",
+      "source_key": "pubmed",
+      "source_record_id": "17018160"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_21356067.json",
+      "sha256": "eb13b835d36ec7df6655443da3735740f00372b6f2e8ea49cc25ee1214600bb7",
+      "source_key": "pubmed",
+      "source_record_id": "21356067"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_22889855.json",
+      "sha256": "73fb1595af3364f396f28be3c9a6052f9c76e67cf30402a91204c7d96ec26a80",
+      "source_key": "pubmed",
+      "source_record_id": "22889855"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_23985030.json",
+      "sha256": "06ce94eb22003b2020c2a7d639a83f9fdf38b9a7bc75fc6a07c35ada2789e036",
+      "source_key": "pubmed",
+      "source_record_id": "23985030"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_25923549.json",
+      "sha256": "0659bfaac1ddb602fee29024d899b4405afc394f84a174fb61a5c8b74cfe4a05",
+      "source_key": "pubmed",
+      "source_record_id": "25923549"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_26195121.json",
+      "sha256": "65bb686bb11ab5e64f9a64760a88b4d61e66c63db2887903561f1dbfdb3a4869",
+      "source_key": "pubmed",
+      "source_record_id": "26195121"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_26314834.json",
+      "sha256": "821d5c860e2342f210e4b480c2b66ca381e77427c3be57f1e38b3b791b0f1da0",
+      "source_key": "pubmed",
+      "source_record_id": "26314834"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_26344711.json",
+      "sha256": "888f90d5481943d1871dc1c4eacaf7ced8aaa345bd977d1e718cfb35ef3d2b7c",
+      "source_key": "pubmed",
+      "source_record_id": "26344711"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_27393503.json",
+      "sha256": "1f3dff7afb499317cbb6fbd715ad28e3b18ad09e8a434da8b55fef2a0205faa8",
+      "source_key": "pubmed",
+      "source_record_id": "27393503"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_27913932.json",
+      "sha256": "f66f6107b0af95ae067d405334b57738b870e004e15bb46ee610ccb100ebd46c",
+      "source_key": "pubmed",
+      "source_record_id": "27913932"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_27959700.json",
+      "sha256": "21852796188cea7216a47d97da305e4a956fa63d6d17ce1c716e1feabd12b3dc",
+      "source_key": "pubmed",
+      "source_record_id": "27959700"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_30191368.json",
+      "sha256": "f5748033ff3f7d5484d4b0e5c51f415548585118b50b6b50b4c9d6463c4a010f",
+      "source_key": "pubmed",
+      "source_record_id": "30191368"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_30610487.json",
+      "sha256": "2bc9952bd2bbbcdff8d870f56cfc3f2c3ddf1b4676ee19cb93a2867cb8ff9012",
+      "source_key": "pubmed",
+      "source_record_id": "30610487"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_30657347.json",
+      "sha256": "db378ed5afaa76f62a3cac27b368b86ce3aca35712c7480306fe3b319b9084bf",
+      "source_key": "pubmed",
+      "source_record_id": "30657347"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_31039766.json",
+      "sha256": "d9cbbc0954c75ecc1722e024ab3f4de4928355c3fc67f116f15d22bf88d4cea0",
+      "source_key": "pubmed",
+      "source_record_id": "31039766"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_31206626.json",
+      "sha256": "8b6fb26a09918f1d34634227f35d6fbc877783c83e9952bd60210fe891aea219",
+      "source_key": "pubmed",
+      "source_record_id": "31206626"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_32658311.json",
+      "sha256": "344e8902f323eaeede4ddd0ef71f65b6d42a6428eb3f8c17ca79f294045378e3",
+      "source_key": "pubmed",
+      "source_record_id": "32658311"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_34237702.json",
+      "sha256": "5c58b4e25fe3e45d2da8b5af1fb42d5225cbcd813e9e9924ee5154d3c4ee2007",
+      "source_key": "pubmed",
+      "source_record_id": "34237702"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_34642874.json",
+      "sha256": "29e78b336252fe8cc7987b993cd80a4b2ecffa1120694871293b7103cf62d323",
+      "source_key": "pubmed",
+      "source_record_id": "34642874"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_35681464.json",
+      "sha256": "63547f0f37dfebe8d2ad7411a0410d025557145192ab38ff4ae03df7626f6ce0",
+      "source_key": "pubmed",
+      "source_record_id": "35681464"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_35816621.json",
+      "sha256": "0898b2118f23ee3b69019aa69793c0b18ec6c3358bf342e84e2ac9fccf9f56af",
+      "source_key": "pubmed",
+      "source_record_id": "35816621"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_38198345.json",
+      "sha256": "ea8f52029e4cd956970768b79db1878f961eb1d5672cbab2bab746f8defd0ad1",
+      "source_key": "pubmed",
+      "source_record_id": "38198345"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_39227072.json",
+      "sha256": "1881c9f34daf4c5ba22a70f56d2fbb87de7f77c6d9508600dc00a7463196dbdf",
+      "source_key": "pubmed",
+      "source_record_id": "39227072"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40209082.json",
+      "sha256": "868eb40174ead143ec4a278805736bf84b0af80669f7fcbe750f7f322a55dc0d",
+      "source_key": "pubmed",
+      "source_record_id": "40209082"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40210412.json",
+      "sha256": "f75bf520c7c20b2091e915e81bcd7dae59c99f3c88318a7bc3a4ac667f430e16",
+      "source_key": "pubmed",
+      "source_record_id": "40210412"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40288678.json",
+      "sha256": "1f5330d27fcab5f4a53d1826367f1688e5d5ff98002c91771fa086f195a46ca8",
+      "source_key": "pubmed",
+      "source_record_id": "40288678"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_40403695.json",
+      "sha256": "6633e913e048da7f657b49f61023bba419ee4bda1d1bf58c4b58d9fc21c4c300",
+      "source_key": "pubmed",
+      "source_record_id": "40403695"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_41138737.json",
+      "sha256": "23023c406640e2e2e587c855b1e8914f4952496eff102315a0ea29f6d9895185",
+      "source_key": "pubmed",
+      "source_record_id": "41138737"
+    },
+    {
+      "path": "scripts/validation/evidence_selection/fixtures/expert_pilot_sources/pubmed_41512290.json",
+      "sha256": "46cbaff63c7cb0dc52645ad8f34b2b82bdd8612a598bab2dbeb41233d39513f7",
+      "source_key": "pubmed",
+      "source_record_id": "41512290"
+    }
+  ]
+}

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/__init__.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/__init__.py
@@ -6,6 +6,12 @@ from .contracts import (
 )
 from .evaluation import evaluate_benchmark_v2
 from .loader import load_benchmark_v2
+from .pilot_loader import load_expert_pilot
+from .pilot_packets import (
+    build_expert_pilot_packet_bundles,
+    verify_expert_pilot_packet_bundle,
+)
+from .pilot_publication import publish_expert_pilot_packets
 from .reporting import build_benchmark_v2_report, render_benchmark_v2_markdown
 from .scoring import score_benchmark_v2
 
@@ -15,6 +21,10 @@ __all__ = [
     "build_benchmark_v2_report",
     "evaluate_benchmark_v2",
     "load_benchmark_v2",
+    "load_expert_pilot",
     "render_benchmark_v2_markdown",
     "score_benchmark_v2",
+    "build_expert_pilot_packet_bundles",
+    "verify_expert_pilot_packet_bundle",
+    "publish_expert_pilot_packets",
 ]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/pilot_contracts.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/pilot_contracts.py
@@ -1,0 +1,417 @@
+"""Strict contracts for blinded benchmark-v2 expert pilot packets."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from .contracts import EvidenceSelectionBenchmarkArtifactRef
+
+ExpertPilotSelectionLabel = Literal["select", "reject", "abstain"]
+ExpertPilotPacketSufficiency = Literal["sufficient", "insufficient"]
+
+
+def _literal_nonblank(value: str) -> str:
+    if not value.strip() or value != value.strip():
+        raise ValueError("expert-pilot text must be literal, nonblank, and trimmed")
+    return value
+
+
+class EvidenceSelectionExpertPilotSourceRef(EvidenceSelectionBenchmarkArtifactRef):
+    """One immutable source supplement associated with a benchmark record."""
+
+    source_key: Literal["pubmed"]
+    source_record_id: str = Field(pattern=r"^[0-9]+$")
+
+    @field_validator("source_record_id")
+    @classmethod
+    def _validate_identity(cls, value: str) -> str:
+        return _literal_nonblank(value)
+
+
+class EvidenceSelectionExpertPilotSupplementManifest(BaseModel):
+    """Content-addressed supplemental source inventory for the pilot."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_supplements.v1"]
+    supplements: tuple[EvidenceSelectionExpertPilotSourceRef, ...] = Field(
+        min_length=1,
+    )
+
+    @field_validator("supplements", mode="before")
+    @classmethod
+    def _accept_json_array(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _supplements_are_unique(
+        self,
+    ) -> EvidenceSelectionExpertPilotSupplementManifest:
+        source_ids = [item.source_record_id for item in self.supplements]
+        paths = [item.path for item in self.supplements]
+        if len(set(source_ids)) != len(source_ids):
+            raise ValueError("expert-pilot supplemental source IDs must be unique")
+        if len(set(paths)) != len(paths):
+            raise ValueError("expert-pilot supplemental paths must be unique")
+        return self
+
+
+class EvidenceSelectionExpertPilotAbstractSection(BaseModel):
+    """One literal section from the frozen PubMed abstract."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    section: str = Field(min_length=1)
+    text: str = Field(min_length=1)
+
+    @field_validator("section", "text")
+    @classmethod
+    def _validate_text(cls, value: str) -> str:
+        return _literal_nonblank(value)
+
+
+class EvidenceSelectionExpertPilotSourceSupplement(BaseModel):
+    """Frozen primary-source metadata without an interpretation or label."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_source.v1"]
+    source_key: Literal["pubmed"]
+    source_record_id: str = Field(pattern=r"^[0-9]+$")
+    source_url: str = Field(pattern=r"^https://pubmed\.ncbi\.nlm\.nih\.gov/[0-9]+/$")
+    retrieval_method: Literal["ncbi_pubmed_efetch"]
+    retrieved_at: datetime
+    title: str = Field(min_length=1)
+    doi: str = Field(min_length=1)
+    publication_types: tuple[str, ...] = Field(min_length=1)
+    abstract_sections: tuple[EvidenceSelectionExpertPilotAbstractSection, ...] = (
+        Field(min_length=1)
+    )
+
+    @field_validator("publication_types", "abstract_sections", mode="before")
+    @classmethod
+    def _accept_json_arrays(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("title", "doi")
+    @classmethod
+    def _validate_text(cls, value: str) -> str:
+        return _literal_nonblank(value)
+
+    @field_validator("publication_types")
+    @classmethod
+    def _validate_publication_types(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(_literal_nonblank(item) for item in value)
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("publication types must be unique")
+        return normalized
+
+    @field_validator("retrieved_at")
+    @classmethod
+    def _retrieval_time_is_aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("source retrieval time must include a timezone")
+        return value
+
+    @model_validator(mode="after")
+    def _source_url_matches_identity(
+        self,
+    ) -> EvidenceSelectionExpertPilotSourceSupplement:
+        expected_url = (
+            f"https://pubmed.ncbi.nlm.nih.gov/{self.source_record_id}/"
+        )
+        if self.source_url != expected_url:
+            raise ValueError("expert-pilot PubMed URL must match source_record_id")
+        return self
+
+
+class EvidenceSelectionExpertPilotBlindingPolicy(BaseModel):
+    """Frozen protections against model and ranking leakage to reviewers."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    hide_model_identity: Literal[True] = True
+    hide_model_decisions: Literal[True] = True
+    hide_ai_diagnostics: Literal[True] = True
+    hide_ranking_values: Literal[True] = True
+    candidate_order: Literal["reviewer_specific_deterministic_shuffle"]
+
+
+class EvidenceSelectionExpertPilotAcceptanceThresholds(BaseModel):
+    """Code-owned thresholds computed only from categorical human findings."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    metric_origin: Literal["deterministic_from_categorical_human_findings"]
+    minimum_adjudicated_precision: float = Field(ge=0.0, le=1.0)
+    minimum_adjudicated_recall: float = Field(ge=0.0, le=1.0)
+    minimum_first_pass_percent_agreement: float = Field(ge=0.0, le=1.0)
+    maximum_high_severity_overclaim_count: Literal[0]
+
+    @model_validator(mode="after")
+    def _thresholds_are_frozen(
+        self,
+    ) -> EvidenceSelectionExpertPilotAcceptanceThresholds:
+        thresholds = (
+            self.minimum_adjudicated_precision,
+            self.minimum_adjudicated_recall,
+            self.minimum_first_pass_percent_agreement,
+        )
+        if thresholds != (0.8, 0.8, 0.8):
+            raise ValueError("expert-pilot acceptance thresholds are frozen")
+        return self
+
+
+class EvidenceSelectionExpertPilotProtocol(BaseModel):
+    """Predeclared diagnostic pilot protocol; never a readiness claim."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_protocol.v1"]
+    study_id: str = Field(min_length=1)
+    study_tier: Literal["diagnostic_pilot"]
+    benchmark_fixture: EvidenceSelectionBenchmarkArtifactRef
+    supplement_manifest: EvidenceSelectionBenchmarkArtifactRef
+    expected_case_ids: tuple[str, ...] = Field(min_length=1)
+    expected_record_count: int = Field(ge=1)
+    diagnostic_pilot_question_count: Literal[3]
+    production_calibration_minimum_question_count: Literal[20]
+    production_calibration_minimum_record_count: Literal[200]
+    production_calibration_training_question_count: Literal[12]
+    production_calibration_held_out_question_count: Literal[8]
+    independent_reviewer_slots: tuple[str, ...] = Field(min_length=2)
+    adjudicator_slot: str = Field(min_length=1)
+    reviewer_qualification_requirement: Literal[
+        "domain_qualified_human_bound_by_external_attestation"
+    ]
+    reviewer_identity_authentication: Literal["external_signed_attestation_required"]
+    minimum_independent_reviewers_per_record: Literal[2] = 2
+    disagreement_policy: Literal["third_reviewer_adjudication"]
+    reviewer_labels: tuple[ExpertPilotSelectionLabel, ...]
+    packet_sufficiency_labels: tuple[ExpertPilotPacketSufficiency, ...]
+    reviewer_numeric_judgments_allowed: Literal[False] = False
+    production_readiness_claim: Literal[False] = False
+    production_calibration_claim: Literal[False] = False
+    calibration_status: Literal["unavailable_insufficient_independent_corpus"]
+    blinding: EvidenceSelectionExpertPilotBlindingPolicy
+    acceptance_thresholds: EvidenceSelectionExpertPilotAcceptanceThresholds
+
+    @field_validator(
+        "expected_case_ids",
+        "independent_reviewer_slots",
+        "reviewer_labels",
+        "packet_sufficiency_labels",
+        mode="before",
+    )
+    @classmethod
+    def _accept_json_arrays(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("study_id", "adjudicator_slot")
+    @classmethod
+    def _validate_text(cls, value: str) -> str:
+        return _literal_nonblank(value)
+
+    @field_validator("expected_case_ids", "independent_reviewer_slots")
+    @classmethod
+    def _validate_unique_text(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(_literal_nonblank(item) for item in value)
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("expert-pilot identities must be unique")
+        return normalized
+
+    @model_validator(mode="after")
+    def _review_contract_is_frozen(self) -> EvidenceSelectionExpertPilotProtocol:
+        if set(self.reviewer_labels) != {"select", "reject", "abstain"}:
+            raise ValueError("expert-pilot reviewer labels must be the frozen categories")
+        if set(self.packet_sufficiency_labels) != {"sufficient", "insufficient"}:
+            raise ValueError("expert-pilot packet sufficiency labels are incomplete")
+        if self.adjudicator_slot in self.independent_reviewer_slots:
+            raise ValueError("expert-pilot adjudicator must be independent")
+        return self
+
+
+class EvidenceSelectionExpertPilotCandidate(BaseModel):
+    """One blinded source candidate awaiting categorical human findings."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    candidate_id: str = Field(pattern=r"^candidate-[a-f0-9]{16}$")
+    source_key: Literal["pubmed"]
+    source_record_id: str = Field(pattern=r"^[0-9]+$")
+    source_url: str = Field(pattern=r"^https://pubmed\.ncbi\.nlm\.nih\.gov/[0-9]+/$")
+    title: str = Field(min_length=1)
+    bounded_source_text: tuple[EvidenceSelectionExpertPilotAbstractSection, ...] = (
+        Field(min_length=1)
+    )
+    selection_label: None = None
+    packet_sufficiency: None = None
+    supporting_spans: tuple[str, ...] = ()
+    reviewer_explanation: None = None
+
+    @field_validator("bounded_source_text", mode="before")
+    @classmethod
+    def _accept_json_source_text(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("supporting_spans", mode="before")
+    @classmethod
+    def _require_blank_supporting_spans(cls, value: object) -> tuple[()]:
+        if value not in ([], ()):
+            raise ValueError("uncompleted expert-pilot supporting spans must be empty")
+        return ()
+
+
+class EvidenceSelectionExpertPilotReviewerPacket(BaseModel):
+    """Blinded editable packet distributed to one independent reviewer slot."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_reviewer_packet.v1"]
+    study_id: str
+    packet_id: str = Field(pattern=r"^packet-[a-f0-9]{16}$")
+    reviewer_slot: str
+    review_role: Literal["independent_first_pass"]
+    review_case_id: str = Field(pattern=r"^case-[a-f0-9]{16}$")
+    goal: str
+    instructions: str
+    inclusion_criteria: tuple[str, ...]
+    exclusion_criteria: tuple[str, ...]
+    completion_status: Literal["requires_human_labels"]
+    reviewer_identity_attestation_required: Literal[True] = True
+    production_readiness_claim: Literal[False] = False
+    candidates: tuple[EvidenceSelectionExpertPilotCandidate, ...] = Field(min_length=1)
+
+    @field_validator(
+        "inclusion_criteria",
+        "exclusion_criteria",
+        "candidates",
+        mode="before",
+    )
+    @classmethod
+    def _accept_json_arrays(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+
+class EvidenceSelectionExpertPilotCandidateBinding(BaseModel):
+    """Machine-only mapping from a blinded candidate to benchmark identity."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    candidate_id: str = Field(pattern=r"^candidate-[a-f0-9]{16}$")
+    record_id: str = Field(min_length=1)
+    historical_packet_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    supplement_sha256: str | None = Field(default=None, pattern=r"^[a-f0-9]{64}$")
+
+
+class EvidenceSelectionExpertPilotMachineSidecar(BaseModel):
+    """Signed machine-only identity binding kept away from first-pass reviewers."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_sidecar.v1"]
+    study_id: str
+    packet_id: str = Field(pattern=r"^packet-[a-f0-9]{16}$")
+    reviewer_slot: str
+    review_case_id: str = Field(pattern=r"^case-[a-f0-9]{16}$")
+    case_id: str
+    protocol_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    benchmark_fixture_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    supplement_manifest_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    reviewer_packet_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    candidate_bindings: tuple[EvidenceSelectionExpertPilotCandidateBinding, ...] = (
+        Field(min_length=1)
+    )
+    producer_signature: str = Field(pattern=r"^[a-f0-9]{64}$")
+
+    @field_validator("candidate_bindings", mode="before")
+    @classmethod
+    def _accept_json_bindings(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _bindings_are_unique(self) -> EvidenceSelectionExpertPilotMachineSidecar:
+        candidate_ids = [item.candidate_id for item in self.candidate_bindings]
+        record_ids = [item.record_id for item in self.candidate_bindings]
+        if len(set(candidate_ids)) != len(candidate_ids):
+            raise ValueError("expert-pilot sidecar candidate IDs must be unique")
+        if len(set(record_ids)) != len(record_ids):
+            raise ValueError("expert-pilot sidecar record IDs must be unique")
+        return self
+
+
+class EvidenceSelectionExpertPilotPublishedArtifact(BaseModel):
+    """Digest-bound identity for one published pilot artifact."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    artifact_kind: Literal["reviewer_packet", "machine_sidecar"]
+    path: str = Field(min_length=1)
+    sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+
+    @field_validator("path")
+    @classmethod
+    def _path_is_relative_and_literal(cls, value: str) -> str:
+        normalized = _literal_nonblank(value)
+        if normalized.startswith("/") or ".." in normalized.split("/"):
+            raise ValueError("published expert-pilot path must stay relative")
+        return normalized
+
+
+class EvidenceSelectionExpertPilotPublicationManifest(BaseModel):
+    """Deterministic inventory of one atomic packet publication."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_publication.v1"]
+    study_id: str
+    protocol_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    benchmark_fixture_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    supplement_manifest_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    independent_reviewer_count: int = Field(ge=2)
+    reviewer_packet_count: int = Field(ge=1)
+    candidate_review_count: int = Field(ge=1)
+    production_readiness_claim: Literal[False] = False
+    production_calibration_claim: Literal[False] = False
+    artifacts: tuple[EvidenceSelectionExpertPilotPublishedArtifact, ...] = Field(
+        min_length=1
+    )
+
+    @field_validator("artifacts", mode="before")
+    @classmethod
+    def _accept_json_artifacts(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _artifact_inventory_is_complete(
+        self,
+    ) -> EvidenceSelectionExpertPilotPublicationManifest:
+        paths = [artifact.path for artifact in self.artifacts]
+        if len(set(paths)) != len(paths):
+            raise ValueError("published expert-pilot artifact paths must be unique")
+        packet_count = sum(
+            artifact.artifact_kind == "reviewer_packet"
+            for artifact in self.artifacts
+        )
+        sidecar_count = sum(
+            artifact.artifact_kind == "machine_sidecar"
+            for artifact in self.artifacts
+        )
+        if packet_count != self.reviewer_packet_count or sidecar_count != packet_count:
+            raise ValueError("every reviewer packet requires exactly one machine sidecar")
+        return self
+
+
+__all__ = [
+    "EvidenceSelectionExpertPilotCandidate",
+    "EvidenceSelectionExpertPilotCandidateBinding",
+    "EvidenceSelectionExpertPilotMachineSidecar",
+    "EvidenceSelectionExpertPilotPublicationManifest",
+    "EvidenceSelectionExpertPilotProtocol",
+    "EvidenceSelectionExpertPilotReviewerPacket",
+    "EvidenceSelectionExpertPilotSourceSupplement",
+    "EvidenceSelectionExpertPilotSupplementManifest",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/pilot_loader.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/pilot_loader.py
@@ -1,0 +1,165 @@
+"""Load and bind a frozen benchmark-v2 expert pilot protocol."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from .contracts import EvidenceSelectionBenchmarkArtifactRef
+from .loader import (
+    LoadedEvidenceSelectionBenchmarkV2,
+    load_benchmark_v2,
+    read_verified_artifact,
+)
+from .pilot_contracts import (
+    EvidenceSelectionExpertPilotProtocol,
+    EvidenceSelectionExpertPilotSourceSupplement,
+    EvidenceSelectionExpertPilotSupplementManifest,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedEvidenceSelectionExpertPilot:
+    """Fully verified pilot protocol, benchmark, and source supplements."""
+
+    protocol_path: Path
+    protocol_sha256: str
+    protocol: EvidenceSelectionExpertPilotProtocol
+    benchmark: LoadedEvidenceSelectionBenchmarkV2
+    supplement_manifest_sha256: str
+    supplement_manifest: EvidenceSelectionExpertPilotSupplementManifest
+    supplements_by_record: dict[str, EvidenceSelectionExpertPilotSourceSupplement]
+    supplement_sha256_by_record: dict[str, str]
+
+
+def load_expert_pilot(
+    *,
+    protocol_path: Path,
+    repository_root: Path,
+) -> LoadedEvidenceSelectionExpertPilot:
+    """Verify a diagnostic pilot without converting it into expert evidence."""
+
+    resolved_root = repository_root.resolve()
+    protocol_bytes = protocol_path.read_bytes()
+    protocol = EvidenceSelectionExpertPilotProtocol.model_validate_json(
+        protocol_bytes,
+    )
+    benchmark_path, _ = read_verified_artifact(
+        reference=protocol.benchmark_fixture,
+        repository_root=resolved_root,
+    )
+    benchmark = load_benchmark_v2(
+        fixture_path=benchmark_path,
+        repository_root=resolved_root,
+    )
+    manifest_path, manifest_bytes = read_verified_artifact(
+        reference=protocol.supplement_manifest,
+        repository_root=resolved_root,
+    )
+    del manifest_path
+    manifest = EvidenceSelectionExpertPilotSupplementManifest.model_validate_json(
+        manifest_bytes,
+    )
+    supplements_by_source, supplement_hashes_by_source = _load_supplements(
+        manifest=manifest,
+        repository_root=resolved_root,
+    )
+    _verify_protocol_inventory(protocol=protocol, benchmark=benchmark)
+    supplements, supplement_hashes = _bind_complete_source_inventory(
+        benchmark=benchmark,
+        supplements_by_source=supplements_by_source,
+        supplement_hashes_by_source=supplement_hashes_by_source,
+    )
+    return LoadedEvidenceSelectionExpertPilot(
+        protocol_path=protocol_path,
+        protocol_sha256=hashlib.sha256(protocol_bytes).hexdigest(),
+        protocol=protocol,
+        benchmark=benchmark,
+        supplement_manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+        supplement_manifest=manifest,
+        supplements_by_record=supplements,
+        supplement_sha256_by_record=supplement_hashes,
+    )
+
+
+def _load_supplements(
+    *,
+    manifest: EvidenceSelectionExpertPilotSupplementManifest,
+    repository_root: Path,
+) -> tuple[
+    dict[str, EvidenceSelectionExpertPilotSourceSupplement],
+    dict[str, str],
+]:
+    supplements: dict[str, EvidenceSelectionExpertPilotSourceSupplement] = {}
+    hashes: dict[str, str] = {}
+    for reference in manifest.supplements:
+        _, content = read_verified_artifact(
+            reference=EvidenceSelectionBenchmarkArtifactRef(
+                path=reference.path,
+                sha256=reference.sha256,
+            ),
+            repository_root=repository_root,
+        )
+        supplement = EvidenceSelectionExpertPilotSourceSupplement.model_validate_json(
+            content,
+        )
+        expected_identity = (reference.source_key, reference.source_record_id)
+        actual_identity = (
+            supplement.source_key,
+            supplement.source_record_id,
+        )
+        if actual_identity != expected_identity:
+            raise ValueError(
+                "expert-pilot supplement source identity mismatch: "
+                f"{reference.source_record_id}"
+            )
+        supplements[reference.source_record_id] = supplement
+        hashes[reference.source_record_id] = reference.sha256
+    return supplements, hashes
+
+
+def _verify_protocol_inventory(
+    *,
+    protocol: EvidenceSelectionExpertPilotProtocol,
+    benchmark: LoadedEvidenceSelectionBenchmarkV2,
+) -> None:
+    case_ids = tuple(case.case_id for case in benchmark.historical_v1.cases)
+    record_count = sum(len(case.records) for case in benchmark.historical_v1.cases)
+    if protocol.expected_case_ids != case_ids:
+        raise ValueError("expert-pilot protocol case inventory does not match benchmark")
+    if protocol.expected_record_count != record_count:
+        raise ValueError("expert-pilot protocol record count does not match benchmark")
+
+
+def _bind_complete_source_inventory(
+    *,
+    benchmark: LoadedEvidenceSelectionBenchmarkV2,
+    supplements_by_source: dict[str, EvidenceSelectionExpertPilotSourceSupplement],
+    supplement_hashes_by_source: dict[str, str],
+) -> tuple[
+    dict[str, EvidenceSelectionExpertPilotSourceSupplement],
+    dict[str, str],
+]:
+    records = tuple(
+        record
+        for case in benchmark.historical_v1.cases
+        for record in case.records
+    )
+    expected_source_ids = {record.source_record_id for record in records}
+    if set(supplements_by_source) != expected_source_ids:
+        raise ValueError(
+            "expert-pilot supplements must exactly cover every benchmark source"
+        )
+    supplements_by_record = {
+        record.record_id: supplements_by_source[record.source_record_id]
+        for record in records
+    }
+    hashes_by_record = {
+        record.record_id: supplement_hashes_by_source[record.source_record_id]
+        for record in records
+    }
+    return supplements_by_record, hashes_by_record
+
+
+__all__ = ["LoadedEvidenceSelectionExpertPilot", "load_expert_pilot"]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/pilot_packets.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/pilot_packets.py
@@ -1,0 +1,319 @@
+"""Build blinded reviewer packets and signed machine-only identity sidecars."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+from artana_evidence_api.evidence_selection.diagnostics.fixture import (
+    EvidenceSelectionSemanticDiagnosticCase,
+    EvidenceSelectionSemanticDiagnosticRecord,
+)
+from artana_evidence_api.evidence_selection.shadow_review_integrity import (
+    sign_machine_packet_digest,
+    verify_machine_packet_signature,
+)
+
+from .pilot_contracts import (
+    EvidenceSelectionExpertPilotAbstractSection,
+    EvidenceSelectionExpertPilotCandidate,
+    EvidenceSelectionExpertPilotCandidateBinding,
+    EvidenceSelectionExpertPilotMachineSidecar,
+    EvidenceSelectionExpertPilotReviewerPacket,
+)
+from .pilot_loader import LoadedEvidenceSelectionExpertPilot
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSelectionExpertPilotPacketBundle:
+    """One reviewer-facing packet paired with its private sidecar."""
+
+    reviewer_packet: EvidenceSelectionExpertPilotReviewerPacket
+    machine_sidecar: EvidenceSelectionExpertPilotMachineSidecar
+
+
+def build_expert_pilot_packet_bundles(
+    loaded: LoadedEvidenceSelectionExpertPilot,
+) -> tuple[EvidenceSelectionExpertPilotPacketBundle, ...]:
+    """Build independently ordered packets for every case and reviewer slot."""
+
+    bundles: list[EvidenceSelectionExpertPilotPacketBundle] = []
+    packet_refs_by_case = {
+        item.case_id: item for item in loaded.benchmark.packet_manifest.packets
+    }
+    historical_case_ids = tuple(
+        case.case_id for case in loaded.benchmark.historical_v1.cases
+    )
+    for case in loaded.benchmark.historical_v1.cases:
+        _validate_reviewer_narrative(
+            case=case,
+            historical_case_ids=historical_case_ids,
+        )
+        for reviewer_slot in loaded.protocol.independent_reviewer_slots:
+            ordered_records = sorted(
+                case.records,
+                key=lambda record: _blind_digest(
+                    loaded.protocol.study_id,
+                    case.case_id,
+                    reviewer_slot,
+                    record.record_id,
+                ),
+            )
+            packet_id = "packet-" + _blind_digest(
+                loaded.protocol.study_id,
+                case.case_id,
+                reviewer_slot,
+                "packet",
+            )[:16]
+            review_case_id = "case-" + _blind_digest(
+                loaded.protocol.study_id,
+                case.case_id,
+                reviewer_slot,
+                "review-case",
+            )[:16]
+            candidates = tuple(
+                _candidate(
+                    loaded=loaded,
+                    case_id=case.case_id,
+                    reviewer_slot=reviewer_slot,
+                    record=record,
+                )
+                for record in ordered_records
+            )
+            reviewer_packet = EvidenceSelectionExpertPilotReviewerPacket(
+                schema_version="evidence_selection_expert_pilot_reviewer_packet.v1",
+                study_id=loaded.protocol.study_id,
+                packet_id=packet_id,
+                reviewer_slot=reviewer_slot,
+                review_role="independent_first_pass",
+                review_case_id=review_case_id,
+                goal=case.goal,
+                instructions=case.instructions,
+                inclusion_criteria=case.inclusion_criteria,
+                exclusion_criteria=case.exclusion_criteria,
+                completion_status="requires_human_labels",
+                candidates=candidates,
+            )
+            packet_sha256 = reviewer_packet_sha256(reviewer_packet)
+            bindings = tuple(
+                EvidenceSelectionExpertPilotCandidateBinding(
+                    candidate_id=candidate.candidate_id,
+                    record_id=record.record_id,
+                    historical_packet_sha256=packet_refs_by_case[case.case_id].sha256,
+                    supplement_sha256=loaded.supplement_sha256_by_record.get(
+                        record.record_id
+                    ),
+                )
+                for candidate, record in zip(candidates, ordered_records, strict=True)
+            )
+            signature_payload = _sidecar_digest(
+                study_id=loaded.protocol.study_id,
+                packet_id=packet_id,
+                reviewer_slot=reviewer_slot,
+                review_case_id=review_case_id,
+                case_id=case.case_id,
+                packet_sha256=packet_sha256,
+                protocol_sha256=loaded.protocol_sha256,
+                benchmark_fixture_sha256=loaded.benchmark.fixture_sha256,
+                supplement_manifest_sha256=loaded.supplement_manifest_sha256,
+                candidate_bindings=bindings,
+            )
+            sidecar = EvidenceSelectionExpertPilotMachineSidecar(
+                schema_version="evidence_selection_expert_pilot_sidecar.v1",
+                study_id=loaded.protocol.study_id,
+                packet_id=packet_id,
+                reviewer_slot=reviewer_slot,
+                review_case_id=review_case_id,
+                case_id=case.case_id,
+                protocol_sha256=loaded.protocol_sha256,
+                benchmark_fixture_sha256=loaded.benchmark.fixture_sha256,
+                supplement_manifest_sha256=loaded.supplement_manifest_sha256,
+                reviewer_packet_sha256=packet_sha256,
+                candidate_bindings=bindings,
+                producer_signature=sign_machine_packet_digest(signature_payload),
+            )
+            bundles.append(
+                EvidenceSelectionExpertPilotPacketBundle(
+                    reviewer_packet=reviewer_packet,
+                    machine_sidecar=sidecar,
+                )
+            )
+    return tuple(bundles)
+
+
+def verify_expert_pilot_packet_bundle(
+    bundle: EvidenceSelectionExpertPilotPacketBundle,
+) -> None:
+    """Fail closed when packet bytes or sidecar bindings were altered."""
+
+    packet = bundle.reviewer_packet
+    sidecar = bundle.machine_sidecar
+    packet_sha256 = reviewer_packet_sha256(packet)
+    if packet_sha256 != sidecar.reviewer_packet_sha256:
+        raise ValueError("expert-pilot reviewer packet digest mismatch")
+    if (
+        packet.packet_id,
+        packet.study_id,
+        packet.reviewer_slot,
+        packet.review_case_id,
+    ) != (
+        sidecar.packet_id,
+        sidecar.study_id,
+        sidecar.reviewer_slot,
+        sidecar.review_case_id,
+    ):
+        raise ValueError("expert-pilot packet identity does not match sidecar")
+    candidate_ids = tuple(candidate.candidate_id for candidate in packet.candidates)
+    binding_ids = tuple(binding.candidate_id for binding in sidecar.candidate_bindings)
+    if candidate_ids != binding_ids:
+        raise ValueError("expert-pilot candidate order does not match sidecar")
+    verify_machine_packet_signature(
+        digest=_sidecar_digest(
+            study_id=sidecar.study_id,
+            packet_id=sidecar.packet_id,
+            reviewer_slot=sidecar.reviewer_slot,
+            review_case_id=sidecar.review_case_id,
+            case_id=sidecar.case_id,
+            packet_sha256=packet_sha256,
+            protocol_sha256=sidecar.protocol_sha256,
+            benchmark_fixture_sha256=sidecar.benchmark_fixture_sha256,
+            supplement_manifest_sha256=sidecar.supplement_manifest_sha256,
+            candidate_bindings=sidecar.candidate_bindings,
+        ),
+        signature=sidecar.producer_signature,
+    )
+
+
+def reviewer_packet_sha256(
+    packet: EvidenceSelectionExpertPilotReviewerPacket,
+) -> str:
+    """Return a canonical digest for one reviewer-facing packet."""
+
+    content = json.dumps(
+        packet.model_dump(mode="json"),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(content).hexdigest()
+
+
+def _candidate(
+    *,
+    loaded: LoadedEvidenceSelectionExpertPilot,
+    case_id: str,
+    reviewer_slot: str,
+    record: EvidenceSelectionSemanticDiagnosticRecord,
+) -> EvidenceSelectionExpertPilotCandidate:
+    supplement = loaded.supplements_by_record[record.record_id]
+    source_text: tuple[EvidenceSelectionExpertPilotAbstractSection, ...]
+    bounded_text = "\n\n".join(
+        section.text for section in supplement.abstract_sections
+    )
+    source_text = (
+        EvidenceSelectionExpertPilotAbstractSection(
+            section="SOURCE_TEXT",
+            text=bounded_text,
+        ),
+    )
+    return EvidenceSelectionExpertPilotCandidate(
+        candidate_id="candidate-"
+        + _blind_digest(
+            loaded.protocol.study_id,
+            case_id,
+            reviewer_slot,
+            record.record_id,
+        )[:16],
+        source_key=supplement.source_key,
+        source_record_id=supplement.source_record_id,
+        source_url=supplement.source_url,
+        title=supplement.title,
+        bounded_source_text=source_text,
+    )
+
+
+def _blind_digest(*parts: str) -> str:
+    return hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+
+
+def _validate_reviewer_narrative(
+    *,
+    case: EvidenceSelectionSemanticDiagnosticCase,
+    historical_case_ids: tuple[str, ...],
+) -> None:
+    narrative = "\n".join(
+        (
+            case.goal,
+            case.instructions,
+            *case.inclusion_criteria,
+            *case.exclusion_criteria,
+        )
+    ).casefold()
+    forbidden_markers = (
+        "ai diagnostic",
+        "calibrated probability",
+        "canary",
+        "expected label",
+        "expected_label",
+        "harness",
+        "historical label",
+        "model decision",
+        "model identity",
+        "ranking",
+    )
+    leaked_markers = tuple(
+        marker
+        for marker in (*forbidden_markers, *historical_case_ids)
+        if marker.casefold() in narrative
+    )
+    if leaked_markers:
+        raise ValueError(
+            "expert-pilot reviewer narrative leaks blinded context: "
+            + ", ".join(leaked_markers)
+        )
+
+
+def _sidecar_digest(
+    *,
+    study_id: str,
+    packet_id: str,
+    reviewer_slot: str,
+    review_case_id: str,
+    case_id: str,
+    packet_sha256: str,
+    protocol_sha256: str,
+    benchmark_fixture_sha256: str,
+    supplement_manifest_sha256: str,
+    candidate_bindings: tuple[EvidenceSelectionExpertPilotCandidateBinding, ...],
+) -> str:
+    payload = {
+        "schema_version": "evidence_selection_expert_pilot_sidecar.v1",
+        "study_id": study_id,
+        "packet_id": packet_id,
+        "reviewer_slot": reviewer_slot,
+        "review_case_id": review_case_id,
+        "case_id": case_id,
+        "protocol_sha256": protocol_sha256,
+        "benchmark_fixture_sha256": benchmark_fixture_sha256,
+        "supplement_manifest_sha256": supplement_manifest_sha256,
+        "reviewer_packet_sha256": packet_sha256,
+        "candidate_bindings": [
+            binding.model_dump(mode="json") for binding in candidate_bindings
+        ],
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+__all__ = [
+    "EvidenceSelectionExpertPilotPacketBundle",
+    "build_expert_pilot_packet_bundles",
+    "reviewer_packet_sha256",
+    "verify_expert_pilot_packet_bundle",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/pilot_publication.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/pilot_publication.py
@@ -1,0 +1,195 @@
+"""Atomically publish blinded expert-pilot packets and private sidecars."""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import hashlib
+import os
+import platform
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Literal
+
+from .pilot_contracts import (
+    EvidenceSelectionExpertPilotPublicationManifest,
+    EvidenceSelectionExpertPilotPublishedArtifact,
+)
+from .pilot_loader import LoadedEvidenceSelectionExpertPilot
+from .pilot_packets import (
+    build_expert_pilot_packet_bundles,
+    verify_expert_pilot_packet_bundle,
+)
+
+
+def publish_expert_pilot_packets(
+    *,
+    loaded: LoadedEvidenceSelectionExpertPilot,
+    output_dir: Path,
+) -> EvidenceSelectionExpertPilotPublicationManifest:
+    """Publish a complete packet set through one atomic directory rename."""
+
+    resolved_output = output_dir.resolve()
+    if resolved_output.exists():
+        raise ValueError("expert-pilot output directory must not already exist")
+    resolved_output.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(
+            prefix=f".{resolved_output.name}.staging-",
+            dir=resolved_output.parent,
+        )
+    )
+    try:
+        bundles = build_expert_pilot_packet_bundles(loaded)
+        artifacts: list[EvidenceSelectionExpertPilotPublishedArtifact] = []
+        candidate_review_count = 0
+        for bundle in bundles:
+            verify_expert_pilot_packet_bundle(bundle)
+            packet = bundle.reviewer_packet
+            reviewer_slot = _safe_path_segment(
+                packet.reviewer_slot,
+                field_name="reviewer_slot",
+            )
+            review_case_id = _safe_path_segment(
+                packet.review_case_id,
+                field_name="review_case_id",
+            )
+            packet_path = (
+                Path("reviewer_packets") / reviewer_slot / f"{review_case_id}.json"
+            )
+            sidecar_path = (
+                Path("machine_sidecars") / reviewer_slot / f"{review_case_id}.json"
+            )
+            artifacts.extend(
+                (
+                    _write_artifact(
+                        staging=staging,
+                        relative_path=packet_path,
+                        artifact_kind="reviewer_packet",
+                        content=packet.model_dump_json(indent=2) + "\n",
+                    ),
+                    _write_artifact(
+                        staging=staging,
+                        relative_path=sidecar_path,
+                        artifact_kind="machine_sidecar",
+                        content=bundle.machine_sidecar.model_dump_json(indent=2) + "\n",
+                    ),
+                )
+            )
+            candidate_review_count += len(packet.candidates)
+        manifest = EvidenceSelectionExpertPilotPublicationManifest(
+            schema_version="evidence_selection_expert_pilot_publication.v1",
+            study_id=loaded.protocol.study_id,
+            protocol_sha256=loaded.protocol_sha256,
+            benchmark_fixture_sha256=loaded.benchmark.fixture_sha256,
+            supplement_manifest_sha256=loaded.supplement_manifest_sha256,
+            independent_reviewer_count=len(
+                loaded.protocol.independent_reviewer_slots
+            ),
+            reviewer_packet_count=len(bundles),
+            candidate_review_count=candidate_review_count,
+            artifacts=tuple(artifacts),
+        )
+        manifest_path = staging / "publication_manifest.json"
+        manifest_path.write_text(
+            manifest.model_dump_json(indent=2) + "\n",
+            encoding="utf-8",
+        )
+        manifest_path.chmod(0o600)
+        _publish_directory_no_replace(staging=staging, destination=resolved_output)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+    return manifest
+
+
+def _write_artifact(
+    *,
+    staging: Path,
+    relative_path: Path,
+    artifact_kind: Literal["reviewer_packet", "machine_sidecar"],
+    content: str,
+) -> EvidenceSelectionExpertPilotPublishedArtifact:
+    destination = staging / relative_path
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(content, encoding="utf-8")
+    destination.chmod(0o600)
+    return EvidenceSelectionExpertPilotPublishedArtifact(
+        artifact_kind=artifact_kind,
+        path=relative_path.as_posix(),
+        sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+    )
+
+
+def _safe_path_segment(value: str, *, field_name: str) -> str:
+    if value in {".", ".."} or Path(value).name != value or "/" in value or "\\" in value:
+        raise ValueError(f"expert-pilot {field_name} is not path-safe")
+    return value
+
+
+def _publish_directory_no_replace(*, staging: Path, destination: Path) -> None:
+    """Atomically publish a directory without replacing a racing destination."""
+
+    platform_name = platform.system()
+    if platform_name == "Darwin":
+        _call_rename_no_replace(
+            function_name="renamex_np",
+            arguments=(os.fsencode(staging), os.fsencode(destination), 4),
+            argument_types=(ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint),
+            destination=destination,
+        )
+        return
+    if platform_name == "Linux":
+        _call_rename_no_replace(
+            function_name="renameat2",
+            arguments=(
+                -100,
+                os.fsencode(staging),
+                -100,
+                os.fsencode(destination),
+                1,
+            ),
+            argument_types=(
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_int,
+                ctypes.c_char_p,
+                ctypes.c_uint,
+            ),
+            destination=destination,
+        )
+        return
+    if platform_name == "Windows":
+        staging.rename(destination)
+        return
+    raise OSError(
+        errno.ENOTSUP,
+        "atomic no-replace directory publication is unsupported",
+        str(destination),
+    )
+
+
+def _call_rename_no_replace(
+    *,
+    function_name: str,
+    arguments: tuple[object, ...],
+    argument_types: tuple[object, ...],
+    destination: Path,
+) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    operation = getattr(libc, function_name, None)
+    if operation is None:
+        raise OSError(
+            errno.ENOTSUP,
+            f"atomic no-replace operation {function_name} is unavailable",
+            str(destination),
+        )
+    operation.argtypes = list(argument_types)
+    operation.restype = ctypes.c_int
+    if operation(*arguments) != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(error_number, os.strerror(error_number), str(destination))
+
+
+__all__ = ["publish_expert_pilot_packets"]

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_semantic_expert_pilot.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_semantic_expert_pilot.py
@@ -1,0 +1,454 @@
+"""Regression coverage for the blinded semantic expert-pilot boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2 import (
+    build_expert_pilot_packet_bundles,
+    load_expert_pilot,
+    pilot_publication,
+    verify_expert_pilot_packet_bundle,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_contracts import (
+    EvidenceSelectionExpertPilotCandidate,
+    EvidenceSelectionExpertPilotMachineSidecar,
+    EvidenceSelectionExpertPilotProtocol,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_packets import (
+    EvidenceSelectionExpertPilotPacketBundle,
+)
+from pydantic import ValidationError
+
+PROTOCOL_PATH = Path(
+    "scripts/validation/evidence_selection/fixtures/"
+    "semantic_relevance_expert_pilot_protocol_v1.json"
+)
+SIGNING_KEY_ENV = "ARTANA_EVIDENCE_SHADOW_REVIEW_PACKET_SIGNING_KEY"
+
+
+def test_protocol_binds_complete_diagnostic_pilot_inventory() -> None:
+    loaded = load_expert_pilot(
+        protocol_path=PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+
+    assert loaded.protocol.study_tier == "diagnostic_pilot"
+    assert loaded.protocol.production_readiness_claim is False
+    assert loaded.protocol.production_calibration_claim is False
+    assert loaded.protocol.expected_record_count == 33
+    assert loaded.protocol.diagnostic_pilot_question_count == 3
+    assert loaded.protocol.production_calibration_minimum_question_count == 20
+    assert loaded.protocol.production_calibration_minimum_record_count == 200
+    assert (
+        loaded.protocol.acceptance_thresholds.metric_origin
+        == "deterministic_from_categorical_human_findings"
+    )
+    assert len(loaded.supplements_by_record) == 33
+    assert len(
+        {
+            supplement.source_record_id
+            for supplement in loaded.supplements_by_record.values()
+        }
+    ) == 29
+    assert all(loaded.supplement_sha256_by_record.values())
+
+
+def test_reviewer_packets_are_blinded_and_independently_ordered(monkeypatch) -> None:
+    monkeypatch.setenv(SIGNING_KEY_ENV, "unit-test-producer-key")
+    loaded = load_expert_pilot(
+        protocol_path=PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+
+    bundles = build_expert_pilot_packet_bundles(loaded)
+    historical_case_ids = {
+        case.case_id for case in loaded.benchmark.historical_v1.cases
+    }
+
+    assert len(bundles) == 8
+    assert sum(len(bundle.reviewer_packet.candidates) for bundle in bundles) == 66
+    for bundle in bundles:
+        verify_expert_pilot_packet_bundle(bundle)
+        parsed_packet = type(bundle.reviewer_packet).model_validate_json(
+            bundle.reviewer_packet.model_dump_json()
+        )
+        parsed_sidecar = type(bundle.machine_sidecar).model_validate_json(
+            bundle.machine_sidecar.model_dump_json()
+        )
+        verify_expert_pilot_packet_bundle(
+            EvidenceSelectionExpertPilotPacketBundle(
+                reviewer_packet=parsed_packet,
+                machine_sidecar=parsed_sidecar,
+            )
+        )
+        payload = bundle.reviewer_packet.model_dump(mode="json")
+        serialized_packet = json.dumps(payload, sort_keys=True)
+        assert not any(
+            case_id in serialized_packet for case_id in historical_case_ids
+        )
+        assert not _keys(payload).intersection(
+            {
+                "decision",
+                "expected_label",
+                "harness_selected_record_ids",
+                "operational_ranking",
+                "calibrated_probability",
+                "model_id",
+                "diagnostic_decision",
+            }
+        )
+    first_case = [
+        bundle
+        for bundle in bundles
+        if bundle.machine_sidecar.case_id == "egfr_t790m_primary_evidence"
+    ]
+    assert len(first_case) == 2
+    assert (
+        first_case[0].reviewer_packet.review_case_id
+        != first_case[1].reviewer_packet.review_case_id
+    )
+    assert _source_order(first_case[0]) != _source_order(first_case[1])
+
+
+def test_all_records_use_frozen_pubmed_source_snapshots(monkeypatch) -> None:
+    monkeypatch.setenv(SIGNING_KEY_ENV, "unit-test-producer-key")
+    loaded = load_expert_pilot(
+        protocol_path=PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+    bundles = build_expert_pilot_packet_bundles(loaded)
+
+    sections_by_record: dict[str, tuple[str, ...]] = {}
+    text_by_record: dict[str, str] = {}
+    title_by_record: dict[str, str] = {}
+    for bundle in bundles:
+        for candidate, binding in zip(
+            bundle.reviewer_packet.candidates,
+            bundle.machine_sidecar.candidate_bindings,
+            strict=True,
+        ):
+            sections_by_record[binding.record_id] = tuple(
+                section.section for section in candidate.bounded_source_text
+            )
+            text_by_record[binding.record_id] = candidate.bounded_source_text[0].text
+            title_by_record[binding.record_id] = candidate.title
+            assert binding.supplement_sha256 is not None
+
+    assert set(sections_by_record.values()) == {("SOURCE_TEXT",)}
+    for record_id, supplement in loaded.supplements_by_record.items():
+        assert text_by_record[record_id] == "\n\n".join(
+            section.text for section in supplement.abstract_sections
+        )
+        assert title_by_record[record_id] == supplement.title
+
+
+def test_reviewer_packet_cannot_arrive_with_prefilled_judgments() -> None:
+    with pytest.raises(ValidationError):
+        EvidenceSelectionExpertPilotCandidate(
+            candidate_id="candidate-0123456789abcdef",
+            source_key="pubmed",
+            source_record_id="123",
+            source_url="https://pubmed.ncbi.nlm.nih.gov/123/",
+            title="Source title",
+            bounded_source_text=[
+                {"section": "ABSTRACT", "text": "Bounded source text."}
+            ],
+            selection_label="select",  # type: ignore[arg-type]
+        )
+
+
+def test_reviewer_narrative_leakage_fails_closed(monkeypatch) -> None:
+    monkeypatch.setenv(SIGNING_KEY_ENV, "unit-test-producer-key")
+    loaded = load_expert_pilot(
+        protocol_path=PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+    cases = loaded.benchmark.historical_v1.cases
+    tainted_case = cases[-1].model_copy(
+        update={"instructions": "This canary has expected_label=reject."}
+    )
+    tainted_fixture = loaded.benchmark.historical_v1.model_copy(
+        update={"cases": (*cases[:-1], tainted_case)}
+    )
+    tainted_benchmark = replace(
+        loaded.benchmark,
+        historical_v1=tainted_fixture,
+    )
+
+    with pytest.raises(ValueError, match="reviewer narrative leaks blinded context"):
+        build_expert_pilot_packet_bundles(
+            replace(loaded, benchmark=tainted_benchmark)
+        )
+
+
+def test_protocol_rejects_readiness_numeric_or_agent_judgment_drift() -> None:
+    payload = json.loads(PROTOCOL_PATH.read_text(encoding="utf-8"))
+    payload["production_readiness_claim"] = True
+    with pytest.raises(ValidationError, match="production_readiness_claim"):
+        EvidenceSelectionExpertPilotProtocol.model_validate(payload)
+
+    payload = json.loads(PROTOCOL_PATH.read_text(encoding="utf-8"))
+    payload["reviewer_confidence_scale"] = [1, 2, 3, 4, 5]
+    with pytest.raises(ValidationError, match="reviewer_confidence_scale"):
+        EvidenceSelectionExpertPilotProtocol.model_validate(payload)
+
+    payload = json.loads(PROTOCOL_PATH.read_text(encoding="utf-8"))
+    payload["acceptance_thresholds"]["minimum_adjudicated_precision"] = 0.79
+    with pytest.raises(ValidationError, match="thresholds are frozen"):
+        EvidenceSelectionExpertPilotProtocol.model_validate(payload)
+
+
+def test_missing_benchmark_source_snapshot_fails_closed(tmp_path: Path) -> None:
+    protocol_path = _copy_pilot_inputs(tmp_path)
+    manifest_path = tmp_path / _supplement_manifest_path(protocol_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["supplements"] = manifest["supplements"][1:]
+    _write_json(manifest_path, manifest)
+    _rebind_protocol_manifest(protocol_path=protocol_path, manifest_path=manifest_path)
+
+    with pytest.raises(ValueError, match="exactly cover every benchmark source"):
+        load_expert_pilot(protocol_path=protocol_path, repository_root=tmp_path)
+
+
+def test_supplement_identity_drift_fails_closed(tmp_path: Path) -> None:
+    protocol_path = _copy_pilot_inputs(tmp_path)
+    manifest_path = tmp_path / _supplement_manifest_path(protocol_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    source_ref = manifest["supplements"][0]
+    source_path = tmp_path / source_ref["path"]
+    source = json.loads(source_path.read_text(encoding="utf-8"))
+    source["source_record_id"] = "99999999"
+    source["source_url"] = "https://pubmed.ncbi.nlm.nih.gov/99999999/"
+    _write_json(source_path, source)
+    source_ref["sha256"] = _sha256(source_path)
+    _write_json(manifest_path, manifest)
+    _rebind_protocol_manifest(protocol_path=protocol_path, manifest_path=manifest_path)
+
+    with pytest.raises(ValueError, match="supplement source identity mismatch"):
+        load_expert_pilot(protocol_path=protocol_path, repository_root=tmp_path)
+
+
+def test_supplement_url_identity_drift_fails_closed(tmp_path: Path) -> None:
+    protocol_path = _copy_pilot_inputs(tmp_path)
+    manifest_path = tmp_path / _supplement_manifest_path(protocol_path)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    source_ref = manifest["supplements"][0]
+    source_path = tmp_path / source_ref["path"]
+    source = json.loads(source_path.read_text(encoding="utf-8"))
+    source["source_url"] = "https://pubmed.ncbi.nlm.nih.gov/99999999/"
+    _write_json(source_path, source)
+    source_ref["sha256"] = _sha256(source_path)
+    _write_json(manifest_path, manifest)
+    _rebind_protocol_manifest(protocol_path=protocol_path, manifest_path=manifest_path)
+
+    with pytest.raises(ValidationError, match="URL must match source_record_id"):
+        load_expert_pilot(protocol_path=protocol_path, repository_root=tmp_path)
+
+
+def test_packet_and_mapping_tampering_fail_signature_verification(monkeypatch) -> None:
+    monkeypatch.setenv(SIGNING_KEY_ENV, "unit-test-producer-key")
+    loaded = load_expert_pilot(
+        protocol_path=PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+    bundle = build_expert_pilot_packet_bundles(loaded)[0]
+    candidate = bundle.reviewer_packet.candidates[0]
+    tampered_candidate = candidate.model_copy(update={"title": "Tampered title"})
+    tampered_packet = bundle.reviewer_packet.model_copy(
+        update={
+            "candidates": (
+                tampered_candidate,
+                *bundle.reviewer_packet.candidates[1:],
+            )
+        }
+    )
+    with pytest.raises(ValueError, match="packet digest mismatch"):
+        verify_expert_pilot_packet_bundle(
+            EvidenceSelectionExpertPilotPacketBundle(
+                reviewer_packet=tampered_packet,
+                machine_sidecar=bundle.machine_sidecar,
+            )
+        )
+
+    first_binding = bundle.machine_sidecar.candidate_bindings[0]
+    tampered_binding = first_binding.model_copy(update={"record_id": "forged-record"})
+    sidecar_payload = bundle.machine_sidecar.model_dump()
+    sidecar_payload["candidate_bindings"] = (
+        tampered_binding,
+        *bundle.machine_sidecar.candidate_bindings[1:],
+    )
+    tampered_sidecar = EvidenceSelectionExpertPilotMachineSidecar.model_validate(
+        sidecar_payload
+    )
+    with pytest.raises(ValueError, match="signature"):
+        verify_expert_pilot_packet_bundle(
+            EvidenceSelectionExpertPilotPacketBundle(
+                reviewer_packet=bundle.reviewer_packet,
+                machine_sidecar=tampered_sidecar,
+            )
+        )
+
+
+def test_packet_publication_failure_leaves_no_partial_output(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(SIGNING_KEY_ENV, "unit-test-producer-key")
+    loaded = load_expert_pilot(
+        protocol_path=PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+    original_write = pilot_publication._write_artifact
+    write_count = 0
+
+    def fail_second_write(**kwargs):
+        nonlocal write_count
+        write_count += 1
+        if write_count == 2:
+            raise OSError("simulated sidecar write failure")
+        return original_write(**kwargs)
+
+    monkeypatch.setattr(pilot_publication, "_write_artifact", fail_second_write)
+    output_dir = tmp_path / "expert-pilot"
+
+    with pytest.raises(OSError, match="simulated sidecar"):
+        pilot_publication.publish_expert_pilot_packets(
+            loaded=loaded,
+            output_dir=output_dir,
+        )
+
+    assert not output_dir.exists()
+    assert not list(tmp_path.glob(".expert-pilot.staging-*"))
+
+
+def test_packet_publication_verifies_bundle_before_exposure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(SIGNING_KEY_ENV, "unit-test-producer-key")
+    loaded = load_expert_pilot(
+        protocol_path=PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+    bundle = build_expert_pilot_packet_bundles(loaded)[0]
+    tampered_packet = bundle.reviewer_packet.model_copy(
+        update={"instructions": "Tampered instructions"}
+    )
+    tampered_bundle = EvidenceSelectionExpertPilotPacketBundle(
+        reviewer_packet=tampered_packet,
+        machine_sidecar=bundle.machine_sidecar,
+    )
+    monkeypatch.setattr(
+        pilot_publication,
+        "build_expert_pilot_packet_bundles",
+        lambda _loaded: (tampered_bundle,),
+    )
+    output_dir = tmp_path / "expert-pilot"
+
+    with pytest.raises(ValueError, match="packet digest mismatch"):
+        pilot_publication.publish_expert_pilot_packets(
+            loaded=loaded,
+            output_dir=output_dir,
+        )
+
+    assert not output_dir.exists()
+    assert not list(tmp_path.glob(".expert-pilot.staging-*"))
+
+
+def test_packet_publication_does_not_replace_racing_destination(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(SIGNING_KEY_ENV, "unit-test-producer-key")
+    loaded = load_expert_pilot(
+        protocol_path=PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+    original_publish = pilot_publication._publish_directory_no_replace
+
+    def race_destination(*, staging: Path, destination: Path) -> None:
+        destination.mkdir()
+        original_publish(staging=staging, destination=destination)
+
+    monkeypatch.setattr(
+        pilot_publication,
+        "_publish_directory_no_replace",
+        race_destination,
+    )
+    output_dir = tmp_path / "expert-pilot"
+
+    with pytest.raises(FileExistsError):
+        pilot_publication.publish_expert_pilot_packets(
+            loaded=loaded,
+            output_dir=output_dir,
+        )
+
+    assert output_dir.is_dir()
+    assert not list(output_dir.iterdir())
+    assert not list(tmp_path.glob(".expert-pilot.staging-*"))
+
+
+def _source_order(bundle: EvidenceSelectionExpertPilotPacketBundle) -> tuple[str, ...]:
+    return tuple(
+        candidate.source_record_id for candidate in bundle.reviewer_packet.candidates
+    )
+
+
+def _keys(value: object) -> set[str]:
+    if isinstance(value, dict):
+        return set(value).union(*(_keys(item) for item in value.values()), set())
+    if isinstance(value, list):
+        return set().union(*(_keys(item) for item in value), set())
+    return set()
+
+
+def _copy_pilot_inputs(root: Path) -> Path:
+    protocol = json.loads(PROTOCOL_PATH.read_text(encoding="utf-8"))
+    benchmark_path = Path(protocol["benchmark_fixture"]["path"])
+    benchmark = json.loads(benchmark_path.read_text(encoding="utf-8"))
+    v1_path = Path(benchmark["historical_v1"]["path"])
+    packet_manifest_path = Path(benchmark["source_packet_manifest"]["path"])
+    packet_manifest = json.loads(packet_manifest_path.read_text(encoding="utf-8"))
+    supplement_manifest_path = Path(protocol["supplement_manifest"]["path"])
+    supplement_manifest = json.loads(
+        supplement_manifest_path.read_text(encoding="utf-8")
+    )
+    paths = [
+        PROTOCOL_PATH,
+        benchmark_path,
+        v1_path,
+        packet_manifest_path,
+        *(Path(item["path"]) for item in packet_manifest["packets"]),
+        supplement_manifest_path,
+        *(Path(item["path"]) for item in supplement_manifest["supplements"]),
+    ]
+    for source in paths:
+        destination = root / source
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+    return root / PROTOCOL_PATH
+
+
+def _supplement_manifest_path(protocol_path: Path) -> Path:
+    protocol = json.loads(protocol_path.read_text(encoding="utf-8"))
+    return Path(protocol["supplement_manifest"]["path"])
+
+
+def _rebind_protocol_manifest(*, protocol_path: Path, manifest_path: Path) -> None:
+    protocol = json.loads(protocol_path.read_text(encoding="utf-8"))
+    protocol["supplement_manifest"]["sha256"] = _sha256(manifest_path)
+    _write_json(protocol_path, protocol)
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_semantic_expert_pilot_cli.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_semantic_expert_pilot_cli.py
@@ -1,0 +1,102 @@
+"""CLI coverage for atomic blinded expert-pilot packet publication."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_contracts import (
+    EvidenceSelectionExpertPilotMachineSidecar,
+    EvidenceSelectionExpertPilotReviewerPacket,
+)
+
+from scripts.build_evidence_selection_expert_pilot_packets import main
+
+PROTOCOL_PATH = Path(
+    "scripts/validation/evidence_selection/fixtures/"
+    "semantic_relevance_expert_pilot_protocol_v1.json"
+)
+SIGNING_KEY_ENV = "ARTANA_EVIDENCE_SHADOW_REVIEW_PACKET_SIGNING_KEY"
+
+
+def test_cli_publishes_blinded_packets_and_private_sidecars(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv(SIGNING_KEY_ENV, "cli-test-producer-key")
+    output_dir = tmp_path / "expert-pilot"
+
+    result = main(
+        (
+            "--protocol",
+            str(PROTOCOL_PATH),
+            "--output-dir",
+            str(output_dir),
+        )
+    )
+
+    assert result == 0
+    manifest = json.loads(
+        (output_dir / "publication_manifest.json").read_text(encoding="utf-8")
+    )
+    assert manifest["independent_reviewer_count"] == 2
+    assert manifest["reviewer_packet_count"] == 8
+    assert manifest["candidate_review_count"] == 66
+    assert manifest["production_readiness_claim"] is False
+    assert manifest["production_calibration_claim"] is False
+    assert len(list((output_dir / "reviewer_packets").rglob("*.json"))) == 8
+    assert len(list((output_dir / "machine_sidecars").rglob("*.json"))) == 8
+    reviewer_paths = list((output_dir / "reviewer_packets").rglob("*.json"))
+    for reviewer_path in reviewer_paths:
+        relative_path = reviewer_path.relative_to(output_dir / "reviewer_packets")
+        packet = EvidenceSelectionExpertPilotReviewerPacket.model_validate_json(
+            reviewer_path.read_bytes()
+        )
+        sidecar = EvidenceSelectionExpertPilotMachineSidecar.model_validate_json(
+            (output_dir / "machine_sidecars" / relative_path).read_bytes()
+        )
+        assert reviewer_path.stem == packet.review_case_id
+        assert packet.review_case_id == sidecar.review_case_id
+        assert reviewer_path.stem.startswith("case-")
+        assert sidecar.case_id not in reviewer_path.as_posix()
+    reviewer_payload = json.loads(reviewer_paths[0].read_text(encoding="utf-8"))
+    assert "candidate_bindings" not in reviewer_payload
+    assert "producer_signature" not in reviewer_payload
+    assert "production_readiness=false" in capsys.readouterr().out
+
+
+def test_cli_fails_closed_without_signing_key_or_on_existing_output(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.delenv(SIGNING_KEY_ENV, raising=False)
+    missing_key_output = tmp_path / "missing-key"
+
+    result = main(
+        (
+            "--protocol",
+            str(PROTOCOL_PATH),
+            "--output-dir",
+            str(missing_key_output),
+        )
+    )
+
+    assert result == 1
+    assert not missing_key_output.exists()
+    assert SIGNING_KEY_ENV in capsys.readouterr().err
+
+    monkeypatch.setenv(SIGNING_KEY_ENV, "cli-test-producer-key")
+    existing_output = tmp_path / "existing"
+    existing_output.mkdir()
+    result = main(
+        (
+            "--protocol",
+            str(PROTOCOL_PATH),
+            "--output-dir",
+            str(existing_output),
+        )
+    )
+    assert result == 1
+    assert "must not already exist" in capsys.readouterr().err

--- a/tests/unit/test_ci_service_check_planner.py
+++ b/tests/unit/test_ci_service_check_planner.py
@@ -241,6 +241,20 @@ def test_evidence_api_shadow_review_packet_script_pr_runs_evidence_api_gate() ->
     assert plan.targeted_test_paths == ()
 
 
+def test_evidence_api_expert_pilot_packet_script_pr_runs_evidence_api_gate() -> None:
+    plan = plan_checks(
+        ["scripts/build_evidence_selection_expert_pilot_packets.py"],
+        event_name="pull_request",
+        ref="refs/pull/153/merge",
+    )
+
+    assert plan.evidence_api
+    assert not plan.graph_service
+    assert not plan.repo_control
+    assert not plan.full
+    assert plan.targeted_test_paths == ()
+
+
 def test_evidence_api_shadow_review_source_input_script_pr_runs_evidence_api_gate() -> (
     None
 ):


### PR DESCRIPTION
## Summary

- freeze a diagnostic-only expert pilot for 3 questions, 4 cases, 33 records, 2 independent reviewers, and third-reviewer adjudication
- replace mixed benchmark excerpts with 29 content-addressed NCBI PubMed source snapshots covering every candidate
- publish reviewer-specific blinded packets separately from signed private machine sidecars
- enforce categorical human findings, deterministic downstream metrics, false readiness/calibration claims, and fail-closed source/blinding/tamper boundaries
- use pre-verified atomic no-replace publication and record the full adversarial validation loop

## Validation

- 59 focused benchmark, pilot, CLI, and CI-planner tests passed
- live generation and signature/source verification passed for 8 packet/sidecar pairs and 66 candidate reviews
- `make evidence-selection-semantic-benchmark-v2-check`
- `make artana-evidence-api-service-checks`
- `pre-commit run --all-files`
- final independent adversarial review: no remaining merge blocker

## Honest boundary

This PR creates no expert labels and makes no production-readiness or production-calibration claim. Two authenticated domain experts, third-reviewer adjudication, external attestation verification, completed-packet import, and deterministic metric computation remain required before any record becomes expert-eligible.

Validation report: `docs/validation/reports/2026-07-14-pr153-independent-expert-pilot-summary.md`