### PR TITLE
Verify externally attested expert pilot scoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ ARTANA_EVIDENCE_API_LINT_PATHS := \
  scripts/run_evidence_selection_review_calibration_gate.py \
  scripts/build_evidence_selection_shadow_review_packet.py \
  scripts/build_evidence_selection_expert_pilot_packets.py \
+ scripts/import_evidence_selection_expert_pilot_reviews.py \
  scripts/build_evidence_selection_shadow_review_source_inputs.py \
  scripts/build_evidence_selection_shadow_review_study_batch_manifest.py \
  scripts/build_evidence_selection_shadow_review_study_batch.py \
@@ -309,6 +310,7 @@ artana-evidence-api-type-check: ## Run strict mypy on evidence API package
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/run_evidence_selection_review_calibration_gate.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/build_evidence_selection_shadow_review_packet.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/build_evidence_selection_expert_pilot_packets.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
+	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/import_evidence_selection_expert_pilot_reviews.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/build_evidence_selection_shadow_review_source_inputs.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/build_evidence_selection_shadow_review_study_batch_manifest.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/build_evidence_selection_shadow_review_study_batch.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)

--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -3441,6 +3441,35 @@ Remaining proof boundary:
   artifacts pass that boundary, benchmark v2 remains at zero expert-eligible
   records.
 
+### 2026-07-14 - PR154 External Attestation And Expert-Gold Import
+
+Branch: `alvaro/evidence-pr154-attestation`
+
+Goal: verify externally authenticated categorical human findings, freeze
+adjudicated gold before model-claim review, and recompute diagnostic model
+quality without accepting human or agent-authored numbers.
+
+Progress:
+
+- Added a pre-review evaluation protocol binding all six frozen PR150 live-agent
+  runs, evaluated commit, exact case/record scope, deterministic metric rules,
+  post-gold safety scope, and preserved PR150 coverage, per-case, canary, and
+  repeatability gates.
+- Added an issuer-signed Ed25519 study authorization binding three distinct
+  verified human subjects, qualifications, conflict declarations, reviewer
+  roles, keys, validity period, the packet publication, and both protocols.
+- Added exact signed first-pass import, deterministic disagreement requests,
+  signed third-reviewer adjudication, frozen gold, post-gold selected-claim
+  safety review, and atomic result publication.
+- Numeric reviewer and agent judgments remain forbidden. Agreement, quality,
+  repeatability, and safety values are code-derived from categorical findings.
+- Partial, insufficient, abstained, not-assessable, tampered, stale, missing, or
+  extra evidence fails closed or keeps diagnostic gates unavailable.
+- Model adoption, production calibration, and trusted-graph readiness remain
+  false. Real external reviewer artifacts are still pending.
+- Validation evidence:
+  `docs/validation/reports/2026-07-14-pr154-expert-pilot-attestation-import.md`.
+
 ## PR Update Template
 
 Copy this block when a PR is opened or merged.

--- a/docs/validation/evidence-selection-expert-pilot-runbook.md
+++ b/docs/validation/evidence-selection-expert-pilot-runbook.md
@@ -1,7 +1,7 @@
 # Evidence Selection Independent Expert Pilot Runbook
 
-Status: packet generation is implemented; independent human review has not
-started.
+Status: packet generation and the fail-closed signed-review import path are
+implemented; independent human review has not started.
 
 This run is a diagnostic pilot over three distinct research questions, four
 benchmark cases, and 33 candidate records. It can correct the benchmark and
@@ -16,6 +16,8 @@ calibration or trusted-graph readiness.
   `scripts/validation/evidence_selection/fixtures/semantic_relevance_benchmark_v2.json`
 - Supplemental-source manifest:
   `scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_supplement_manifest_v1.json`
+- Pre-registered evaluation protocol:
+  `scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_evaluation_protocol_v1.json`
 
 The historical v1 benchmark and its original source snapshots remain unchanged.
 The pilot freezes content-addressed NCBI PubMed metadata and abstracts for all
@@ -67,9 +69,68 @@ fields or act as the gold-label author.
 
 Two externally authenticated, domain-qualified humans review every record
 independently. A third qualified human adjudicates every disagreement. External
-attestations must bind the real reviewer identity to reviewer slot, packet hash,
-case, candidate inventory, source hashes, completion timestamp, and categorical
-findings.
+attestations must bind a stable verified natural-person subject, qualification,
+conflict-of-interest declaration, reviewer slot, Ed25519 public key,
+credential-validity period, packet-publication hash, evaluation-protocol hash,
+completion timestamp, and categorical findings. Reviewer private keys and the
+issuer private key must remain outside Artana.
+
+The externally signed reviewer registry is the study authorization. It contains
+exactly three distinct subjects and keys: reviewer slots A and B plus
+adjudicator/safety slot C. Artana receives only the signed registry, the pinned
+issuer public key, and the issuer key ID.
+
+## Import Workflow
+
+Run every stage against the original no-replace packet publication. Artana
+recomputes all intermediate artifacts; it never trusts uploaded gold or numeric
+scores.
+
+1. Verify both signed first-pass completions and generate only disagreements:
+
+```bash
+uv run python scripts/import_evidence_selection_expert_pilot_reviews.py \
+  prepare-adjudication \
+  --pilot-protocol scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_protocol_v1.json \
+  --evaluation-protocol scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_evaluation_protocol_v1.json \
+  --packet-publication reports/human-shadow-study/semantic-relevance-expert-pilot-v1 \
+  --reviewer-registry /secure/path/signed-reviewer-registry.json \
+  --issuer-public-key-hex "$EXPERT_PILOT_ISSUER_PUBLIC_KEY_HEX" \
+  --issuer-key-id "$EXPERT_PILOT_ISSUER_KEY_ID" \
+  --first-pass-completions /secure/path/first-pass-completions \
+  --output-dir reports/human-shadow-study/pilot-v1-adjudication-request
+```
+
+2. After slot C signs the generated adjudication request, freeze gold and
+generate the post-gold safety request:
+
+```bash
+uv run python scripts/import_evidence_selection_expert_pilot_reviews.py \
+  prepare-safety-audit \
+  <the same common arguments> \
+  --adjudication-completion /secure/path/adjudication-completion.json \
+  --output-dir reports/human-shadow-study/pilot-v1-safety-request
+```
+
+Omit `--adjudication-completion` only when the generated request contains zero
+items. Slot C cannot see model claims until the adjudicated gold hash is frozen.
+
+3. After slot C signs categorical safety findings, recompute and publish the
+diagnostic result:
+
+```bash
+uv run python scripts/import_evidence_selection_expert_pilot_reviews.py \
+  finalize \
+  <the same common arguments> \
+  --adjudication-completion /secure/path/adjudication-completion.json \
+  --safety-completion /secure/path/safety-completion.json \
+  --output-dir reports/human-shadow-study/pilot-v1-verified-result
+```
+
+Every output directory is atomic and no-replace. A modified packet, sidecar,
+manifest, roster, signature, completion inventory, timestamp, literal span,
+adjudication item, gold hash, model-run artifact, or safety item fails before
+result publication.
 
 ## Predeclared Evaluation
 
@@ -84,6 +145,19 @@ attestation. The frozen pilot thresholds are:
 No threshold may be changed after first-pass review begins. A threshold change
 requires a new protocol version and new first-pass reviews.
 
+The evaluation protocol also preserves the stricter PR150 diagnostic gates:
+worst-run decision coverage, per-case precision/recall/coverage, canary safety,
+and exact three-run repeatability. It binds all six existing PR150 live-agent
+run hashes before human review. Embedded PR150 scores are ignored; predictions
+are rescored against signed expert gold. Because agents saw sanitized source
+snapshots while experts receive complete PubMed abstracts, this is an
+end-to-end diagnostic re-score, not an isolated same-input model comparison.
+
+PR154 never selects a production model. A real result can correct the benchmark
+and show which diagnostic gates pass, but model adoption requires a later live
+comparison with the corrected benchmark, complete runtime telemetry, and the
+existing adoption policy.
+
 ## Scale Boundary
 
 This pilot has three distinct research questions and 33 records. Production
@@ -91,6 +165,5 @@ calibration remains unavailable. A calibration study requires at least 20
 questions and 200 records, with at least 12 questions frozen for training and 8
 different questions held out before review begins.
 
-The next PR must implement completed-packet import and external attestation
-verification. Until that PR receives real reviewer artifacts, benchmark v2 must
-continue to report zero expert-eligible records.
+Until real externally signed reviewer, adjudication, and safety artifacts pass
+this importer, benchmark v2 continues to report zero expert-eligible records.

--- a/docs/validation/evidence-selection-expert-pilot-runbook.md
+++ b/docs/validation/evidence-selection-expert-pilot-runbook.md
@@ -102,13 +102,20 @@ uv run python scripts/import_evidence_selection_expert_pilot_reviews.py \
 ```
 
 2. After slot C signs the generated adjudication request, freeze gold and
-generate the post-gold safety request:
+generate the post-gold safety request. First generate and retain an owner-only
+random key; do not include this file in the reviewer packet or repository:
+
+```bash
+umask 077
+openssl rand -hex 32 > /secure/path/pilot-v1-safety-blinding.key
+```
 
 ```bash
 uv run python scripts/import_evidence_selection_expert_pilot_reviews.py \
   prepare-safety-audit \
   <the same common arguments> \
   --adjudication-completion /secure/path/adjudication-completion.json \
+  --safety-blinding-key-file /secure/path/pilot-v1-safety-blinding.key \
   --output-dir reports/human-shadow-study/pilot-v1-safety-request
 ```
 
@@ -123,6 +130,7 @@ uv run python scripts/import_evidence_selection_expert_pilot_reviews.py \
   finalize \
   <the same common arguments> \
   --adjudication-completion /secure/path/adjudication-completion.json \
+  --safety-blinding-key-file /secure/path/pilot-v1-safety-blinding.key \
   --safety-completion /secure/path/safety-completion.json \
   --output-dir reports/human-shadow-study/pilot-v1-verified-result
 ```

--- a/docs/validation/evidence-selection-validation.md
+++ b/docs/validation/evidence-selection-validation.md
@@ -250,6 +250,15 @@ production calibration and readiness unavailable. Follow
 `docs/validation/evidence-selection-expert-pilot-runbook.md` for distribution,
 reviewer independence, categorical findings, adjudication, and attestation.
 
+Completed pilot reviews use
+`scripts/import_evidence_selection_expert_pilot_reviews.py`. Its three commands
+(`prepare-adjudication`, `prepare-safety-audit`, and `finalize`) verify the
+issuer-signed reviewer authorization plus every human Ed25519 signature,
+generate the model-blinded disagreement packet, freeze adjudicated gold before
+revealing model claims, and compute metrics deterministically. The importer
+binds all six pre-existing live-agent runs but emits no model-adoption,
+production-calibration, or trusted-graph-readiness claim.
+
 Full expert/shadow study gate:
 
 For a selection-only study, pass `--study-type selection_relevance` to the

--- a/docs/validation/reports/2026-07-14-pr154-expert-pilot-attestation-import.md
+++ b/docs/validation/reports/2026-07-14-pr154-expert-pilot-attestation-import.md
@@ -1,0 +1,74 @@
+# PR154 Expert Pilot Attestation Import
+
+Date: 2026-07-14
+
+Branch: `alvaro/evidence-pr154-attestation`
+
+## Result
+
+PR154 implements the externally authenticated human-review boundary left open
+by PR153. It does not create human labels, select a model, claim production
+calibration, or claim trusted-graph readiness.
+
+The implementation adds:
+
+- a pre-review evaluation protocol binding all six immutable PR150 live-agent
+  runs, exact case/record scope, deterministic formulas, safety scope, and the
+  stronger PR150 coverage, per-case, canary, and repeatability gates;
+- an issuer-signed Ed25519 study authorization for three distinct verified,
+  qualified, conflict-declared human subjects and public keys, with the exact
+  issuer trust-anchor fingerprint preserved in the result;
+- reviewer-signed categorical first-pass completions with exact packet,
+  publication, protocol, chronology, inventory, and literal-span verification;
+- deterministic disagreement detection and a model-blinded third-reviewer
+  adjudication request;
+- adjudicated gold frozen before any model claim is shown to the safety
+  reviewer;
+- a post-gold categorical claim-safety audit over every selected claim in all
+  six runs;
+- deterministic human agreement, precision, recall, coverage, per-case,
+  canary, repeatability, and overclaim metrics;
+- source-owned case/record and primary/canary partitions that registered model
+  artifacts cannot redefine;
+- atomic no-replace publications for each workflow stage.
+
+## Methodology Corrections
+
+PR153 required zero high-severity overclaims while correctly hiding model claims
+from first-pass reviewers. PR154 resolves that mismatch through a separate
+post-gold safety phase. It also prevents an expert re-score from weakening PR150
+to precision and recall alone.
+
+The six historical runs are treated as pre-existing end-to-end predictions.
+Their embedded AI-gold scores are ignored. Experts review complete PubMed
+abstracts, whereas those agents consumed sanitized snapshots, so the output is
+explicitly a diagnostic re-score and never an automatic model-adoption result.
+
+## Current Honest State
+
+No real reviewer artifacts exist yet. The repository therefore remains at zero
+expert-eligible benchmark records. Synthetic cryptographic rehearsals exercise
+the implementation only and cannot be imported as expert evidence.
+
+## Validation
+
+Final local branch evidence:
+
+- focused expert-pilot and benchmark regression suite: **44 passed**;
+- strict Evidence API typing, including the importer: **passed across 577
+  package source files and all registered scripts**;
+- architecture size and structure checks: **passed**;
+- complete database-backed Evidence API service gate: **passed against a fresh
+  migrated ephemeral PostgreSQL database**;
+- benchmark truthfulness check: **33 visible, 0 score-eligible, expert study
+  pending**.
+
+Repository pre-commit hooks remain a required commit-time gate and may not be
+skipped.
+
+Synthetic tests cover forged signatures, packet-publication substitution,
+duplicate run bytes, fixture drift, case remapping, canary-role remapping,
+incomplete adjudication, incomplete gold, not-assessable safety findings,
+repeatability failure, and atomic no-replace publication. Final command results
+are recorded in the PR description and CI; none of these rehearsals count as
+expert evidence.

--- a/docs/validation/reports/2026-07-14-pr154-expert-pilot-attestation-import.md
+++ b/docs/validation/reports/2026-07-14-pr154-expert-pilot-attestation-import.md
@@ -54,8 +54,8 @@ the implementation only and cannot be imported as expert evidence.
 
 Final local branch evidence:
 
-- focused expert-pilot and benchmark regression suite: **44 passed**;
-- strict Evidence API typing, including the importer: **passed across 577
+- focused expert-pilot and benchmark regression suite: **47 passed**;
+- strict Evidence API typing, including the importer: **passed across 578
   package source files and all registered scripts**;
 - architecture size and structure checks: **passed**;
 - complete database-backed Evidence API service gate: **passed against a fresh
@@ -68,7 +68,8 @@ skipped.
 
 Synthetic tests cover forged signatures, packet-publication substitution,
 duplicate run bytes, fixture drift, case remapping, canary-role remapping,
-incomplete adjudication, incomplete gold, not-assessable safety findings,
-repeatability failure, and atomic no-replace publication. Final command results
-are recorded in the PR description and CI; none of these rehearsals count as
-expert evidence.
+producer-signed stale packet bundles, cross-study packet substitution, blank
+literal spans, enumerable safety blinding, incomplete adjudication, incomplete
+gold, not-assessable safety findings, repeatability failure, and atomic
+no-replace publication. Final command results are recorded in the PR
+description and CI; none of these rehearsals count as expert evidence.

--- a/scripts/ci/plan_service_checks.py
+++ b/scripts/ci/plan_service_checks.py
@@ -42,6 +42,7 @@ EVIDENCE_API_FILES = (
     "docs/validation/reports/pr-semantic-pr2-agent-selector-evaluation.md",
     "scripts/build_evidence_selection_shadow_review_packet.py",
     "scripts/build_evidence_selection_expert_pilot_packets.py",
+    "scripts/import_evidence_selection_expert_pilot_reviews.py",
     "scripts/build_evidence_selection_shadow_review_source_inputs.py",
     "scripts/build_evidence_selection_shadow_review_study_batch_manifest.py",
     "scripts/build_evidence_selection_shadow_review_study_batch.py",

--- a/scripts/import_evidence_selection_expert_pilot_reviews.py
+++ b/scripts/import_evidence_selection_expert_pilot_reviews.py
@@ -30,6 +30,9 @@ from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilo
     load_and_verify_adjudication_completion,
     prepare_expert_pilot_adjudication,
 )
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.blinding import (  # noqa: E402
+    load_safety_blinding_key,
+)
 from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.evaluation import (  # noqa: E402
     LoadedExpertPilotModelRun,
     PreparedExpertPilotSafetyAudit,
@@ -99,11 +102,13 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     prepare_safety = subparsers.add_parser("prepare-safety-audit")
     _add_common_args(prepare_safety)
     prepare_safety.add_argument("--adjudication-completion", type=Path)
+    prepare_safety.add_argument("--safety-blinding-key-file", required=True, type=Path)
     prepare_safety.add_argument("--output-dir", required=True, type=Path)
 
     finalize = subparsers.add_parser("finalize")
     _add_common_args(finalize)
     finalize.add_argument("--adjudication-completion", type=Path)
+    finalize.add_argument("--safety-blinding-key-file", required=True, type=Path)
     finalize.add_argument("--safety-completion", required=True, type=Path)
     finalize.add_argument("--output-dir", required=True, type=Path)
     return parser.parse_args(argv)
@@ -128,11 +133,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             first_pass=first_pass,
             adjudication_path=args.adjudication_completion,
         )
+        safety_blinding_key = load_safety_blinding_key(args.safety_blinding_key_file)
         prepared_safety = prepare_expert_pilot_safety_audit(
             loaded_pilot=first_pass.loaded_pilot,
             evaluation_protocol_sha256=first_pass.evaluation_protocol_sha256,
             gold=gold_context.gold,
             model_runs=gold_context.model_runs,
+            blinding_key=safety_blinding_key,
         )
         if args.command == "prepare-safety-audit":
             _publish_safety(

--- a/scripts/import_evidence_selection_expert_pilot_reviews.py
+++ b/scripts/import_evidence_selection_expert_pilot_reviews.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Import externally signed human reviews through the staged expert-pilot gate."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import ValidationError
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SERVICES_ROOT = _REPO_ROOT / "services"
+for _path in (_REPO_ROOT, _SERVICES_ROOT):
+    _path_text = str(_path)
+    if _path_text not in sys.path:
+        sys.path.insert(0, _path_text)
+
+from artana_evidence_api.evidence_selection.cli_errors import (  # noqa: E402
+    cli_error_message,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.adjudication import (  # noqa: E402
+    PreparedExpertPilotAdjudication,
+    VerifiedExpertPilotAdjudication,
+    build_expert_pilot_gold,
+    load_and_verify_adjudication_completion,
+    prepare_expert_pilot_adjudication,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.evaluation import (  # noqa: E402
+    LoadedExpertPilotModelRun,
+    PreparedExpertPilotSafetyAudit,
+    build_expert_pilot_result,
+    load_and_verify_safety_completion,
+    load_registered_model_runs,
+    prepare_expert_pilot_safety_audit,
+    render_expert_pilot_result_markdown,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.publication import (  # noqa: E402
+    publish_expert_pilot_stage,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.review_loader import (  # noqa: E402
+    LoadedExpertPilotPublication,
+    VerifiedExpertPilotRegistry,
+    VerifiedExpertPilotReviewCompletion,
+    load_and_verify_first_pass_completions,
+    load_and_verify_reviewer_registry,
+    load_expert_pilot_evaluation_protocol,
+    load_expert_pilot_publication,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_loader import (  # noqa: E402
+    LoadedEvidenceSelectionExpertPilot,
+    load_expert_pilot,
+)
+
+if TYPE_CHECKING:
+    from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.evaluation_contracts import (  # noqa: E402
+        EvidenceSelectionExpertPilotEvaluationProtocol,
+        EvidenceSelectionExpertPilotGoldArtifact,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _FirstPassContext:
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot
+    evaluation_protocol: EvidenceSelectionExpertPilotEvaluationProtocol
+    evaluation_protocol_sha256: str
+    publication: LoadedExpertPilotPublication
+    registry: VerifiedExpertPilotRegistry
+    completions: tuple[VerifiedExpertPilotReviewCompletion, ...]
+    prepared: PreparedExpertPilotAdjudication
+
+
+@dataclass(frozen=True, slots=True)
+class _GoldContext:
+    first_pass: _FirstPassContext
+    adjudication: VerifiedExpertPilotAdjudication | None
+    gold: EvidenceSelectionExpertPilotGoldArtifact
+    model_runs: tuple[LoadedExpertPilotModelRun, ...]
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse one staged workflow command."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify external expert attestations, create adjudicated gold, and "
+            "compute deterministic semantic-selector pilot metrics."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare_adjudication = subparsers.add_parser("prepare-adjudication")
+    _add_common_args(prepare_adjudication)
+    prepare_adjudication.add_argument("--output-dir", required=True, type=Path)
+
+    prepare_safety = subparsers.add_parser("prepare-safety-audit")
+    _add_common_args(prepare_safety)
+    prepare_safety.add_argument("--adjudication-completion", type=Path)
+    prepare_safety.add_argument("--output-dir", required=True, type=Path)
+
+    finalize = subparsers.add_parser("finalize")
+    _add_common_args(finalize)
+    finalize.add_argument("--adjudication-completion", type=Path)
+    finalize.add_argument("--safety-completion", required=True, type=Path)
+    finalize.add_argument("--output-dir", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Execute one stage and return a process-style status."""
+
+    args = parse_args(argv)
+    try:
+        first_pass = _load_first_pass_context(args)
+        if args.command == "prepare-adjudication":
+            _publish_adjudication(first_pass=first_pass, output_dir=args.output_dir)
+            item_count = len(first_pass.prepared.request.items)
+            print(
+                "evidence_selection_expert_pilot "
+                f"stage=adjudication disagreements={item_count} "
+                "production_readiness=false"
+            )
+            return 0
+        gold_context = _load_gold_context(
+            first_pass=first_pass,
+            adjudication_path=args.adjudication_completion,
+        )
+        prepared_safety = prepare_expert_pilot_safety_audit(
+            loaded_pilot=first_pass.loaded_pilot,
+            evaluation_protocol_sha256=first_pass.evaluation_protocol_sha256,
+            gold=gold_context.gold,
+            model_runs=gold_context.model_runs,
+        )
+        if args.command == "prepare-safety-audit":
+            _publish_safety(
+                gold_context=gold_context,
+                prepared_safety=prepared_safety,
+                output_dir=args.output_dir,
+            )
+            print(
+                "evidence_selection_expert_pilot "
+                f"stage=safety claims={len(prepared_safety.request.items)} "
+                f"expert_eligible={gold_context.gold.score_eligible_record_count} "
+                "production_readiness=false"
+            )
+            return 0
+        earliest_time = _latest_gold_input_time(gold_context)
+        safety = load_and_verify_safety_completion(
+            path=args.safety_completion,
+            prepared=prepared_safety,
+            registry=first_pass.registry,
+            loaded_pilot=first_pass.loaded_pilot,
+            earliest_time=earliest_time,
+        )
+        result = build_expert_pilot_result(
+            protocol=first_pass.evaluation_protocol,
+            gold=gold_context.gold,
+            registry=first_pass.registry,
+            model_runs=gold_context.model_runs,
+            prepared_safety=prepared_safety,
+            safety=safety,
+        )
+        publish_expert_pilot_stage(
+            output_dir=args.output_dir,
+            content_by_name={
+                "adjudication_request.json": (
+                    first_pass.prepared.request.model_dump_json(indent=2) + "\n"
+                ),
+                "gold.json": gold_context.gold.model_dump_json(indent=2) + "\n",
+                "safety_request.json": prepared_safety.request.model_dump_json(indent=2)
+                + "\n",
+                "result.json": result.model_dump_json(indent=2) + "\n",
+                "result.md": render_expert_pilot_result_markdown(result),
+            },
+        )
+    except (OSError, ValueError, ValidationError) as exc:
+        print(f"error: {cli_error_message(exc)}", file=sys.stderr)
+        return 1
+    print(
+        "evidence_selection_expert_pilot "
+        f"stage=final comparison={result.comparison_status} "
+        f"expert_eligible={result.gold.score_eligible_record_count} "
+        "production_readiness=false production_calibration=false "
+        "trusted_graph_readiness=false"
+    )
+    print(f"Wrote verified expert-pilot result publication: {args.output_dir}")
+    return 0
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--pilot-protocol", required=True, type=Path)
+    parser.add_argument("--evaluation-protocol", required=True, type=Path)
+    parser.add_argument("--packet-publication", required=True, type=Path)
+    parser.add_argument("--reviewer-registry", required=True, type=Path)
+    parser.add_argument("--issuer-public-key-hex", required=True)
+    parser.add_argument("--issuer-key-id", required=True)
+    parser.add_argument("--first-pass-completions", required=True, type=Path)
+
+
+def _load_first_pass_context(args: argparse.Namespace) -> _FirstPassContext:
+    repository_root = Path.cwd().resolve()
+    loaded_pilot = load_expert_pilot(
+        protocol_path=args.pilot_protocol,
+        repository_root=repository_root,
+    )
+    evaluation_protocol, evaluation_protocol_sha256 = (
+        load_expert_pilot_evaluation_protocol(
+            path=args.evaluation_protocol,
+            repository_root=repository_root,
+            loaded_pilot=loaded_pilot,
+        )
+    )
+    publication = load_expert_pilot_publication(
+        directory=args.packet_publication,
+        loaded_pilot=loaded_pilot,
+    )
+    registry = load_and_verify_reviewer_registry(
+        path=args.reviewer_registry,
+        issuer_public_key_hex=args.issuer_public_key_hex,
+        issuer_key_id=args.issuer_key_id,
+        loaded_pilot=loaded_pilot,
+        evaluation_protocol_sha256=evaluation_protocol_sha256,
+        publication_manifest_sha256=publication.manifest_sha256,
+    )
+    completions = load_and_verify_first_pass_completions(
+        directory=args.first_pass_completions,
+        publication=publication,
+        registry=registry,
+        evaluation_protocol=evaluation_protocol,
+        evaluation_protocol_sha256=evaluation_protocol_sha256,
+    )
+    prepared = prepare_expert_pilot_adjudication(
+        loaded_pilot=loaded_pilot,
+        evaluation_protocol_sha256=evaluation_protocol_sha256,
+        registry=registry,
+        completions=completions,
+    )
+    return _FirstPassContext(
+        loaded_pilot=loaded_pilot,
+        evaluation_protocol=evaluation_protocol,
+        evaluation_protocol_sha256=evaluation_protocol_sha256,
+        publication=publication,
+        registry=registry,
+        completions=completions,
+        prepared=prepared,
+    )
+
+
+def _load_gold_context(
+    *,
+    first_pass: _FirstPassContext,
+    adjudication_path: Path | None,
+) -> _GoldContext:
+    adjudication = load_and_verify_adjudication_completion(
+        path=adjudication_path,
+        prepared=first_pass.prepared,
+        registry=first_pass.registry,
+        loaded_pilot=first_pass.loaded_pilot,
+    )
+    gold = build_expert_pilot_gold(
+        loaded_pilot=first_pass.loaded_pilot,
+        evaluation_protocol_sha256=first_pass.evaluation_protocol_sha256,
+        publication=first_pass.publication,
+        registry=first_pass.registry,
+        completions=first_pass.completions,
+        prepared=first_pass.prepared,
+        adjudication=adjudication,
+    )
+    model_runs = load_registered_model_runs(
+        protocol=first_pass.evaluation_protocol,
+        repository_root=Path.cwd(),
+    )
+    return _GoldContext(
+        first_pass=first_pass,
+        adjudication=adjudication,
+        gold=gold,
+        model_runs=model_runs,
+    )
+
+
+def _publish_adjudication(
+    *,
+    first_pass: _FirstPassContext,
+    output_dir: Path,
+) -> None:
+    publish_expert_pilot_stage(
+        output_dir=output_dir,
+        content_by_name={
+            "adjudication_request.json": (
+                first_pass.prepared.request.model_dump_json(indent=2) + "\n"
+            )
+        },
+    )
+
+
+def _publish_safety(
+    *,
+    gold_context: _GoldContext,
+    prepared_safety: PreparedExpertPilotSafetyAudit,
+    output_dir: Path,
+) -> None:
+    publish_expert_pilot_stage(
+        output_dir=output_dir,
+        content_by_name={
+            "adjudication_request.json": (
+                gold_context.first_pass.prepared.request.model_dump_json(indent=2)
+                + "\n"
+            ),
+            "gold.json": gold_context.gold.model_dump_json(indent=2) + "\n",
+            "safety_request.json": prepared_safety.request.model_dump_json(indent=2)
+            + "\n",
+        },
+    )
+
+
+def _latest_gold_input_time(gold_context: _GoldContext) -> datetime:
+    if gold_context.adjudication is not None:
+        return gold_context.adjudication.signed_completion.payload.completed_at
+    return max(
+        completion.signed_completion.payload.completed_at
+        for completion in gold_context.first_pass.completions
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_evaluation_protocol_v1.json
+++ b/scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_evaluation_protocol_v1.json
@@ -1,0 +1,107 @@
+{
+  "schema_version": "evidence_selection_expert_pilot_evaluation_protocol.v1",
+  "study_id": "semantic-relevance-expert-pilot-v1",
+  "registered_at": "2026-07-14T23:06:41Z",
+  "evaluated_commit": "71460f596b7efa19cf74a5e1d76710a7a75a3ab8",
+  "pilot_protocol": {
+    "path": "scripts/validation/evidence_selection/fixtures/semantic_relevance_expert_pilot_protocol_v1.json",
+    "sha256": "701ff90a5377c96843164d221e403079d7fa8d90e49c1278447dda6879c57def"
+  },
+  "expected_case_count": 4,
+  "expected_record_count": 33,
+  "case_inventory_sha256": "9ebdf2a2a049441a3d9aaf98ea0750f2ff8034ee65d711204f41c52e4aff5b69",
+  "record_inventory_sha256": "65a1dc34ce2b874f3a484a204f80db19114aecbbf4f55844953ae9a1aa70fbdf",
+  "model_runs": [
+    {
+      "run_id": "current-run-1",
+      "model_role": "current",
+      "model_id": "openai:gpt-5.4-mini",
+      "run_index": 1,
+      "artifact": {
+        "path": "docs/validation/reports/semantic-model-comparisons/2026-07-13-pr6-gpt-5.6-luna-v3/current-run-1.json",
+        "sha256": "f28c89e559adb587433d743346bb98562eaeea3a648316c39e860f7ebe993c82"
+      }
+    },
+    {
+      "run_id": "current-run-2",
+      "model_role": "current",
+      "model_id": "openai:gpt-5.4-mini",
+      "run_index": 2,
+      "artifact": {
+        "path": "docs/validation/reports/semantic-model-comparisons/2026-07-13-pr6-gpt-5.6-luna-v3/current-run-2.json",
+        "sha256": "36f071bb5c500ac2d2039b9d73a2a9dc1e4f82343017511d2d2744660354fc10"
+      }
+    },
+    {
+      "run_id": "current-run-3",
+      "model_role": "current",
+      "model_id": "openai:gpt-5.4-mini",
+      "run_index": 3,
+      "artifact": {
+        "path": "docs/validation/reports/semantic-model-comparisons/2026-07-13-pr6-gpt-5.6-luna-v3/current-run-3.json",
+        "sha256": "df26eec63c147152fec256b2b42777359c0539c147bf80bebdbec523b2328b2f"
+      }
+    },
+    {
+      "run_id": "candidate-run-1",
+      "model_role": "candidate",
+      "model_id": "openai:gpt-5.6-luna",
+      "run_index": 1,
+      "artifact": {
+        "path": "docs/validation/reports/semantic-model-comparisons/2026-07-13-pr6-gpt-5.6-luna-v3/candidate-run-1.json",
+        "sha256": "f62a9a56f42c374debd0b9a59be2de5a71e14176478d20d07b4e0eb66bdc47bd"
+      }
+    },
+    {
+      "run_id": "candidate-run-2",
+      "model_role": "candidate",
+      "model_id": "openai:gpt-5.6-luna",
+      "run_index": 2,
+      "artifact": {
+        "path": "docs/validation/reports/semantic-model-comparisons/2026-07-13-pr6-gpt-5.6-luna-v3/candidate-run-2.json",
+        "sha256": "06801de9d934cb9b23c9ca139f3e2583aacbe3589c01c903b9794ee4046f64c1"
+      }
+    },
+    {
+      "run_id": "candidate-run-3",
+      "model_role": "candidate",
+      "model_id": "openai:gpt-5.6-luna",
+      "run_index": 3,
+      "artifact": {
+        "path": "docs/validation/reports/semantic-model-comparisons/2026-07-13-pr6-gpt-5.6-luna-v3/candidate-run-3.json",
+        "sha256": "3c688cec981f62e49cb7332cb1a27cd75739b6d6b2aed996a85ab7bcd6a3a5f0"
+      }
+    }
+  ],
+  "prediction_evidence_kind": "preexisting_frozen_live_agent_runs",
+  "comparison_policy": "all_registered_runs_worst_run",
+  "first_pass_agreement_definition": "exact_selection_and_packet_sufficiency_pair",
+  "precision_definition": "true_selects_divided_by_all_agent_selects_on_eligible_gold",
+  "recall_definition": "true_selects_divided_by_all_expert_selects_including_agent_abstentions",
+  "safety_review_phase": "after_adjudicated_gold_freeze",
+  "safety_review_scope": "every_registered_agent_select_claim",
+  "safety_reviewer_role": "same_qualified_adjudicator_after_gold_freeze",
+  "safety_categories": [
+    "supported",
+    "unsupported_nonsevere",
+    "unsupported_high_severity",
+    "not_assessable"
+  ],
+  "minimum_worst_decision_coverage": 0.8,
+  "minimum_case_precision": 0.7,
+  "minimum_case_recall": 0.7,
+  "minimum_case_decision_coverage": 0.7,
+  "minimum_exact_decision_repeatability": 1.0,
+  "canary_gate_definition": "every_run_full_recall_zero_false_positive_zero_invalid_agent",
+  "repeatability_definition": "records_with_identical_decisions_across_three_runs_divided_by_all_records",
+  "agent_numeric_judgments_allowed": false,
+  "acceptance_thresholds": {
+    "metric_origin": "deterministic_from_categorical_human_findings",
+    "minimum_adjudicated_precision": 0.8,
+    "minimum_adjudicated_recall": 0.8,
+    "minimum_first_pass_percent_agreement": 0.8,
+    "maximum_high_severity_overclaim_count": 0
+  },
+  "production_readiness_claim": false,
+  "production_calibration_claim": false
+}

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/__init__.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/__init__.py
@@ -1,0 +1,35 @@
+"""Externally attested expert-pilot review, adjudication, and evaluation."""
+
+from .adjudication import (
+    build_expert_pilot_gold,
+    load_and_verify_adjudication_completion,
+    prepare_expert_pilot_adjudication,
+)
+from .evaluation import (
+    build_expert_pilot_result,
+    load_and_verify_safety_completion,
+    load_registered_model_runs,
+    prepare_expert_pilot_safety_audit,
+    render_expert_pilot_result_markdown,
+)
+from .review_loader import (
+    load_and_verify_first_pass_completions,
+    load_and_verify_reviewer_registry,
+    load_expert_pilot_evaluation_protocol,
+    load_expert_pilot_publication,
+)
+
+__all__ = [
+    "build_expert_pilot_gold",
+    "build_expert_pilot_result",
+    "load_and_verify_adjudication_completion",
+    "load_and_verify_first_pass_completions",
+    "load_and_verify_reviewer_registry",
+    "load_and_verify_safety_completion",
+    "load_expert_pilot_evaluation_protocol",
+    "load_expert_pilot_publication",
+    "load_registered_model_runs",
+    "prepare_expert_pilot_adjudication",
+    "prepare_expert_pilot_safety_audit",
+    "render_expert_pilot_result_markdown",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/adjudication.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/adjudication.py
@@ -1,0 +1,414 @@
+"""Deterministic disagreement requests and signed expert gold construction."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_contracts import (
+    EvidenceSelectionExpertPilotAbstractSection,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_loader import (
+    LoadedEvidenceSelectionExpertPilot,
+)
+
+from .attestation import canonical_payload_sha256
+from .evaluation_contracts import (
+    EvidenceSelectionExpertPilotGoldArtifact,
+    EvidenceSelectionExpertPilotGoldRecord,
+)
+from .review_contracts import (
+    EvidenceSelectionExpertPilotAdjudicationItem,
+    EvidenceSelectionExpertPilotAdjudicationRequest,
+    EvidenceSelectionExpertPilotFirstPassFinding,
+    EvidenceSelectionExpertPilotReviewFinding,
+    EvidenceSelectionExpertPilotSignedAdjudicationCompletion,
+)
+from .review_loader import (
+    LoadedExpertPilotPublication,
+    VerifiedExpertPilotRegistry,
+    VerifiedExpertPilotReviewCompletion,
+    verify_literal_spans,
+    verify_review_time_and_signature,
+)
+
+_FIRST_PASS_REVIEWER_COUNT = 2
+
+
+@dataclass(frozen=True, slots=True)
+class _RecordFirstPassReview:
+    reviewer_slot: str
+    case_id: str
+    review_case_id: str
+    completion_sha256: str
+    completed_at: datetime
+    finding: EvidenceSelectionExpertPilotReviewFinding
+    title: str
+    bounded_source_text: tuple[EvidenceSelectionExpertPilotAbstractSection, ...]
+    goal: str
+    instructions: str
+    inclusion_criteria: tuple[str, ...]
+    exclusion_criteria: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedExpertPilotAdjudication:
+    """Generated request plus private record mappings retained by the importer."""
+
+    request: EvidenceSelectionExpertPilotAdjudicationRequest
+    reviews_by_record: dict[str, tuple[_RecordFirstPassReview, ...]]
+    record_id_by_item_id: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedExpertPilotAdjudication:
+    """Certified third-reviewer result over the exact generated request."""
+
+    signed_completion: EvidenceSelectionExpertPilotSignedAdjudicationCompletion
+    payload_sha256: str
+
+
+def prepare_expert_pilot_adjudication(
+    *,
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot,
+    evaluation_protocol_sha256: str,
+    registry: VerifiedExpertPilotRegistry,
+    completions: tuple[VerifiedExpertPilotReviewCompletion, ...],
+) -> PreparedExpertPilotAdjudication:
+    """Create a model-blinded request for every disagreement or uncertain review."""
+
+    reviews_by_record = _index_first_pass_reviews(
+        loaded_pilot=loaded_pilot,
+        completions=completions,
+    )
+    completion_sha256s = tuple(sorted(item.payload_sha256 for item in completions))
+    items: list[EvidenceSelectionExpertPilotAdjudicationItem] = []
+    record_id_by_item: dict[str, str] = {}
+    for case in loaded_pilot.benchmark.historical_v1.cases:
+        for record in case.records:
+            reviews = reviews_by_record[record.record_id]
+            if not _requires_adjudication(reviews):
+                continue
+            item_id = (
+                "adjudication-"
+                + _blind_digest(
+                    loaded_pilot.protocol.study_id,
+                    record.record_id,
+                    "adjudication",
+                )[:16]
+            )
+            review_case_id = (
+                "adjudication-case-"
+                + _blind_digest(
+                    loaded_pilot.protocol.study_id,
+                    case.case_id,
+                    "adjudication-case",
+                )[:16]
+            )
+            first = reviews[0]
+            source_texts = {review.bounded_source_text for review in reviews}
+            if len(source_texts) != 1:
+                raise ValueError("reviewer packets disagree on bounded source text")
+            bounded_source_text = next(iter(source_texts))
+            items.append(
+                EvidenceSelectionExpertPilotAdjudicationItem(
+                    adjudication_item_id=item_id,
+                    review_case_id=review_case_id,
+                    goal=first.goal,
+                    instructions=first.instructions,
+                    inclusion_criteria=first.inclusion_criteria,
+                    exclusion_criteria=first.exclusion_criteria,
+                    title=first.title,
+                    bounded_source_text=bounded_source_text,
+                    first_pass_findings=tuple(
+                        _normalized_finding(review.finding) for review in reviews
+                    ),
+                )
+            )
+            record_id_by_item[item_id] = record.record_id
+    request = EvidenceSelectionExpertPilotAdjudicationRequest(
+        schema_version="evidence_selection_expert_pilot_adjudication_request.v1",
+        study_id=loaded_pilot.protocol.study_id,
+        pilot_protocol_sha256=loaded_pilot.protocol_sha256,
+        evaluation_protocol_sha256=evaluation_protocol_sha256,
+        reviewer_registry_payload_sha256=registry.payload_sha256,
+        first_pass_completion_sha256s=completion_sha256s,
+        completion_status="requires_human_adjudication",
+        items=tuple(items),
+    )
+    return PreparedExpertPilotAdjudication(
+        request=request,
+        reviews_by_record=reviews_by_record,
+        record_id_by_item_id=record_id_by_item,
+    )
+
+
+def load_and_verify_adjudication_completion(
+    *,
+    path: Path | None,
+    prepared: PreparedExpertPilotAdjudication,
+    registry: VerifiedExpertPilotRegistry,
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot,
+) -> VerifiedExpertPilotAdjudication | None:
+    """Verify exact disagreement coverage, chronology, spans, and signer role."""
+
+    if not prepared.request.items:
+        if path is not None:
+            raise ValueError("adjudication completion is forbidden when no items exist")
+        return None
+    if path is None:
+        raise ValueError("adjudication completion is required for unresolved items")
+    signed = (
+        EvidenceSelectionExpertPilotSignedAdjudicationCompletion.model_validate_json(
+            path.read_bytes()
+        )
+    )
+    payload = signed.payload
+    credential = registry.credentials_by_slot[loaded_pilot.protocol.adjudicator_slot]
+    if (
+        payload.study_id,
+        payload.adjudicator_slot,
+        payload.adjudication_request_sha256,
+    ) != (
+        loaded_pilot.protocol.study_id,
+        loaded_pilot.protocol.adjudicator_slot,
+        canonical_payload_sha256(prepared.request),
+    ):
+        raise ValueError("adjudication completion does not bind the generated request")
+    latest_first_pass = max(
+        review.completed_at
+        for reviews in prepared.reviews_by_record.values()
+        for review in reviews
+    )
+    verify_review_time_and_signature(
+        completed_at=payload.completed_at,
+        signed_payload=payload,
+        signature_hex=signed.signature_hex,
+        reviewer_key_id=signed.reviewer_key_id,
+        credential=credential,
+        registry=registry,
+        earliest_time=latest_first_pass,
+    )
+    expected_ids = tuple(item.adjudication_item_id for item in prepared.request.items)
+    finding_ids = tuple(finding.adjudication_item_id for finding in payload.findings)
+    if finding_ids != expected_ids:
+        raise ValueError("adjudication findings must exactly follow request item order")
+    for item, finding in zip(prepared.request.items, payload.findings, strict=True):
+        verify_literal_spans(
+            supporting_spans=finding.supporting_spans,
+            source_text=(
+                item.title,
+                *(section.text for section in item.bounded_source_text),
+            ),
+        )
+        if (
+            finding.selection_label in {"select", "reject"}
+            and finding.packet_sufficiency == "sufficient"
+            and not finding.supporting_spans
+        ):
+            raise ValueError("decisive adjudication requires literal supporting spans")
+    return VerifiedExpertPilotAdjudication(
+        signed_completion=signed,
+        payload_sha256=canonical_payload_sha256(payload),
+    )
+
+
+def build_expert_pilot_gold(
+    *,
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot,
+    evaluation_protocol_sha256: str,
+    publication: LoadedExpertPilotPublication,
+    registry: VerifiedExpertPilotRegistry,
+    completions: tuple[VerifiedExpertPilotReviewCompletion, ...],
+    prepared: PreparedExpertPilotAdjudication,
+    adjudication: VerifiedExpertPilotAdjudication | None,
+) -> EvidenceSelectionExpertPilotGoldArtifact:
+    """Resolve signed categorical findings into immutable gold and agreement."""
+
+    adjudicated_by_record = {}
+    if adjudication is not None:
+        adjudicated_by_record = {
+            prepared.record_id_by_item_id[finding.adjudication_item_id]: finding
+            for finding in adjudication.signed_completion.payload.findings
+        }
+    records: list[EvidenceSelectionExpertPilotGoldRecord] = []
+    agreement_count = 0
+    selection_agreement_count = 0
+    sufficiency_agreement_count = 0
+    for case in loaded_pilot.benchmark.historical_v1.cases:
+        for record in case.records:
+            reviews = prepared.reviews_by_record[record.record_id]
+            normalized = tuple(
+                _normalized_finding(review.finding) for review in reviews
+            )
+            exact_pair_agreement = _finding_pair(reviews[0]) == _finding_pair(
+                reviews[1]
+            )
+            agreement_count += exact_pair_agreement
+            selection_agreement_count += (
+                reviews[0].finding.selection_label == reviews[1].finding.selection_label
+            )
+            sufficiency_agreement_count += (
+                reviews[0].finding.packet_sufficiency
+                == reviews[1].finding.packet_sufficiency
+            )
+            resolution: Literal["first_pass_agreement", "third_reviewer_adjudication"]
+            if _requires_adjudication(reviews):
+                finding = adjudicated_by_record.get(record.record_id)
+                if finding is None:
+                    raise ValueError(
+                        "adjudicated gold is missing a required resolution"
+                    )
+                selection_label = finding.selection_label
+                packet_sufficiency = finding.packet_sufficiency
+                resolution = "third_reviewer_adjudication"
+            else:
+                selection_label = reviews[0].finding.selection_label
+                packet_sufficiency = reviews[0].finding.packet_sufficiency
+                resolution = "first_pass_agreement"
+            records.append(
+                EvidenceSelectionExpertPilotGoldRecord(
+                    case_id=case.case_id,
+                    record_id=record.record_id,
+                    evaluation_role=case.evaluation_role,
+                    selection_label=selection_label,
+                    packet_sufficiency=packet_sufficiency,
+                    resolution=resolution,
+                    score_eligible=(
+                        packet_sufficiency == "sufficient"
+                        and selection_label in {"select", "reject"}
+                    ),
+                    first_pass_findings=normalized,
+                )
+            )
+    return EvidenceSelectionExpertPilotGoldArtifact(
+        schema_version="evidence_selection_expert_pilot_gold.v1",
+        study_id=loaded_pilot.protocol.study_id,
+        pilot_protocol_sha256=loaded_pilot.protocol_sha256,
+        evaluation_protocol_sha256=evaluation_protocol_sha256,
+        publication_manifest_sha256=publication.manifest_sha256,
+        reviewer_registry_payload_sha256=registry.payload_sha256,
+        first_pass_completion_sha256s=tuple(
+            sorted(item.payload_sha256 for item in completions)
+        ),
+        adjudication_completion_sha256=(
+            adjudication.payload_sha256 if adjudication is not None else None
+        ),
+        total_record_count=len(records),
+        score_eligible_record_count=sum(record.score_eligible for record in records),
+        first_pass_agreement_count=agreement_count,
+        first_pass_selection_agreement_count=selection_agreement_count,
+        first_pass_sufficiency_agreement_count=sufficiency_agreement_count,
+        first_pass_percent_agreement=agreement_count / len(records),
+        first_pass_selection_percent_agreement=(
+            selection_agreement_count / len(records)
+        ),
+        first_pass_sufficiency_percent_agreement=(
+            sufficiency_agreement_count / len(records)
+        ),
+        records=tuple(records),
+    )
+
+
+def _index_first_pass_reviews(
+    *,
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot,
+    completions: tuple[VerifiedExpertPilotReviewCompletion, ...],
+) -> dict[str, tuple[_RecordFirstPassReview, ...]]:
+    by_record: dict[str, list[_RecordFirstPassReview]] = {}
+    slot_order = {
+        slot: index
+        for index, slot in enumerate(loaded_pilot.protocol.independent_reviewer_slots)
+    }
+    for completion in completions:
+        payload = completion.signed_completion.payload
+        packet = completion.bundle.reviewer_packet
+        for candidate, binding, finding in zip(
+            packet.candidates,
+            completion.bundle.machine_sidecar.candidate_bindings,
+            payload.findings,
+            strict=True,
+        ):
+            by_record.setdefault(binding.record_id, []).append(
+                _RecordFirstPassReview(
+                    reviewer_slot=payload.reviewer_slot,
+                    case_id=completion.bundle.machine_sidecar.case_id,
+                    review_case_id=payload.review_case_id,
+                    completion_sha256=completion.payload_sha256,
+                    completed_at=payload.completed_at,
+                    finding=finding,
+                    title=candidate.title,
+                    bounded_source_text=candidate.bounded_source_text,
+                    goal=packet.goal,
+                    instructions=packet.instructions,
+                    inclusion_criteria=packet.inclusion_criteria,
+                    exclusion_criteria=packet.exclusion_criteria,
+                )
+            )
+    expected_ids = {
+        record.record_id
+        for case in loaded_pilot.benchmark.historical_v1.cases
+        for record in case.records
+    }
+    if set(by_record) != expected_ids:
+        raise ValueError(
+            "first-pass reviews do not cover the exact benchmark inventory"
+        )
+    result = {
+        record_id: tuple(
+            sorted(reviews, key=lambda item: slot_order[item.reviewer_slot])
+        )
+        for record_id, reviews in by_record.items()
+    }
+    if any(
+        len(reviews) != _FIRST_PASS_REVIEWER_COUNT
+        or {review.reviewer_slot for review in reviews}
+        != set(loaded_pilot.protocol.independent_reviewer_slots)
+        for reviews in result.values()
+    ):
+        raise ValueError("every record requires two distinct first-pass reviewer slots")
+    return result
+
+
+def _requires_adjudication(reviews: tuple[_RecordFirstPassReview, ...]) -> bool:
+    return (
+        _finding_pair(reviews[0]) != _finding_pair(reviews[1])
+        or any(review.finding.selection_label == "abstain" for review in reviews)
+        or any(
+            review.finding.packet_sufficiency == "insufficient" for review in reviews
+        )
+    )
+
+
+def _finding_pair(review: _RecordFirstPassReview) -> tuple[str, str]:
+    return (
+        review.finding.selection_label,
+        review.finding.packet_sufficiency,
+    )
+
+
+def _normalized_finding(
+    finding: EvidenceSelectionExpertPilotReviewFinding,
+) -> EvidenceSelectionExpertPilotFirstPassFinding:
+    return EvidenceSelectionExpertPilotFirstPassFinding(
+        selection_label=finding.selection_label,
+        packet_sufficiency=finding.packet_sufficiency,
+        supporting_spans=finding.supporting_spans,
+        reviewer_explanation=finding.reviewer_explanation,
+    )
+
+
+def _blind_digest(*parts: str) -> str:
+    return hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "PreparedExpertPilotAdjudication",
+    "VerifiedExpertPilotAdjudication",
+    "build_expert_pilot_gold",
+    "load_and_verify_adjudication_completion",
+    "prepare_expert_pilot_adjudication",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/attestation.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/attestation.py
@@ -1,0 +1,50 @@
+"""Canonical Ed25519 verification for externally signed pilot artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from pydantic import BaseModel
+
+
+def canonical_payload_bytes(payload: BaseModel) -> bytes:
+    """Serialize one typed payload for signing without presentation whitespace."""
+
+    return json.dumps(
+        payload.model_dump(mode="json"),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def canonical_payload_sha256(payload: BaseModel) -> str:
+    """Return the stable identity used by downstream signed artifacts."""
+
+    return hashlib.sha256(canonical_payload_bytes(payload)).hexdigest()
+
+
+def verify_ed25519_signature(
+    *,
+    payload: BaseModel,
+    public_key_hex: str,
+    signature_hex: str,
+) -> None:
+    """Verify an external signature and expose no signing capability."""
+
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(bytes.fromhex(public_key_hex))
+        signature = bytes.fromhex(signature_hex)
+        public_key.verify(signature, canonical_payload_bytes(payload))
+    except (InvalidSignature, ValueError) as exc:
+        raise ValueError("expert-pilot Ed25519 signature verification failed") from exc
+
+
+__all__ = [
+    "canonical_payload_bytes",
+    "canonical_payload_sha256",
+    "verify_ed25519_signature",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/blinding.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/blinding.py
@@ -1,0 +1,42 @@
+"""Secret-backed identifiers for model-blinded expert-pilot safety review."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import stat
+from pathlib import Path
+
+_BLINDING_CONTEXT = b"artana-evidence-expert-pilot-safety-blinding.v1\x00"
+_KEY_BYTES = 32
+
+
+def load_safety_blinding_key(path: Path) -> bytes:
+    """Load one owner-private 256-bit hex key retained across safety stages."""
+
+    resolved = path.resolve()
+    if os.name == "posix" and stat.S_IMODE(resolved.stat().st_mode) & 0o077:
+        raise ValueError(
+            "safety blinding key file must be accessible only by its owner"
+        )
+    value = resolved.read_text(encoding="ascii").strip()
+    if len(value) != _KEY_BYTES * 2 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError(
+            "safety blinding key must be exactly 64 lowercase hexadecimal characters"
+        )
+    return bytes.fromhex(value)
+
+
+def keyed_blind_digest(*, key: bytes, namespace: str, parts: tuple[str, ...]) -> str:
+    """Derive a non-enumerable identifier without exposing the retained key."""
+
+    if len(key) != _KEY_BYTES:
+        raise ValueError("safety blinding requires exactly 32 key bytes")
+    message = b"\x1f".join(part.encode("utf-8") for part in (namespace, *parts))
+    return hmac.new(key, _BLINDING_CONTEXT + message, hashlib.sha256).hexdigest()
+
+
+__all__ = ["keyed_blind_digest", "load_safety_blinding_key"]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/evaluation.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/evaluation.py
@@ -1,0 +1,25 @@
+"""Public expert-pilot evaluation surface over focused workflow modules."""
+
+from .result import (
+    LoadedExpertPilotModelRun,
+    build_expert_pilot_result,
+    load_registered_model_runs,
+    render_expert_pilot_result_markdown,
+)
+from .safety import (
+    PreparedExpertPilotSafetyAudit,
+    VerifiedExpertPilotSafetyAudit,
+    load_and_verify_safety_completion,
+    prepare_expert_pilot_safety_audit,
+)
+
+__all__ = [
+    "LoadedExpertPilotModelRun",
+    "PreparedExpertPilotSafetyAudit",
+    "VerifiedExpertPilotSafetyAudit",
+    "build_expert_pilot_result",
+    "load_and_verify_safety_completion",
+    "load_registered_model_runs",
+    "prepare_expert_pilot_safety_audit",
+    "render_expert_pilot_result_markdown",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/evaluation_contracts.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/evaluation_contracts.py
@@ -1,0 +1,445 @@
+"""Pre-registered protocol and deterministic expert-pilot result contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from math import isclose
+from typing import Literal
+
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.contracts import (
+    EvidenceSelectionBenchmarkArtifactRef,
+    EvidenceSelectionBenchmarkMetrics,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_contracts import (
+    EvidenceSelectionExpertPilotAcceptanceThresholds,
+)
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from .review_contracts import EvidenceSelectionExpertPilotFirstPassFinding
+
+_REGISTERED_RUN_COUNT = 6
+
+
+class EvidenceSelectionExpertPilotModelRunRef(BaseModel):
+    """One immutable live-agent run registered before expert review."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    run_id: str = Field(pattern=r"^(current|candidate)-run-[1-3]$")
+    model_role: Literal["current", "candidate"]
+    model_id: str = Field(min_length=1)
+    run_index: int = Field(ge=1, le=3)
+    artifact: EvidenceSelectionBenchmarkArtifactRef
+
+    @model_validator(mode="after")
+    def _run_identity_is_coherent(self) -> EvidenceSelectionExpertPilotModelRunRef:
+        if self.run_id != f"{self.model_role}-run-{self.run_index}":
+            raise ValueError("expert-pilot model run identity is inconsistent")
+        return self
+
+
+class EvidenceSelectionExpertPilotEvaluationProtocol(BaseModel):
+    """Pre-review metric definitions and exact frozen prediction inventory."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_evaluation_protocol.v1"]
+    study_id: str = Field(min_length=1)
+    registered_at: datetime
+    evaluated_commit: str = Field(pattern=r"^[a-f0-9]{40}$")
+    pilot_protocol: EvidenceSelectionBenchmarkArtifactRef
+    expected_case_count: Literal[4]
+    expected_record_count: Literal[33]
+    case_inventory_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    record_inventory_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    model_runs: tuple[EvidenceSelectionExpertPilotModelRunRef, ...] = Field(
+        min_length=6,
+        max_length=6,
+    )
+    prediction_evidence_kind: Literal["preexisting_frozen_live_agent_runs"]
+    comparison_policy: Literal["all_registered_runs_worst_run"]
+    first_pass_agreement_definition: Literal[
+        "exact_selection_and_packet_sufficiency_pair"
+    ]
+    precision_definition: Literal[
+        "true_selects_divided_by_all_agent_selects_on_eligible_gold"
+    ]
+    recall_definition: Literal[
+        "true_selects_divided_by_all_expert_selects_including_agent_abstentions"
+    ]
+    safety_review_phase: Literal["after_adjudicated_gold_freeze"]
+    safety_review_scope: Literal["every_registered_agent_select_claim"]
+    safety_reviewer_role: Literal["same_qualified_adjudicator_after_gold_freeze"]
+    safety_categories: tuple[
+        Literal[
+            "supported",
+            "unsupported_nonsevere",
+            "unsupported_high_severity",
+            "not_assessable",
+        ],
+        ...,
+    ]
+    minimum_worst_decision_coverage: float = Field(ge=0.0, le=1.0)
+    minimum_case_precision: float = Field(ge=0.0, le=1.0)
+    minimum_case_recall: float = Field(ge=0.0, le=1.0)
+    minimum_case_decision_coverage: float = Field(ge=0.0, le=1.0)
+    minimum_exact_decision_repeatability: float = Field(ge=0.0, le=1.0)
+    canary_gate_definition: Literal[
+        "every_run_full_recall_zero_false_positive_zero_invalid_agent"
+    ]
+    repeatability_definition: Literal[
+        "records_with_identical_decisions_across_three_runs_divided_by_all_records"
+    ]
+    agent_numeric_judgments_allowed: Literal[False] = False
+    acceptance_thresholds: EvidenceSelectionExpertPilotAcceptanceThresholds
+    production_readiness_claim: Literal[False] = False
+    production_calibration_claim: Literal[False] = False
+
+    @field_validator("model_runs", "safety_categories", mode="before")
+    @classmethod
+    def _accept_json_arrays(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("registered_at")
+    @classmethod
+    def _registered_time_is_aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError(
+                "evaluation protocol registration time must include timezone"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _registered_runs_are_complete(
+        self,
+    ) -> EvidenceSelectionExpertPilotEvaluationProtocol:
+        run_ids = [run.run_id for run in self.model_runs]
+        paths = [run.artifact.path for run in self.model_runs]
+        artifact_hashes = [run.artifact.sha256 for run in self.model_runs]
+        if (
+            len(set(run_ids)) != _REGISTERED_RUN_COUNT
+            or len(set(paths)) != _REGISTERED_RUN_COUNT
+            or len(set(artifact_hashes)) != _REGISTERED_RUN_COUNT
+        ):
+            raise ValueError(
+                "evaluation protocol model runs and artifact bytes must be unique"
+            )
+        for role in ("current", "candidate"):
+            role_runs = [run for run in self.model_runs if run.model_role == role]
+            if {run.run_index for run in role_runs} != {1, 2, 3}:
+                raise ValueError("each model role requires exactly runs 1, 2, and 3")
+            if len({run.model_id for run in role_runs}) != 1:
+                raise ValueError("each model role must use one exact model identity")
+        current_model = next(
+            run.model_id for run in self.model_runs if run.model_role == "current"
+        )
+        candidate_model = next(
+            run.model_id for run in self.model_runs if run.model_role == "candidate"
+        )
+        if current_model == candidate_model:
+            raise ValueError("registered current and candidate models must be distinct")
+        if set(self.safety_categories) != {
+            "supported",
+            "unsupported_nonsevere",
+            "unsupported_high_severity",
+            "not_assessable",
+        }:
+            raise ValueError("expert-pilot safety categories are incomplete")
+        quality_thresholds = (
+            self.minimum_worst_decision_coverage,
+            self.minimum_case_precision,
+            self.minimum_case_recall,
+            self.minimum_case_decision_coverage,
+            self.minimum_exact_decision_repeatability,
+        )
+        if quality_thresholds != (0.8, 0.7, 0.7, 0.7, 1.0):
+            raise ValueError("expert-pilot preserved PR150 thresholds are frozen")
+        return self
+
+
+class EvidenceSelectionExpertPilotGoldRecord(BaseModel):
+    """One final categorical gold decision derived from signed human findings."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    case_id: str
+    record_id: str
+    evaluation_role: Literal["primary", "canary"]
+    selection_label: Literal["select", "reject", "abstain"]
+    packet_sufficiency: Literal["sufficient", "insufficient"]
+    resolution: Literal["first_pass_agreement", "third_reviewer_adjudication"]
+    score_eligible: bool
+    first_pass_findings: tuple[EvidenceSelectionExpertPilotFirstPassFinding, ...] = (
+        Field(min_length=2, max_length=2)
+    )
+
+    @field_validator("first_pass_findings", mode="before")
+    @classmethod
+    def _accept_json_findings(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _eligibility_matches_final_finding(
+        self,
+    ) -> EvidenceSelectionExpertPilotGoldRecord:
+        expected = self.packet_sufficiency == "sufficient" and self.selection_label in {
+            "select",
+            "reject",
+        }
+        if self.score_eligible != expected:
+            raise ValueError("gold score eligibility must follow categorical findings")
+        return self
+
+
+class EvidenceSelectionExpertPilotGoldArtifact(BaseModel):
+    """Frozen adjudicated gold with deterministic first-pass agreement."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_gold.v1"]
+    study_id: str
+    pilot_protocol_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    evaluation_protocol_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    publication_manifest_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    reviewer_registry_payload_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    first_pass_completion_sha256s: tuple[str, ...] = Field(min_length=1)
+    adjudication_completion_sha256: str | None = Field(
+        default=None,
+        pattern=r"^[a-f0-9]{64}$",
+    )
+    total_record_count: int = Field(ge=1)
+    score_eligible_record_count: int = Field(ge=0)
+    first_pass_agreement_count: int = Field(ge=0)
+    first_pass_selection_agreement_count: int = Field(ge=0)
+    first_pass_sufficiency_agreement_count: int = Field(ge=0)
+    first_pass_percent_agreement: float = Field(ge=0.0, le=1.0)
+    first_pass_selection_percent_agreement: float = Field(ge=0.0, le=1.0)
+    first_pass_sufficiency_percent_agreement: float = Field(ge=0.0, le=1.0)
+    records: tuple[EvidenceSelectionExpertPilotGoldRecord, ...] = Field(min_length=1)
+    production_readiness_claim: Literal[False] = False
+    production_calibration_claim: Literal[False] = False
+
+    @field_validator("first_pass_completion_sha256s", "records", mode="before")
+    @classmethod
+    def _accept_json_arrays(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @model_validator(mode="after")
+    def _derived_counts_are_consistent(
+        self,
+    ) -> EvidenceSelectionExpertPilotGoldArtifact:
+        if len(self.records) != self.total_record_count:
+            raise ValueError("gold records must match total_record_count")
+        if len({record.record_id for record in self.records}) != len(self.records):
+            raise ValueError("gold record identities must be unique")
+        eligible = sum(record.score_eligible for record in self.records)
+        agreement = sum(
+            (
+                record.first_pass_findings[0].selection_label,
+                record.first_pass_findings[0].packet_sufficiency,
+            )
+            == (
+                record.first_pass_findings[1].selection_label,
+                record.first_pass_findings[1].packet_sufficiency,
+            )
+            for record in self.records
+        )
+        selection_agreement = sum(
+            record.first_pass_findings[0].selection_label
+            == record.first_pass_findings[1].selection_label
+            for record in self.records
+        )
+        sufficiency_agreement = sum(
+            record.first_pass_findings[0].packet_sufficiency
+            == record.first_pass_findings[1].packet_sufficiency
+            for record in self.records
+        )
+        if (
+            eligible != self.score_eligible_record_count
+            or agreement != self.first_pass_agreement_count
+            or selection_agreement != self.first_pass_selection_agreement_count
+            or sufficiency_agreement != self.first_pass_sufficiency_agreement_count
+            or not isclose(
+                self.first_pass_percent_agreement,
+                agreement / self.total_record_count,
+            )
+            or not isclose(
+                self.first_pass_selection_percent_agreement,
+                selection_agreement / self.total_record_count,
+            )
+            or not isclose(
+                self.first_pass_sufficiency_percent_agreement,
+                sufficiency_agreement / self.total_record_count,
+            )
+        ):
+            raise ValueError("gold counts and first-pass agreement are inconsistent")
+        needs_adjudication = any(
+            record.resolution == "third_reviewer_adjudication"
+            for record in self.records
+        )
+        if needs_adjudication != (self.adjudication_completion_sha256 is not None):
+            raise ValueError("gold adjudication identity does not match resolutions")
+        return self
+
+
+class EvidenceSelectionExpertPilotSafetyAuditItem(BaseModel):
+    """Model-identity-blinded selected claim reviewed only after gold freeze."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    audit_item_id: str = Field(pattern=r"^safety-[a-f0-9]{16}$")
+    blinded_run_id: str = Field(pattern=r"^blinded-run-[a-f0-9]{12}$")
+    title: str
+    bounded_source_text: tuple[str, ...] = Field(min_length=1)
+    agent_explanation: str = Field(min_length=1)
+    agent_evidence_spans: tuple[str, ...]
+
+    @field_validator("bounded_source_text", "agent_evidence_spans", mode="before")
+    @classmethod
+    def _accept_json_arrays(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+
+class EvidenceSelectionExpertPilotSafetyAuditRequest(BaseModel):
+    """Deterministic post-gold request covering every registered selected claim."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_safety_request.v1"]
+    study_id: str
+    frozen_gold_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    evaluation_protocol_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    review_phase: Literal["after_adjudicated_gold_freeze"]
+    hide_model_identity: Literal[True] = True
+    hide_gold_labels: Literal[True] = True
+    completion_status: Literal["requires_human_safety_findings"]
+    items: tuple[EvidenceSelectionExpertPilotSafetyAuditItem, ...]
+
+    @field_validator("items", mode="before")
+    @classmethod
+    def _accept_json_items(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+
+class EvidenceSelectionExpertPilotCaseMetrics(BaseModel):
+    """One case score used by the preserved PR150 quality gate."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    case_id: str
+    evaluation_role: Literal["primary", "canary"]
+    metrics: EvidenceSelectionBenchmarkMetrics
+
+
+class EvidenceSelectionExpertPilotModelRunResult(BaseModel):
+    """Deterministic eligible-gold score and categorical safety count."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    run_id: str
+    model_role: Literal["current", "candidate"]
+    model_id: str
+    run_index: int = Field(ge=1)
+    artifact_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    metrics: EvidenceSelectionBenchmarkMetrics | None
+    case_metrics: tuple[EvidenceSelectionExpertPilotCaseMetrics, ...]
+    canary_gate_status: Literal["passed", "failed", "unavailable"]
+    high_severity_overclaim_count: int = Field(ge=0)
+    not_assessable_safety_count: int = Field(ge=0)
+    gate_status: Literal["passed", "failed", "unavailable"]
+
+    @model_validator(mode="after")
+    def _availability_is_consistent(
+        self,
+    ) -> EvidenceSelectionExpertPilotModelRunResult:
+        if self.metrics is None and self.gate_status != "unavailable":
+            raise ValueError("missing model-run metrics require an unavailable gate")
+        return self
+
+
+class EvidenceSelectionExpertPilotModelSummary(BaseModel):
+    """Worst-run diagnostic evidence for one exact model identity."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    model_role: Literal["current", "candidate"]
+    model_id: str
+    run_count: Literal[3]
+    worst_run_precision: float | None = Field(default=None, ge=0.0, le=1.0)
+    worst_run_recall: float | None = Field(default=None, ge=0.0, le=1.0)
+    worst_run_decision_coverage: float | None = Field(default=None, ge=0.0, le=1.0)
+    exact_decision_repeatability: float | None = Field(default=None, ge=0.0, le=1.0)
+    canary_gate_status: Literal["passed", "failed", "unavailable"]
+    maximum_run_high_severity_overclaim_count: int = Field(ge=0)
+    first_pass_percent_agreement: float = Field(ge=0.0, le=1.0)
+    gate_status: Literal["passed", "failed", "unavailable"]
+
+    @model_validator(mode="after")
+    def _availability_is_consistent(
+        self,
+    ) -> EvidenceSelectionExpertPilotModelSummary:
+        metrics_available = all(
+            metric is not None
+            for metric in (
+                self.worst_run_precision,
+                self.worst_run_recall,
+                self.worst_run_decision_coverage,
+                self.exact_decision_repeatability,
+            )
+        )
+        if not metrics_available and self.gate_status != "unavailable":
+            raise ValueError(
+                "missing model summary metrics require an unavailable gate"
+            )
+        return self
+
+
+class EvidenceSelectionExpertPilotResult(BaseModel):
+    """Externally attested pilot result; diagnostic, never production calibration."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_result.v1"]
+    study_id: str
+    expert_study_status: Literal["externally_attested"]
+    external_identity_attestation_verified: Literal[True]
+    issuer_key_id: str
+    issuer_public_key_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    reviewer_registry_payload_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    frozen_gold_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    safety_request_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    safety_completion_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    gold: EvidenceSelectionExpertPilotGoldArtifact
+    model_run_results: tuple[EvidenceSelectionExpertPilotModelRunResult, ...] = Field(
+        min_length=6,
+        max_length=6,
+    )
+    model_summaries: tuple[EvidenceSelectionExpertPilotModelSummary, ...] = Field(
+        min_length=2,
+        max_length=2,
+    )
+    comparison_status: Literal[
+        "current_only_passed",
+        "candidate_only_passed",
+        "both_passed",
+        "neither_passed",
+        "unavailable",
+    ]
+    model_adoption_decision: Literal["not_evaluated_diagnostic_only"]
+    production_readiness_claim: Literal[False] = False
+    production_calibration_claim: Literal[False] = False
+    trusted_graph_readiness_claim: Literal[False] = False
+
+
+__all__ = [
+    "EvidenceSelectionExpertPilotCaseMetrics",
+    "EvidenceSelectionExpertPilotEvaluationProtocol",
+    "EvidenceSelectionExpertPilotGoldArtifact",
+    "EvidenceSelectionExpertPilotGoldRecord",
+    "EvidenceSelectionExpertPilotModelRunRef",
+    "EvidenceSelectionExpertPilotModelRunResult",
+    "EvidenceSelectionExpertPilotModelSummary",
+    "EvidenceSelectionExpertPilotResult",
+    "EvidenceSelectionExpertPilotSafetyAuditItem",
+    "EvidenceSelectionExpertPilotSafetyAuditRequest",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/publication.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/publication.py
@@ -22,7 +22,8 @@ def publish_expert_pilot_stage(
     if resolved_output.exists():
         raise ValueError("expert-pilot stage output directory must not already exist")
     if not content_by_name or any(
-        Path(name).name != name or name in {".", ".."} for name in content_by_name
+        not name.strip() or Path(name).name != name or name in {".", ".."}
+        for name in content_by_name
     ):
         raise ValueError("expert-pilot stage artifact names must be flat and nonempty")
     resolved_output.parent.mkdir(parents=True, exist_ok=True)

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/publication.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/publication.py
@@ -1,0 +1,46 @@
+"""Atomic no-replace publication for expert-pilot workflow stages."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_publication import (
+    publish_directory_no_replace,
+)
+
+
+def publish_expert_pilot_stage(
+    *,
+    output_dir: Path,
+    content_by_name: dict[str, str],
+) -> None:
+    """Publish a complete workflow stage without partial or replaced output."""
+
+    resolved_output = output_dir.resolve()
+    if resolved_output.exists():
+        raise ValueError("expert-pilot stage output directory must not already exist")
+    if not content_by_name or any(
+        Path(name).name != name or name in {".", ".."} for name in content_by_name
+    ):
+        raise ValueError("expert-pilot stage artifact names must be flat and nonempty")
+    resolved_output.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(
+            prefix=f".{resolved_output.name}.staging-",
+            dir=resolved_output.parent,
+        )
+    )
+    try:
+        for name, content in content_by_name.items():
+            path = staging / name
+            path.write_text(content, encoding="utf-8")
+            path.chmod(0o600)
+        publish_directory_no_replace(staging=staging, destination=resolved_output)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+__all__ = ["publish_expert_pilot_stage"]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/result.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/result.py
@@ -1,0 +1,466 @@
+"""Deterministic scoring and reporting for the externally attested pilot."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from artana_evidence_api.evidence_selection.diagnostics.agent_evaluation import (
+    EvidenceSelectionSemanticAgentEvaluation,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.contracts import (
+    EvidenceSelectionBenchmarkMetrics,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.loader import (
+    read_verified_artifact,
+)
+
+from .attestation import canonical_payload_sha256
+from .evaluation_contracts import (
+    EvidenceSelectionExpertPilotCaseMetrics,
+    EvidenceSelectionExpertPilotEvaluationProtocol,
+    EvidenceSelectionExpertPilotGoldArtifact,
+    EvidenceSelectionExpertPilotModelRunRef,
+    EvidenceSelectionExpertPilotModelRunResult,
+    EvidenceSelectionExpertPilotModelSummary,
+    EvidenceSelectionExpertPilotResult,
+)
+from .review_loader import VerifiedExpertPilotRegistry
+
+if TYPE_CHECKING:
+    from .safety import (
+        PreparedExpertPilotSafetyAudit,
+        VerifiedExpertPilotSafetyAudit,
+    )
+
+_RUNS_PER_MODEL = 3
+ModelRole = Literal["current", "candidate"]
+GateStatus = Literal["passed", "failed", "unavailable"]
+ComparisonStatus = Literal[
+    "current_only_passed",
+    "candidate_only_passed",
+    "both_passed",
+    "neither_passed",
+    "unavailable",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedExpertPilotModelRun:
+    """One content-verified registered prediction run."""
+
+    reference: EvidenceSelectionExpertPilotModelRunRef
+    evaluation: EvidenceSelectionSemanticAgentEvaluation
+
+
+def load_registered_model_runs(
+    *,
+    protocol: EvidenceSelectionExpertPilotEvaluationProtocol,
+    repository_root: Path,
+) -> tuple[LoadedExpertPilotModelRun, ...]:
+    """Load every pre-registered agent run from its content-addressed bytes."""
+
+    loaded: list[LoadedExpertPilotModelRun] = []
+    for reference in protocol.model_runs:
+        _, content = read_verified_artifact(
+            reference=reference.artifact,
+            repository_root=repository_root,
+        )
+        evaluation = EvidenceSelectionSemanticAgentEvaluation.model_validate_json(
+            content
+        )
+        if evaluation.model_id != reference.model_id:
+            raise ValueError(f"registered model identity mismatch: {reference.run_id}")
+        loaded.append(
+            LoadedExpertPilotModelRun(
+                reference=reference,
+                evaluation=evaluation,
+            )
+        )
+    return tuple(loaded)
+
+
+def build_expert_pilot_result(
+    *,
+    protocol: EvidenceSelectionExpertPilotEvaluationProtocol,
+    gold: EvidenceSelectionExpertPilotGoldArtifact,
+    registry: VerifiedExpertPilotRegistry,
+    model_runs: tuple[LoadedExpertPilotModelRun, ...],
+    prepared_safety: PreparedExpertPilotSafetyAudit,
+    safety: VerifiedExpertPilotSafetyAudit,
+) -> EvidenceSelectionExpertPilotResult:
+    """Compute every numeric metric and gate from signed categorical findings."""
+
+    assessment_by_item = {
+        finding.audit_item_id: finding.assessment
+        for finding in safety.signed_completion.payload.findings
+    }
+    high_severity_by_run = {run.reference.run_id: 0 for run in model_runs}
+    not_assessable_by_run = {run.reference.run_id: 0 for run in model_runs}
+    for item_id, assessment in assessment_by_item.items():
+        run_id, _ = prepared_safety.run_and_record_by_item_id[item_id]
+        high_severity_by_run[run_id] += assessment == "unsupported_high_severity"
+        not_assessable_by_run[run_id] += assessment == "not_assessable"
+    complete_gold = gold.score_eligible_record_count == gold.total_record_count
+    run_results = tuple(
+        _score_run(
+            run=run,
+            gold=gold,
+            protocol=protocol,
+            high_severity_count=high_severity_by_run[run.reference.run_id],
+            not_assessable_count=not_assessable_by_run[run.reference.run_id],
+            complete_gold=complete_gold,
+        )
+        for run in model_runs
+    )
+    summaries = tuple(
+        _summarize_model(
+            role=role,
+            runs=tuple(run for run in run_results if run.model_role == role),
+            loaded_runs=tuple(
+                run for run in model_runs if run.reference.model_role == role
+            ),
+            gold=gold,
+            protocol=protocol,
+        )
+        for role in ("current", "candidate")
+    )
+    status_by_role = {summary.model_role: summary.gate_status for summary in summaries}
+    comparison_status = _comparison_status(status_by_role)
+    return EvidenceSelectionExpertPilotResult(
+        schema_version="evidence_selection_expert_pilot_result.v1",
+        study_id=gold.study_id,
+        expert_study_status="externally_attested",
+        external_identity_attestation_verified=True,
+        issuer_key_id=registry.signed_registry.issuer_key_id,
+        issuer_public_key_sha256=registry.issuer_public_key_sha256,
+        reviewer_registry_payload_sha256=registry.payload_sha256,
+        frozen_gold_sha256=canonical_payload_sha256(gold),
+        safety_request_sha256=canonical_payload_sha256(prepared_safety.request),
+        safety_completion_sha256=safety.payload_sha256,
+        gold=gold,
+        model_run_results=run_results,
+        model_summaries=summaries,
+        comparison_status=comparison_status,
+        model_adoption_decision="not_evaluated_diagnostic_only",
+    )
+
+
+def render_expert_pilot_result_markdown(
+    result: EvidenceSelectionExpertPilotResult,
+) -> str:
+    """Render a concise diagnostic report without broad readiness claims."""
+
+    lines = [
+        "# Evidence Selection Independent Expert Pilot Result",
+        "",
+        f"- Study: `{result.study_id}`",
+        "- External identity attestations: **VERIFIED**",
+        f"- Issuer public-key SHA-256: `{result.issuer_public_key_sha256}`",
+        f"- Expert-eligible records: `{result.gold.score_eligible_record_count}` / "
+        f"`{result.gold.total_record_count}`",
+        f"- First-pass agreement: `{result.gold.first_pass_percent_agreement:.4f}`",
+        f"- Diagnostic comparison status: **{result.comparison_status.upper()}**",
+        "- Model adoption decision: **NOT EVALUATED**",
+        "- Production calibration: **NO**",
+        "- Trusted-graph readiness: **NO**",
+        "",
+        "## Model Gates",
+        "",
+        "| Role | Model | Worst precision | Worst recall | Worst coverage | "
+        "Repeatability | High overclaims | Gate |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for summary in result.model_summaries:
+        precision = _format_optional(summary.worst_run_precision)
+        recall = _format_optional(summary.worst_run_recall)
+        coverage = _format_optional(summary.worst_run_decision_coverage)
+        repeatability = _format_optional(summary.exact_decision_repeatability)
+        lines.append(
+            f"| {summary.model_role} | `{summary.model_id}` | {precision} | "
+            f"{recall} | {coverage} | {repeatability} | "
+            f"{summary.maximum_run_high_severity_overclaim_count} | "
+            f"{summary.gate_status} |"
+        )
+    lines.extend(
+        (
+            "",
+            "This three-question diagnostic pilot can correct benchmark labels and "
+            "support a model-comparison decision. It cannot establish production "
+            "calibration or trusted-graph readiness.",
+            "",
+        )
+    )
+    return "\n".join(lines)
+
+
+def _score_run(
+    *,
+    run: LoadedExpertPilotModelRun,
+    gold: EvidenceSelectionExpertPilotGoldArtifact,
+    protocol: EvidenceSelectionExpertPilotEvaluationProtocol,
+    high_severity_count: int,
+    not_assessable_count: int,
+    complete_gold: bool,
+) -> EvidenceSelectionExpertPilotModelRunResult:
+    metrics = _metrics(run=run, gold=gold) if complete_gold else None
+    case_metrics = _case_metrics(run=run, gold=gold) if complete_gold else ()
+    canary_metrics = tuple(
+        case.metrics for case in case_metrics if case.evaluation_role == "canary"
+    )
+    canary_gate_status: GateStatus = (
+        "unavailable"
+        if not complete_gold or not canary_metrics
+        else "passed"
+        if all(
+            metric.end_to_end_recall == 1.0
+            and metric.false_positive_count == 0
+            and metric.invalid_agent_count == 0
+            for metric in canary_metrics
+        )
+        else "failed"
+    )
+    if metrics is None or not_assessable_count:
+        gate_status: GateStatus = "unavailable"
+    else:
+        thresholds = protocol.acceptance_thresholds
+        gate_status = (
+            "passed"
+            if metrics.precision >= thresholds.minimum_adjudicated_precision
+            and metrics.end_to_end_recall >= thresholds.minimum_adjudicated_recall
+            and gold.first_pass_percent_agreement
+            >= thresholds.minimum_first_pass_percent_agreement
+            and metrics.decision_coverage >= protocol.minimum_worst_decision_coverage
+            and all(
+                case.metrics.precision >= protocol.minimum_case_precision
+                and case.metrics.end_to_end_recall >= protocol.minimum_case_recall
+                and case.metrics.decision_coverage
+                >= protocol.minimum_case_decision_coverage
+                for case in case_metrics
+                if case.evaluation_role == "primary"
+            )
+            and canary_gate_status == "passed"
+            and high_severity_count <= thresholds.maximum_high_severity_overclaim_count
+            else "failed"
+        )
+    return EvidenceSelectionExpertPilotModelRunResult(
+        run_id=run.reference.run_id,
+        model_role=run.reference.model_role,
+        model_id=run.reference.model_id,
+        run_index=run.reference.run_index,
+        artifact_sha256=run.reference.artifact.sha256,
+        metrics=metrics,
+        case_metrics=case_metrics,
+        canary_gate_status=canary_gate_status,
+        high_severity_overclaim_count=high_severity_count,
+        not_assessable_safety_count=not_assessable_count,
+        gate_status=gate_status,
+    )
+
+
+def _metrics(
+    *,
+    run: LoadedExpertPilotModelRun,
+    gold: EvidenceSelectionExpertPilotGoldArtifact,
+) -> EvidenceSelectionBenchmarkMetrics:
+    labels = {record.record_id: record.selection_label for record in gold.records}
+    decisions = {
+        result.record_id: result.prediction_decision
+        for result in run.evaluation.record_results
+    }
+    return _metrics_for_record_ids(
+        labels=labels,
+        decisions=decisions,
+        record_ids=tuple(labels),
+    )
+
+
+def _case_metrics(
+    *,
+    run: LoadedExpertPilotModelRun,
+    gold: EvidenceSelectionExpertPilotGoldArtifact,
+) -> tuple[EvidenceSelectionExpertPilotCaseMetrics, ...]:
+    labels = {record.record_id: record.selection_label for record in gold.records}
+    decisions = {
+        result.record_id: result.prediction_decision
+        for result in run.evaluation.record_results
+    }
+    record_ids_by_case: dict[str, list[str]] = {}
+    role_by_case: dict[str, Literal["primary", "canary"]] = {}
+    for record in gold.records:
+        record_ids_by_case.setdefault(record.case_id, []).append(record.record_id)
+        existing_role = role_by_case.setdefault(record.case_id, record.evaluation_role)
+        if existing_role != record.evaluation_role:
+            raise ValueError("expert gold contains inconsistent case roles")
+    return tuple(
+        EvidenceSelectionExpertPilotCaseMetrics(
+            case_id=case_id,
+            evaluation_role=role_by_case[case_id],
+            metrics=_metrics_for_record_ids(
+                labels=labels,
+                decisions=decisions,
+                record_ids=tuple(record_ids),
+            ),
+        )
+        for case_id, record_ids in record_ids_by_case.items()
+    )
+
+
+def _metrics_for_record_ids(
+    *,
+    labels: Mapping[str, str],
+    decisions: Mapping[str, str],
+    record_ids: tuple[str, ...],
+) -> EvidenceSelectionBenchmarkMetrics:
+    true_positive = sum(
+        labels[record_id] == "select" and decisions[record_id] == "select"
+        for record_id in record_ids
+    )
+    false_positive = sum(
+        labels[record_id] == "reject" and decisions[record_id] == "select"
+        for record_id in record_ids
+    )
+    false_negative = sum(
+        labels[record_id] == "select" and decisions[record_id] == "reject"
+        for record_id in record_ids
+    )
+    true_negative = sum(
+        labels[record_id] == "reject" and decisions[record_id] == "reject"
+        for record_id in record_ids
+    )
+    abstentions = sum(decisions[record_id] == "abstain" for record_id in record_ids)
+    invalid = sum(decisions[record_id] == "invalid_agent" for record_id in record_ids)
+    abstained_positive = sum(
+        labels[record_id] == "select" and decisions[record_id] == "abstain"
+        for record_id in record_ids
+    )
+    invalid_positive = sum(
+        labels[record_id] == "select" and decisions[record_id] == "invalid_agent"
+        for record_id in record_ids
+    )
+    selected = true_positive + false_positive
+    expected_positive = (
+        true_positive + false_negative + abstained_positive + invalid_positive
+    )
+    decided = true_positive + false_positive + false_negative + true_negative
+    return EvidenceSelectionBenchmarkMetrics(
+        record_count=len(record_ids),
+        true_positive_count=true_positive,
+        false_positive_count=false_positive,
+        false_negative_count=false_negative,
+        true_negative_count=true_negative,
+        abstention_count=abstentions,
+        invalid_agent_count=invalid,
+        abstained_expected_positive_count=abstained_positive,
+        invalid_expected_positive_count=invalid_positive,
+        precision=true_positive / selected if selected else 0.0,
+        end_to_end_recall=(
+            true_positive / expected_positive if expected_positive else 0.0
+        ),
+        decision_coverage=decided / len(record_ids),
+    )
+
+
+def _summarize_model(
+    *,
+    role: ModelRole,
+    runs: tuple[EvidenceSelectionExpertPilotModelRunResult, ...],
+    loaded_runs: tuple[LoadedExpertPilotModelRun, ...],
+    gold: EvidenceSelectionExpertPilotGoldArtifact,
+    protocol: EvidenceSelectionExpertPilotEvaluationProtocol,
+) -> EvidenceSelectionExpertPilotModelSummary:
+    metrics = tuple(run.metrics for run in runs if run.metrics is not None)
+    repeatability = _exact_decision_repeatability(loaded_runs)
+    canary_gate_status: GateStatus = (
+        "unavailable"
+        if any(run.canary_gate_status == "unavailable" for run in runs)
+        else "passed"
+        if all(run.canary_gate_status == "passed" for run in runs)
+        else "failed"
+    )
+    gate_status: GateStatus = (
+        "unavailable"
+        if len(metrics) != _RUNS_PER_MODEL
+        or any(run.gate_status == "unavailable" for run in runs)
+        else "passed"
+        if all(run.gate_status == "passed" for run in runs)
+        and repeatability >= protocol.minimum_exact_decision_repeatability
+        else "failed"
+    )
+    return EvidenceSelectionExpertPilotModelSummary(
+        model_role=role,
+        model_id=runs[0].model_id,
+        run_count=3,
+        worst_run_precision=(
+            min(metric.precision for metric in metrics)
+            if len(metrics) == _RUNS_PER_MODEL
+            else None
+        ),
+        worst_run_recall=(
+            min(metric.end_to_end_recall for metric in metrics)
+            if len(metrics) == _RUNS_PER_MODEL
+            else None
+        ),
+        worst_run_decision_coverage=(
+            min(metric.decision_coverage for metric in metrics)
+            if len(metrics) == _RUNS_PER_MODEL
+            else None
+        ),
+        exact_decision_repeatability=(
+            repeatability if len(metrics) == _RUNS_PER_MODEL else None
+        ),
+        canary_gate_status=canary_gate_status,
+        maximum_run_high_severity_overclaim_count=max(
+            run.high_severity_overclaim_count for run in runs
+        ),
+        first_pass_percent_agreement=gold.first_pass_percent_agreement,
+        gate_status=gate_status,
+    )
+
+
+def _exact_decision_repeatability(
+    runs: tuple[LoadedExpertPilotModelRun, ...],
+) -> float:
+    decisions_by_run = tuple(
+        {
+            result.record_id: result.prediction_decision
+            for result in run.evaluation.record_results
+        }
+        for run in runs
+    )
+    record_ids = tuple(decisions_by_run[0])
+    stable = sum(
+        len({decisions[record_id] for decisions in decisions_by_run}) == 1
+        for record_id in record_ids
+    )
+    return stable / len(record_ids)
+
+
+def _comparison_status(
+    status_by_role: dict[ModelRole, GateStatus],
+) -> ComparisonStatus:
+    current = status_by_role["current"]
+    candidate = status_by_role["candidate"]
+    if "unavailable" in {current, candidate}:
+        return "unavailable"
+    if current == "passed" and candidate == "passed":
+        return "both_passed"
+    if current == "passed":
+        return "current_only_passed"
+    if candidate == "passed":
+        return "candidate_only_passed"
+    return "neither_passed"
+
+
+def _format_optional(value: float | None) -> str:
+    return "unavailable" if value is None else f"{value:.4f}"
+
+
+__all__ = [
+    "LoadedExpertPilotModelRun",
+    "build_expert_pilot_result",
+    "load_registered_model_runs",
+    "render_expert_pilot_result_markdown",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/review_contracts.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/review_contracts.py
@@ -29,6 +29,13 @@ def _literal_nonblank(value: str) -> str:
     return value
 
 
+def _literal_unique_spans(value: tuple[str, ...]) -> tuple[str, ...]:
+    normalized = tuple(_literal_nonblank(span) for span in value)
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("expert-pilot supporting spans must be unique")
+    return normalized
+
+
 def _aware(value: datetime, *, field_name: str) -> datetime:
     if value.tzinfo is None or value.utcoffset() is None:
         raise ValueError(f"{field_name} must include a timezone")
@@ -138,10 +145,7 @@ class EvidenceSelectionExpertPilotReviewFinding(BaseModel):
     @field_validator("supporting_spans")
     @classmethod
     def _validate_spans(cls, value: tuple[str, ...]) -> tuple[str, ...]:
-        normalized = tuple(_literal_nonblank(span) for span in value)
-        if len(set(normalized)) != len(normalized):
-            raise ValueError("expert-pilot supporting spans must be unique")
-        return normalized
+        return _literal_unique_spans(value)
 
     @field_validator("reviewer_explanation")
     @classmethod
@@ -290,6 +294,16 @@ class EvidenceSelectionExpertPilotAdjudicationFinding(BaseModel):
     def _accept_json_spans(cls, value: object) -> object:
         return tuple(value) if isinstance(value, list) else value
 
+    @field_validator("supporting_spans")
+    @classmethod
+    def _validate_spans(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return _literal_unique_spans(value)
+
+    @field_validator("reviewer_explanation")
+    @classmethod
+    def _validate_explanation(cls, value: str) -> str:
+        return _literal_nonblank(value)
+
 
 class EvidenceSelectionExpertPilotAdjudicationCompletionPayload(BaseModel):
     """Signed adjudication over the exact generated disagreement request."""
@@ -343,6 +357,16 @@ class EvidenceSelectionExpertPilotSafetyFinding(BaseModel):
     @classmethod
     def _accept_json_spans(cls, value: object) -> object:
         return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("claim_spans", "source_support_spans")
+    @classmethod
+    def _validate_spans(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return _literal_unique_spans(value)
+
+    @field_validator("reviewer_explanation")
+    @classmethod
+    def _validate_explanation(cls, value: str) -> str:
+        return _literal_nonblank(value)
 
 
 class EvidenceSelectionExpertPilotSafetyCompletionPayload(BaseModel):

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/review_contracts.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/review_contracts.py
@@ -1,0 +1,401 @@
+"""Human-owned categorical and externally signed expert-pilot contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_contracts import (
+    EvidenceSelectionExpertPilotAbstractSection,
+    ExpertPilotPacketSufficiency,
+    ExpertPilotSelectionLabel,
+)
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+ReviewerRole = Literal["independent_first_pass", "adjudicator_and_safety_reviewer"]
+SafetyAssessment = Literal[
+    "supported",
+    "unsupported_nonsevere",
+    "unsupported_high_severity",
+    "not_assessable",
+]
+
+
+def _literal_nonblank(value: str) -> str:
+    if not value.strip() or value != value.strip():
+        raise ValueError(
+            "expert-pilot review text must be literal, nonblank, and trimmed"
+        )
+    return value
+
+
+def _aware(value: datetime, *, field_name: str) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must include a timezone")
+    return value
+
+
+class EvidenceSelectionExpertPilotReviewerCredential(BaseModel):
+    """Issuer-certified reviewer identity and public verification key."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    reviewer_id: str = Field(min_length=1)
+    subject_identity_id: str = Field(pattern=r"^verified-subject-[a-zA-Z0-9._-]+$")
+    reviewer_slot: str = Field(min_length=1)
+    review_role: ReviewerRole
+    key_id: str = Field(pattern=r"^reviewer-key-[a-zA-Z0-9._-]+$")
+    public_key_hex: str = Field(pattern=r"^[a-f0-9]{64}$")
+    identity_assurance: Literal["issuer_verified_real_person"]
+    qualification_claim: Literal["domain_qualified_human"]
+    independence_claim: Literal["independent_of_model_development_and_other_reviewers"]
+    conflict_of_interest_declaration: Literal["no_conflict_declared"]
+
+    @field_validator("reviewer_id", "reviewer_slot")
+    @classmethod
+    def _validate_text(cls, value: str) -> str:
+        return _literal_nonblank(value)
+
+
+class EvidenceSelectionExpertPilotReviewerRegistryPayload(BaseModel):
+    """Externally issued credentials bound to one frozen pilot and evaluation."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_reviewer_registry.v1"]
+    study_id: str = Field(min_length=1)
+    pilot_protocol_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    evaluation_protocol_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    publication_manifest_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    issuer_id: str = Field(min_length=1)
+    valid_from: datetime
+    valid_until: datetime
+    credentials: tuple[EvidenceSelectionExpertPilotReviewerCredential, ...] = Field(
+        min_length=3
+    )
+
+    @field_validator("credentials", mode="before")
+    @classmethod
+    def _accept_json_credentials(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("study_id", "issuer_id")
+    @classmethod
+    def _validate_text(cls, value: str) -> str:
+        return _literal_nonblank(value)
+
+    @field_validator("valid_from", "valid_until")
+    @classmethod
+    def _validate_time(cls, value: datetime) -> datetime:
+        return _aware(value, field_name="reviewer credential validity time")
+
+    @model_validator(mode="after")
+    def _registry_is_coherent(
+        self,
+    ) -> EvidenceSelectionExpertPilotReviewerRegistryPayload:
+        if self.valid_until <= self.valid_from:
+            raise ValueError("reviewer credential validity window must be positive")
+        identities = [credential.reviewer_id for credential in self.credentials]
+        subjects = [credential.subject_identity_id for credential in self.credentials]
+        slots = [credential.reviewer_slot for credential in self.credentials]
+        keys = [credential.key_id for credential in self.credentials]
+        public_keys = [credential.public_key_hex for credential in self.credentials]
+        if any(
+            len(set(values)) != len(values)
+            for values in (identities, subjects, slots, keys, public_keys)
+        ):
+            raise ValueError("reviewer identities, slots, and keys must be distinct")
+        return self
+
+
+class EvidenceSelectionExpertPilotSignedReviewerRegistry(BaseModel):
+    """Registry whose issuer signature anchors external identity assurance."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    payload: EvidenceSelectionExpertPilotReviewerRegistryPayload
+    issuer_key_id: str = Field(pattern=r"^issuer-key-[a-zA-Z0-9._-]+$")
+    signature_algorithm: Literal["ed25519"]
+    signature_hex: str = Field(pattern=r"^[a-f0-9]{128}$")
+
+
+class EvidenceSelectionExpertPilotReviewFinding(BaseModel):
+    """One human categorical decision with literal packet evidence."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    candidate_id: str = Field(pattern=r"^candidate-[a-f0-9]{16}$")
+    selection_label: ExpertPilotSelectionLabel
+    packet_sufficiency: ExpertPilotPacketSufficiency
+    supporting_spans: tuple[str, ...]
+    reviewer_explanation: str = Field(min_length=1)
+
+    @field_validator("supporting_spans", mode="before")
+    @classmethod
+    def _accept_json_spans(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("supporting_spans")
+    @classmethod
+    def _validate_spans(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(_literal_nonblank(span) for span in value)
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("expert-pilot supporting spans must be unique")
+        return normalized
+
+    @field_validator("reviewer_explanation")
+    @classmethod
+    def _validate_explanation(cls, value: str) -> str:
+        return _literal_nonblank(value)
+
+    @model_validator(mode="after")
+    def _decisive_sufficient_finding_has_evidence(
+        self,
+    ) -> EvidenceSelectionExpertPilotReviewFinding:
+        if (
+            self.selection_label in {"select", "reject"}
+            and self.packet_sufficiency == "sufficient"
+            and not self.supporting_spans
+        ):
+            raise ValueError(
+                "decisive sufficient reviewer findings require literal supporting spans"
+            )
+        return self
+
+
+class EvidenceSelectionExpertPilotReviewCompletionPayload(BaseModel):
+    """One reviewer's completed packet, signed outside the platform."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_review_completion.v1"]
+    study_id: str
+    packet_id: str = Field(pattern=r"^packet-[a-f0-9]{16}$")
+    reviewer_slot: str
+    review_case_id: str = Field(pattern=r"^case-[a-f0-9]{16}$")
+    reviewer_id: str
+    reviewer_packet_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    evaluation_protocol_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    completed_at: datetime
+    findings: tuple[EvidenceSelectionExpertPilotReviewFinding, ...] = Field(
+        min_length=1
+    )
+
+    @field_validator("findings", mode="before")
+    @classmethod
+    def _accept_json_findings(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("completed_at")
+    @classmethod
+    def _validate_completion_time(cls, value: datetime) -> datetime:
+        return _aware(value, field_name="review completion time")
+
+    @model_validator(mode="after")
+    def _candidate_findings_are_unique(
+        self,
+    ) -> EvidenceSelectionExpertPilotReviewCompletionPayload:
+        candidate_ids = [finding.candidate_id for finding in self.findings]
+        if len(set(candidate_ids)) != len(candidate_ids):
+            raise ValueError("review completion candidate findings must be unique")
+        return self
+
+
+class EvidenceSelectionExpertPilotSignedReviewCompletion(BaseModel):
+    """Reviewer completion bound to its certified Ed25519 key."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    payload: EvidenceSelectionExpertPilotReviewCompletionPayload
+    reviewer_key_id: str = Field(pattern=r"^reviewer-key-[a-zA-Z0-9._-]+$")
+    signature_algorithm: Literal["ed25519"]
+    signature_hex: str = Field(pattern=r"^[a-f0-9]{128}$")
+
+
+class EvidenceSelectionExpertPilotFirstPassFinding(BaseModel):
+    """Identity-blinded first-pass context shown to the adjudicator."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    selection_label: ExpertPilotSelectionLabel
+    packet_sufficiency: ExpertPilotPacketSufficiency
+    supporting_spans: tuple[str, ...]
+    reviewer_explanation: str
+
+
+class EvidenceSelectionExpertPilotAdjudicationItem(BaseModel):
+    """One neutral disagreement requiring the predeclared third reviewer."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    adjudication_item_id: str = Field(pattern=r"^adjudication-[a-f0-9]{16}$")
+    review_case_id: str = Field(pattern=r"^adjudication-case-[a-f0-9]{16}$")
+    goal: str
+    instructions: str
+    inclusion_criteria: tuple[str, ...]
+    exclusion_criteria: tuple[str, ...]
+    title: str
+    bounded_source_text: tuple[EvidenceSelectionExpertPilotAbstractSection, ...]
+    first_pass_findings: tuple[EvidenceSelectionExpertPilotFirstPassFinding, ...] = (
+        Field(min_length=2, max_length=2)
+    )
+
+    @field_validator(
+        "inclusion_criteria",
+        "exclusion_criteria",
+        "bounded_source_text",
+        "first_pass_findings",
+        mode="before",
+    )
+    @classmethod
+    def _accept_json_arrays(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+
+class EvidenceSelectionExpertPilotAdjudicationRequest(BaseModel):
+    """Deterministically generated, model-blinded disagreement packet."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_adjudication_request.v1"]
+    study_id: str
+    pilot_protocol_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    evaluation_protocol_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    reviewer_registry_payload_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    first_pass_completion_sha256s: tuple[str, ...] = Field(min_length=1)
+    completion_status: Literal["requires_human_adjudication"]
+    hide_model_identity: Literal[True] = True
+    hide_model_decisions: Literal[True] = True
+    items: tuple[EvidenceSelectionExpertPilotAdjudicationItem, ...]
+
+    @field_validator("first_pass_completion_sha256s", "items", mode="before")
+    @classmethod
+    def _accept_json_arrays(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+
+class EvidenceSelectionExpertPilotAdjudicationFinding(BaseModel):
+    """Third-reviewer categorical resolution for one disagreement."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    adjudication_item_id: str = Field(pattern=r"^adjudication-[a-f0-9]{16}$")
+    selection_label: ExpertPilotSelectionLabel
+    packet_sufficiency: ExpertPilotPacketSufficiency
+    supporting_spans: tuple[str, ...]
+    reviewer_explanation: str = Field(min_length=1)
+
+    @field_validator("supporting_spans", mode="before")
+    @classmethod
+    def _accept_json_spans(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+
+class EvidenceSelectionExpertPilotAdjudicationCompletionPayload(BaseModel):
+    """Signed adjudication over the exact generated disagreement request."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal[
+        "evidence_selection_expert_pilot_adjudication_completion.v1"
+    ]
+    study_id: str
+    adjudicator_slot: str
+    reviewer_id: str
+    adjudication_request_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    completed_at: datetime
+    findings: tuple[EvidenceSelectionExpertPilotAdjudicationFinding, ...]
+
+    @field_validator("findings", mode="before")
+    @classmethod
+    def _accept_json_findings(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("completed_at")
+    @classmethod
+    def _validate_completion_time(cls, value: datetime) -> datetime:
+        return _aware(value, field_name="adjudication completion time")
+
+
+class EvidenceSelectionExpertPilotSignedAdjudicationCompletion(BaseModel):
+    """Adjudication completion bound to the certified adjudicator key."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    payload: EvidenceSelectionExpertPilotAdjudicationCompletionPayload
+    reviewer_key_id: str = Field(pattern=r"^reviewer-key-[a-zA-Z0-9._-]+$")
+    signature_algorithm: Literal["ed25519"]
+    signature_hex: str = Field(pattern=r"^[a-f0-9]{128}$")
+
+
+class EvidenceSelectionExpertPilotSafetyFinding(BaseModel):
+    """Categorical human audit of one selected model claim after gold freeze."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    audit_item_id: str = Field(pattern=r"^safety-[a-f0-9]{16}$")
+    assessment: SafetyAssessment
+    claim_spans: tuple[str, ...]
+    source_support_spans: tuple[str, ...]
+    reviewer_explanation: str = Field(min_length=1)
+
+    @field_validator("claim_spans", "source_support_spans", mode="before")
+    @classmethod
+    def _accept_json_spans(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+
+class EvidenceSelectionExpertPilotSafetyCompletionPayload(BaseModel):
+    """Signed post-gold safety review over the exact generated request."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    schema_version: Literal["evidence_selection_expert_pilot_safety_completion.v1"]
+    study_id: str
+    safety_reviewer_slot: str
+    reviewer_id: str
+    safety_request_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    frozen_gold_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    completed_at: datetime
+    findings: tuple[EvidenceSelectionExpertPilotSafetyFinding, ...]
+
+    @field_validator("findings", mode="before")
+    @classmethod
+    def _accept_json_findings(cls, value: object) -> object:
+        return tuple(value) if isinstance(value, list) else value
+
+    @field_validator("completed_at")
+    @classmethod
+    def _validate_completion_time(cls, value: datetime) -> datetime:
+        return _aware(value, field_name="safety completion time")
+
+
+class EvidenceSelectionExpertPilotSignedSafetyCompletion(BaseModel):
+    """Safety completion bound to the certified adjudicator key."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    payload: EvidenceSelectionExpertPilotSafetyCompletionPayload
+    reviewer_key_id: str = Field(pattern=r"^reviewer-key-[a-zA-Z0-9._-]+$")
+    signature_algorithm: Literal["ed25519"]
+    signature_hex: str = Field(pattern=r"^[a-f0-9]{128}$")
+
+
+__all__ = [
+    "EvidenceSelectionExpertPilotAdjudicationCompletionPayload",
+    "EvidenceSelectionExpertPilotAdjudicationFinding",
+    "EvidenceSelectionExpertPilotAdjudicationItem",
+    "EvidenceSelectionExpertPilotAdjudicationRequest",
+    "EvidenceSelectionExpertPilotFirstPassFinding",
+    "EvidenceSelectionExpertPilotReviewCompletionPayload",
+    "EvidenceSelectionExpertPilotReviewFinding",
+    "EvidenceSelectionExpertPilotReviewerCredential",
+    "EvidenceSelectionExpertPilotReviewerRegistryPayload",
+    "EvidenceSelectionExpertPilotSafetyCompletionPayload",
+    "EvidenceSelectionExpertPilotSafetyFinding",
+    "EvidenceSelectionExpertPilotSignedAdjudicationCompletion",
+    "EvidenceSelectionExpertPilotSignedReviewCompletion",
+    "EvidenceSelectionExpertPilotSignedReviewerRegistry",
+    "EvidenceSelectionExpertPilotSignedSafetyCompletion",
+    "SafetyAssessment",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/review_loader.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/review_loader.py
@@ -1,0 +1,478 @@
+"""Fail-closed loading for packet publications and signed first-pass reviews."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from artana_evidence_api.evidence_selection.diagnostics.agent_evaluation import (
+    EvidenceSelectionSemanticAgentEvaluation,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.loader import (
+    read_verified_artifact,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_contracts import (
+    EvidenceSelectionExpertPilotMachineSidecar,
+    EvidenceSelectionExpertPilotPublicationManifest,
+    EvidenceSelectionExpertPilotReviewerPacket,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_loader import (
+    LoadedEvidenceSelectionExpertPilot,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_packets import (
+    EvidenceSelectionExpertPilotPacketBundle,
+    verify_expert_pilot_packet_bundle,
+)
+from pydantic import BaseModel
+
+from .attestation import (
+    canonical_payload_sha256,
+    verify_ed25519_signature,
+)
+from .evaluation_contracts import (
+    EvidenceSelectionExpertPilotEvaluationProtocol,
+)
+from .review_contracts import (
+    EvidenceSelectionExpertPilotReviewerCredential,
+    EvidenceSelectionExpertPilotSignedReviewCompletion,
+    EvidenceSelectionExpertPilotSignedReviewerRegistry,
+)
+
+_REVIEWER_SLOT_COUNT = 3
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedExpertPilotPublication:
+    """Verified packet publication and complete packet-sidecar inventory."""
+
+    directory: Path
+    manifest: EvidenceSelectionExpertPilotPublicationManifest
+    manifest_sha256: str
+    bundles_by_packet_id: dict[str, EvidenceSelectionExpertPilotPacketBundle]
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedExpertPilotRegistry:
+    """Issuer-verified reviewer credentials for the exact study."""
+
+    signed_registry: EvidenceSelectionExpertPilotSignedReviewerRegistry
+    payload_sha256: str
+    issuer_public_key_sha256: str
+    credentials_by_slot: dict[str, EvidenceSelectionExpertPilotReviewerCredential]
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedExpertPilotReviewCompletion:
+    """One signed first-pass completion paired with its immutable packet."""
+
+    signed_completion: EvidenceSelectionExpertPilotSignedReviewCompletion
+    payload_sha256: str
+    bundle: EvidenceSelectionExpertPilotPacketBundle
+
+
+def load_expert_pilot_evaluation_protocol(
+    *,
+    path: Path,
+    repository_root: Path,
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot,
+) -> tuple[EvidenceSelectionExpertPilotEvaluationProtocol, str]:
+    """Verify the pre-review protocol and all registered live-agent artifacts."""
+
+    content = path.read_bytes()
+    protocol = EvidenceSelectionExpertPilotEvaluationProtocol.model_validate_json(
+        content
+    )
+    protocol_sha256 = hashlib.sha256(content).hexdigest()
+    if protocol.study_id != loaded_pilot.protocol.study_id:
+        raise ValueError("evaluation protocol study does not match expert pilot")
+    if (
+        protocol.pilot_protocol.path,
+        protocol.pilot_protocol.sha256,
+    ) != (
+        loaded_pilot.protocol_path.resolve().relative_to(repository_root).as_posix(),
+        loaded_pilot.protocol_sha256,
+    ):
+        raise ValueError("evaluation protocol does not bind the loaded pilot protocol")
+    if protocol.acceptance_thresholds != loaded_pilot.protocol.acceptance_thresholds:
+        raise ValueError("evaluation thresholds drifted from the pilot protocol")
+    case_ids = [case.case_id for case in loaded_pilot.benchmark.historical_v1.cases]
+    record_identities = [
+        f"{case.case_id}\0{record.record_id}"
+        for case in loaded_pilot.benchmark.historical_v1.cases
+        for record in case.records
+    ]
+    if (
+        protocol.expected_case_count != len(case_ids)
+        or protocol.expected_record_count != len(record_identities)
+        or protocol.case_inventory_sha256 != _inventory_sha256(case_ids)
+        or protocol.record_inventory_sha256 != _inventory_sha256(record_identities)
+    ):
+        raise ValueError(
+            "evaluation protocol case or record scope does not match pilot"
+        )
+    expected_record_pairs = [
+        (case.case_id, record.record_id)
+        for case in loaded_pilot.benchmark.historical_v1.cases
+        for record in case.records
+    ]
+    expected_case_roles = {
+        case.case_id: case.evaluation_role
+        for case in loaded_pilot.benchmark.historical_v1.cases
+    }
+    historical_reference = loaded_pilot.benchmark.fixture.historical_v1
+    for run in protocol.model_runs:
+        _, run_bytes = read_verified_artifact(
+            reference=run.artifact,
+            repository_root=repository_root,
+        )
+        evaluation = EvidenceSelectionSemanticAgentEvaluation.model_validate_json(
+            run_bytes
+        )
+        if (
+            evaluation.model_id != run.model_id
+            or evaluation.evaluated_commit != protocol.evaluated_commit
+        ):
+            raise ValueError(f"registered model identity mismatch: {run.run_id}")
+        if (
+            evaluation.fixture_path,
+            evaluation.fixture_sha256,
+        ) != (
+            historical_reference.path,
+            historical_reference.sha256,
+        ):
+            raise ValueError(f"registered model run fixture mismatch: {run.run_id}")
+        record_pairs = [
+            (result.case_id, result.record_id) for result in evaluation.record_results
+        ]
+        if record_pairs != expected_record_pairs or len(set(record_pairs)) != len(
+            record_pairs
+        ):
+            raise ValueError(f"registered model run inventory mismatch: {run.run_id}")
+        score_case_roles = {
+            result.case_id: result.evaluation_role
+            for result in evaluation.score.case_results
+        }
+        if (
+            len(score_case_roles) != len(evaluation.score.case_results)
+            or score_case_roles != expected_case_roles
+        ):
+            raise ValueError(f"registered model run case-role mismatch: {run.run_id}")
+    return protocol, protocol_sha256
+
+
+def load_expert_pilot_publication(
+    *,
+    directory: Path,
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot,
+) -> LoadedExpertPilotPublication:
+    """Verify manifest hashes, exact files, HMAC sidecars, and packet inventory."""
+
+    resolved = directory.resolve()
+    manifest_path = resolved / "publication_manifest.json"
+    manifest_bytes = manifest_path.read_bytes()
+    manifest = EvidenceSelectionExpertPilotPublicationManifest.model_validate_json(
+        manifest_bytes
+    )
+    expected_header = (
+        loaded_pilot.protocol.study_id,
+        loaded_pilot.protocol_sha256,
+        loaded_pilot.benchmark.fixture_sha256,
+        loaded_pilot.supplement_manifest_sha256,
+    )
+    actual_header = (
+        manifest.study_id,
+        manifest.protocol_sha256,
+        manifest.benchmark_fixture_sha256,
+        manifest.supplement_manifest_sha256,
+    )
+    if actual_header != expected_header:
+        raise ValueError("expert-pilot publication identity does not match protocol")
+    expected_files = {"publication_manifest.json"} | {
+        artifact.path for artifact in manifest.artifacts
+    }
+    actual_files = {
+        path.relative_to(resolved).as_posix()
+        for path in resolved.rglob("*")
+        if path.is_file()
+    }
+    if actual_files != expected_files:
+        raise ValueError("expert-pilot publication file inventory is not exact")
+    packets: dict[str, EvidenceSelectionExpertPilotReviewerPacket] = {}
+    sidecars: dict[str, EvidenceSelectionExpertPilotMachineSidecar] = {}
+    for artifact in manifest.artifacts:
+        path = (resolved / artifact.path).resolve()
+        if not path.is_relative_to(resolved):
+            raise ValueError("expert-pilot publication artifact escapes directory")
+        content = path.read_bytes()
+        if hashlib.sha256(content).hexdigest() != artifact.sha256:
+            raise ValueError(
+                f"expert-pilot publication digest mismatch: {artifact.path}"
+            )
+        if artifact.artifact_kind == "reviewer_packet":
+            packet = EvidenceSelectionExpertPilotReviewerPacket.model_validate_json(
+                content
+            )
+            packets[packet.packet_id] = packet
+        else:
+            sidecar = EvidenceSelectionExpertPilotMachineSidecar.model_validate_json(
+                content
+            )
+            sidecars[sidecar.packet_id] = sidecar
+    if set(packets) != set(sidecars) or len(packets) != manifest.reviewer_packet_count:
+        raise ValueError(
+            "expert-pilot publication packet-sidecar pairing is incomplete"
+        )
+    bundles = {
+        packet_id: EvidenceSelectionExpertPilotPacketBundle(
+            reviewer_packet=packets[packet_id],
+            machine_sidecar=sidecars[packet_id],
+        )
+        for packet_id in packets
+    }
+    for bundle in bundles.values():
+        verify_expert_pilot_packet_bundle(bundle)
+    expected_slots = set(loaded_pilot.protocol.independent_reviewer_slots)
+    actual_slots = {bundle.reviewer_packet.reviewer_slot for bundle in bundles.values()}
+    if actual_slots != expected_slots:
+        raise ValueError("expert-pilot publication reviewer slots are incomplete")
+    expected_case_count = len(loaded_pilot.protocol.expected_case_ids)
+    if any(
+        sum(bundle.reviewer_packet.reviewer_slot == slot for bundle in bundles.values())
+        != expected_case_count
+        for slot in expected_slots
+    ):
+        raise ValueError("expert-pilot publication case coverage is incomplete")
+    return LoadedExpertPilotPublication(
+        directory=resolved,
+        manifest=manifest,
+        manifest_sha256=hashlib.sha256(manifest_bytes).hexdigest(),
+        bundles_by_packet_id=bundles,
+    )
+
+
+def load_and_verify_reviewer_registry(
+    *,
+    path: Path,
+    issuer_public_key_hex: str,
+    issuer_key_id: str,
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot,
+    evaluation_protocol_sha256: str,
+    publication_manifest_sha256: str,
+) -> VerifiedExpertPilotRegistry:
+    """Verify the external trust anchor and exact independent reviewer roster."""
+
+    signed = EvidenceSelectionExpertPilotSignedReviewerRegistry.model_validate_json(
+        path.read_bytes()
+    )
+    if signed.issuer_key_id != issuer_key_id:
+        raise ValueError("reviewer registry issuer key ID does not match trust anchor")
+    verify_ed25519_signature(
+        payload=signed.payload,
+        public_key_hex=issuer_public_key_hex,
+        signature_hex=signed.signature_hex,
+    )
+    payload = signed.payload
+    if (
+        payload.study_id,
+        payload.pilot_protocol_sha256,
+        payload.evaluation_protocol_sha256,
+        payload.publication_manifest_sha256,
+    ) != (
+        loaded_pilot.protocol.study_id,
+        loaded_pilot.protocol_sha256,
+        evaluation_protocol_sha256,
+        publication_manifest_sha256,
+    ):
+        raise ValueError("reviewer registry does not bind the loaded study protocols")
+    credentials = {item.reviewer_slot: item for item in payload.credentials}
+    expected_slots = {
+        *loaded_pilot.protocol.independent_reviewer_slots,
+        loaded_pilot.protocol.adjudicator_slot,
+    }
+    if set(credentials) != expected_slots or len(credentials) != _REVIEWER_SLOT_COUNT:
+        raise ValueError("reviewer registry must contain exactly the three study slots")
+    if any(
+        credentials[slot].review_role != "independent_first_pass"
+        for slot in loaded_pilot.protocol.independent_reviewer_slots
+    ) or (
+        credentials[loaded_pilot.protocol.adjudicator_slot].review_role
+        != "adjudicator_and_safety_reviewer"
+    ):
+        raise ValueError("reviewer registry roles do not match the pilot protocol")
+    return VerifiedExpertPilotRegistry(
+        signed_registry=signed,
+        payload_sha256=canonical_payload_sha256(payload),
+        issuer_public_key_sha256=hashlib.sha256(
+            bytes.fromhex(issuer_public_key_hex)
+        ).hexdigest(),
+        credentials_by_slot=credentials,
+    )
+
+
+def load_and_verify_first_pass_completions(
+    *,
+    directory: Path,
+    publication: LoadedExpertPilotPublication,
+    registry: VerifiedExpertPilotRegistry,
+    evaluation_protocol: EvidenceSelectionExpertPilotEvaluationProtocol,
+    evaluation_protocol_sha256: str,
+) -> tuple[VerifiedExpertPilotReviewCompletion, ...]:
+    """Verify exact review coverage, certified signers, and literal evidence."""
+
+    paths = sorted(path for path in directory.resolve().rglob("*") if path.is_file())
+    if any(path.suffix != ".json" for path in paths):
+        raise ValueError("first-pass completion directory may contain only JSON files")
+    if len(paths) != len(publication.bundles_by_packet_id):
+        raise ValueError("first-pass completion count does not match packet count")
+    verified: list[VerifiedExpertPilotReviewCompletion] = []
+    seen_packets: set[str] = set()
+    for path in paths:
+        signed = EvidenceSelectionExpertPilotSignedReviewCompletion.model_validate_json(
+            path.read_bytes()
+        )
+        payload = signed.payload
+        bundle = publication.bundles_by_packet_id.get(payload.packet_id)
+        if bundle is None or payload.packet_id in seen_packets:
+            raise ValueError(
+                "first-pass completion packet identity is unknown or duplicate"
+            )
+        seen_packets.add(payload.packet_id)
+        packet = bundle.reviewer_packet
+        credential = registry.credentials_by_slot.get(payload.reviewer_slot)
+        if credential is None or credential.review_role != "independent_first_pass":
+            raise ValueError("first-pass completion reviewer slot is not certified")
+        if (
+            payload.study_id,
+            payload.reviewer_slot,
+            payload.review_case_id,
+            payload.reviewer_packet_sha256,
+            payload.evaluation_protocol_sha256,
+            payload.reviewer_id,
+            signed.reviewer_key_id,
+        ) != (
+            packet.study_id,
+            packet.reviewer_slot,
+            packet.review_case_id,
+            bundle.machine_sidecar.reviewer_packet_sha256,
+            evaluation_protocol_sha256,
+            credential.reviewer_id,
+            credential.key_id,
+        ):
+            raise ValueError(
+                "first-pass completion identity does not match packet and credential"
+            )
+        registry_payload = registry.signed_registry.payload
+        if (
+            not (
+                registry_payload.valid_from
+                <= payload.completed_at
+                <= registry_payload.valid_until
+            )
+            or payload.completed_at < evaluation_protocol.registered_at
+        ):
+            raise ValueError(
+                "first-pass completion time is outside the registered window"
+            )
+        verify_ed25519_signature(
+            payload=payload,
+            public_key_hex=credential.public_key_hex,
+            signature_hex=signed.signature_hex,
+        )
+        candidate_ids = tuple(candidate.candidate_id for candidate in packet.candidates)
+        finding_ids = tuple(finding.candidate_id for finding in payload.findings)
+        if finding_ids != candidate_ids:
+            raise ValueError(
+                "first-pass findings must exactly follow packet candidate order"
+            )
+        for candidate, finding in zip(packet.candidates, payload.findings, strict=True):
+            _verify_literal_spans(
+                supporting_spans=finding.supporting_spans,
+                source_text=(
+                    candidate.title,
+                    *(section.text for section in candidate.bounded_source_text),
+                ),
+            )
+        verified.append(
+            VerifiedExpertPilotReviewCompletion(
+                signed_completion=signed,
+                payload_sha256=canonical_payload_sha256(payload),
+                bundle=bundle,
+            )
+        )
+    return tuple(
+        sorted(verified, key=lambda item: item.signed_completion.payload.packet_id)
+    )
+
+
+def verify_review_time_and_signature(
+    *,
+    completed_at: datetime,
+    signed_payload: BaseModel,
+    signature_hex: str,
+    reviewer_key_id: str,
+    credential: EvidenceSelectionExpertPilotReviewerCredential,
+    registry: VerifiedExpertPilotRegistry,
+    earliest_time: datetime,
+) -> None:
+    """Apply the shared certified signer and chronology boundary."""
+
+    if (reviewer_key_id, getattr(signed_payload, "reviewer_id", None)) != (
+        credential.key_id,
+        credential.reviewer_id,
+    ):
+        raise ValueError("signed reviewer identity does not match certified credential")
+    registry_payload = registry.signed_registry.payload
+    if (
+        not (
+            registry_payload.valid_from <= completed_at <= registry_payload.valid_until
+        )
+        or completed_at < earliest_time
+    ):
+        raise ValueError("signed human completion violates credential chronology")
+    verify_ed25519_signature(
+        payload=signed_payload,
+        public_key_hex=credential.public_key_hex,
+        signature_hex=signature_hex,
+    )
+
+
+def _inventory_sha256(values: list[str]) -> str:
+    return hashlib.sha256("\n".join(values).encode("utf-8")).hexdigest()
+
+
+def verify_literal_spans(
+    *,
+    supporting_spans: tuple[str, ...],
+    source_text: tuple[str, ...],
+) -> None:
+    """Public span verifier used by adjudication and safety phases."""
+
+    _verify_literal_spans(
+        supporting_spans=supporting_spans,
+        source_text=source_text,
+    )
+
+
+def _verify_literal_spans(
+    *,
+    supporting_spans: tuple[str, ...],
+    source_text: tuple[str, ...],
+) -> None:
+    for span in supporting_spans:
+        if not any(span in source for source in source_text):
+            raise ValueError("expert-pilot supporting span is not literal packet text")
+
+
+__all__ = [
+    "LoadedExpertPilotPublication",
+    "VerifiedExpertPilotRegistry",
+    "VerifiedExpertPilotReviewCompletion",
+    "load_and_verify_first_pass_completions",
+    "load_and_verify_reviewer_registry",
+    "load_expert_pilot_evaluation_protocol",
+    "load_expert_pilot_publication",
+    "verify_literal_spans",
+    "verify_review_time_and_signature",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/review_loader.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/review_loader.py
@@ -23,6 +23,7 @@ from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_loade
 )
 from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_packets import (
     EvidenceSelectionExpertPilotPacketBundle,
+    build_expert_pilot_packet_bundles,
     verify_expert_pilot_packet_bundle,
 )
 from pydantic import BaseModel
@@ -233,6 +234,14 @@ def load_expert_pilot_publication(
     }
     for bundle in bundles.values():
         verify_expert_pilot_packet_bundle(bundle)
+    expected_bundles = {
+        bundle.reviewer_packet.packet_id: bundle
+        for bundle in build_expert_pilot_packet_bundles(loaded_pilot)
+    }
+    if bundles != expected_bundles:
+        raise ValueError(
+            "expert-pilot publication does not exactly match the frozen pilot"
+        )
     expected_slots = set(loaded_pilot.protocol.independent_reviewer_slots)
     actual_slots = {bundle.reviewer_packet.reviewer_slot for bundle in bundles.values()}
     if actual_slots != expected_slots:
@@ -461,6 +470,10 @@ def _verify_literal_spans(
     source_text: tuple[str, ...],
 ) -> None:
     for span in supporting_spans:
+        if not span.strip() or span != span.strip():
+            raise ValueError(
+                "expert-pilot supporting span must be literal, nonblank, and trimmed"
+            )
         if not any(span in source for source in source_text):
             raise ValueError("expert-pilot supporting span is not literal packet text")
 

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/safety.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/safety.py
@@ -1,0 +1,186 @@
+"""Post-gold categorical safety-request construction and verification."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_loader import (
+    LoadedEvidenceSelectionExpertPilot,
+)
+
+from .attestation import canonical_payload_sha256
+from .evaluation_contracts import (
+    EvidenceSelectionExpertPilotGoldArtifact,
+    EvidenceSelectionExpertPilotSafetyAuditItem,
+    EvidenceSelectionExpertPilotSafetyAuditRequest,
+)
+from .review_contracts import (
+    EvidenceSelectionExpertPilotSignedSafetyCompletion,
+)
+from .review_loader import (
+    VerifiedExpertPilotRegistry,
+    verify_literal_spans,
+    verify_review_time_and_signature,
+)
+
+if TYPE_CHECKING:
+    from .result import LoadedExpertPilotModelRun
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedExpertPilotSafetyAudit:
+    """Model-blinded request plus private item-to-run mappings."""
+
+    request: EvidenceSelectionExpertPilotSafetyAuditRequest
+    run_and_record_by_item_id: dict[str, tuple[str, str]]
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedExpertPilotSafetyAudit:
+    """Certified categorical safety findings over the exact frozen request."""
+
+    signed_completion: EvidenceSelectionExpertPilotSignedSafetyCompletion
+    payload_sha256: str
+
+
+def prepare_expert_pilot_safety_audit(
+    *,
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot,
+    evaluation_protocol_sha256: str,
+    gold: EvidenceSelectionExpertPilotGoldArtifact,
+    model_runs: tuple[LoadedExpertPilotModelRun, ...],
+) -> PreparedExpertPilotSafetyAudit:
+    """Expose every selected claim without revealing model identity or gold labels."""
+
+    gold_sha256 = canonical_payload_sha256(gold)
+    items: list[EvidenceSelectionExpertPilotSafetyAuditItem] = []
+    mappings: dict[str, tuple[str, str]] = {}
+    for run in model_runs:
+        blinded_run_id = (
+            "blinded-run-"
+            + _blind_digest(
+                loaded_pilot.protocol.study_id,
+                run.reference.run_id,
+                "safety-run",
+            )[:12]
+        )
+        for result in run.evaluation.record_results:
+            if result.prediction_decision != "select":
+                continue
+            if result.assessment is None:
+                raise ValueError(
+                    "selected registered result is missing agent assessment"
+                )
+            supplement = loaded_pilot.supplements_by_record[result.record_id]
+            item_id = (
+                "safety-"
+                + _blind_digest(
+                    loaded_pilot.protocol.study_id,
+                    run.reference.run_id,
+                    result.record_id,
+                    "safety-item",
+                )[:16]
+            )
+            items.append(
+                EvidenceSelectionExpertPilotSafetyAuditItem(
+                    audit_item_id=item_id,
+                    blinded_run_id=blinded_run_id,
+                    title=supplement.title,
+                    bounded_source_text=tuple(
+                        section.text for section in supplement.abstract_sections
+                    ),
+                    agent_explanation=result.assessment.explanation,
+                    agent_evidence_spans=result.evidence_spans,
+                )
+            )
+            mappings[item_id] = (run.reference.run_id, result.record_id)
+    return PreparedExpertPilotSafetyAudit(
+        request=EvidenceSelectionExpertPilotSafetyAuditRequest(
+            schema_version="evidence_selection_expert_pilot_safety_request.v1",
+            study_id=loaded_pilot.protocol.study_id,
+            frozen_gold_sha256=gold_sha256,
+            evaluation_protocol_sha256=evaluation_protocol_sha256,
+            review_phase="after_adjudicated_gold_freeze",
+            completion_status="requires_human_safety_findings",
+            items=tuple(items),
+        ),
+        run_and_record_by_item_id=mappings,
+    )
+
+
+def load_and_verify_safety_completion(
+    *,
+    path: Path,
+    prepared: PreparedExpertPilotSafetyAudit,
+    registry: VerifiedExpertPilotRegistry,
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot,
+    earliest_time: datetime,
+) -> VerifiedExpertPilotSafetyAudit:
+    """Verify post-gold chronology, exact coverage, literal spans, and signer."""
+
+    signed = EvidenceSelectionExpertPilotSignedSafetyCompletion.model_validate_json(
+        path.read_bytes()
+    )
+    payload = signed.payload
+    credential = registry.credentials_by_slot[loaded_pilot.protocol.adjudicator_slot]
+    if (
+        payload.study_id,
+        payload.safety_reviewer_slot,
+        payload.safety_request_sha256,
+        payload.frozen_gold_sha256,
+    ) != (
+        loaded_pilot.protocol.study_id,
+        loaded_pilot.protocol.adjudicator_slot,
+        canonical_payload_sha256(prepared.request),
+        prepared.request.frozen_gold_sha256,
+    ):
+        raise ValueError("safety completion does not bind the frozen request and gold")
+    verify_review_time_and_signature(
+        completed_at=payload.completed_at,
+        signed_payload=payload,
+        signature_hex=signed.signature_hex,
+        reviewer_key_id=signed.reviewer_key_id,
+        credential=credential,
+        registry=registry,
+        earliest_time=earliest_time,
+    )
+    expected_ids = tuple(item.audit_item_id for item in prepared.request.items)
+    finding_ids = tuple(finding.audit_item_id for finding in payload.findings)
+    if finding_ids != expected_ids:
+        raise ValueError("safety findings must exactly follow request item order")
+    for item, finding in zip(prepared.request.items, payload.findings, strict=True):
+        verify_literal_spans(
+            supporting_spans=finding.claim_spans,
+            source_text=(item.agent_explanation,),
+        )
+        verify_literal_spans(
+            supporting_spans=finding.source_support_spans,
+            source_text=(item.title, *item.bounded_source_text),
+        )
+        if finding.assessment == "supported" and not finding.source_support_spans:
+            raise ValueError("supported safety findings require literal source support")
+        if (
+            finding.assessment in {"unsupported_nonsevere", "unsupported_high_severity"}
+            and not finding.claim_spans
+        ):
+            raise ValueError("overclaim findings require a literal agent claim span")
+    return VerifiedExpertPilotSafetyAudit(
+        signed_completion=signed,
+        payload_sha256=canonical_payload_sha256(payload),
+    )
+
+
+def _blind_digest(*parts: str) -> str:
+    return hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "PreparedExpertPilotSafetyAudit",
+    "VerifiedExpertPilotSafetyAudit",
+    "load_and_verify_safety_completion",
+    "prepare_expert_pilot_safety_audit",
+]

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/safety.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/safety.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -13,6 +12,7 @@ from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_loade
 )
 
 from .attestation import canonical_payload_sha256
+from .blinding import keyed_blind_digest
 from .evaluation_contracts import (
     EvidenceSelectionExpertPilotGoldArtifact,
     EvidenceSelectionExpertPilotSafetyAuditItem,
@@ -53,6 +53,7 @@ def prepare_expert_pilot_safety_audit(
     evaluation_protocol_sha256: str,
     gold: EvidenceSelectionExpertPilotGoldArtifact,
     model_runs: tuple[LoadedExpertPilotModelRun, ...],
+    blinding_key: bytes,
 ) -> PreparedExpertPilotSafetyAudit:
     """Expose every selected claim without revealing model identity or gold labels."""
 
@@ -62,10 +63,13 @@ def prepare_expert_pilot_safety_audit(
     for run in model_runs:
         blinded_run_id = (
             "blinded-run-"
-            + _blind_digest(
-                loaded_pilot.protocol.study_id,
-                run.reference.run_id,
-                "safety-run",
+            + keyed_blind_digest(
+                key=blinding_key,
+                namespace="safety-run",
+                parts=(
+                    loaded_pilot.protocol.study_id,
+                    run.reference.run_id,
+                ),
             )[:12]
         )
         for result in run.evaluation.record_results:
@@ -78,11 +82,14 @@ def prepare_expert_pilot_safety_audit(
             supplement = loaded_pilot.supplements_by_record[result.record_id]
             item_id = (
                 "safety-"
-                + _blind_digest(
-                    loaded_pilot.protocol.study_id,
-                    run.reference.run_id,
-                    result.record_id,
-                    "safety-item",
+                + keyed_blind_digest(
+                    key=blinding_key,
+                    namespace="safety-item",
+                    parts=(
+                        loaded_pilot.protocol.study_id,
+                        run.reference.run_id,
+                        result.record_id,
+                    ),
                 )[:16]
             )
             items.append(
@@ -172,10 +179,6 @@ def load_and_verify_safety_completion(
         signed_completion=signed,
         payload_sha256=canonical_payload_sha256(payload),
     )
-
-
-def _blind_digest(*parts: str) -> str:
-    return hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
 
 
 __all__ = [

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/pilot_publication.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/pilot_publication.py
@@ -128,6 +128,12 @@ def _safe_path_segment(value: str, *, field_name: str) -> str:
     return value
 
 
+def publish_directory_no_replace(*, staging: Path, destination: Path) -> None:
+    """Publish an already staged directory through the platform no-replace API."""
+
+    _publish_directory_no_replace(staging=staging, destination=destination)
+
+
 def _publish_directory_no_replace(*, staging: Path, destination: Path) -> None:
     """Atomically publish a directory without replacing a racing destination."""
 
@@ -192,4 +198,4 @@ def _call_rename_no_replace(
         raise OSError(error_number, os.strerror(error_number), str(destination))
 
 
-__all__ = ["publish_expert_pilot_packets"]
+__all__ = ["publish_directory_no_replace", "publish_expert_pilot_packets"]

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_expert_pilot_attestation.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_expert_pilot_attestation.py
@@ -1,0 +1,842 @@
+"""Adversarial coverage for external expert-pilot attestations and scoring."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot import (
+    review_loader as expert_pilot_review_loader,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.adjudication import (
+    PreparedExpertPilotAdjudication,
+    VerifiedExpertPilotAdjudication,
+    build_expert_pilot_gold,
+    load_and_verify_adjudication_completion,
+    prepare_expert_pilot_adjudication,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.attestation import (
+    canonical_payload_bytes,
+    canonical_payload_sha256,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.evaluation import (
+    PreparedExpertPilotSafetyAudit,
+    build_expert_pilot_result,
+    load_and_verify_safety_completion,
+    load_registered_model_runs,
+    prepare_expert_pilot_safety_audit,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.evaluation_contracts import (
+    EvidenceSelectionExpertPilotEvaluationProtocol,
+    EvidenceSelectionExpertPilotGoldArtifact,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.review_contracts import (
+    EvidenceSelectionExpertPilotAdjudicationCompletionPayload,
+    EvidenceSelectionExpertPilotAdjudicationFinding,
+    EvidenceSelectionExpertPilotReviewCompletionPayload,
+    EvidenceSelectionExpertPilotReviewerCredential,
+    EvidenceSelectionExpertPilotReviewerRegistryPayload,
+    EvidenceSelectionExpertPilotReviewFinding,
+    EvidenceSelectionExpertPilotSafetyCompletionPayload,
+    EvidenceSelectionExpertPilotSafetyFinding,
+    EvidenceSelectionExpertPilotSignedAdjudicationCompletion,
+    EvidenceSelectionExpertPilotSignedReviewCompletion,
+    EvidenceSelectionExpertPilotSignedReviewerRegistry,
+    EvidenceSelectionExpertPilotSignedSafetyCompletion,
+    SafetyAssessment,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.review_loader import (
+    LoadedExpertPilotPublication,
+    VerifiedExpertPilotRegistry,
+    VerifiedExpertPilotReviewCompletion,
+    load_and_verify_first_pass_completions,
+    load_and_verify_reviewer_registry,
+    load_expert_pilot_evaluation_protocol,
+    load_expert_pilot_publication,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.loader import (
+    read_verified_artifact,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_loader import (
+    LoadedEvidenceSelectionExpertPilot,
+    load_expert_pilot,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.pilot_publication import (
+    publish_expert_pilot_packets,
+)
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from pydantic import BaseModel, ValidationError
+
+PILOT_PROTOCOL_PATH = Path(
+    "scripts/validation/evidence_selection/fixtures/"
+    "semantic_relevance_expert_pilot_protocol_v1.json"
+)
+EVALUATION_PROTOCOL_PATH = Path(
+    "scripts/validation/evidence_selection/fixtures/"
+    "semantic_relevance_expert_pilot_evaluation_protocol_v1.json"
+)
+SIGNING_KEY_ENV = "ARTANA_EVIDENCE_SHADOW_REVIEW_PACKET_SIGNING_KEY"
+IMPORT_SCRIPT_PATH = Path("scripts/import_evidence_selection_expert_pilot_reviews.py")
+
+
+@dataclass(frozen=True, slots=True)
+class _SyntheticFirstPass:
+    loaded_pilot: LoadedEvidenceSelectionExpertPilot
+    evaluation_protocol: EvidenceSelectionExpertPilotEvaluationProtocol
+    evaluation_protocol_sha256: str
+    publication: LoadedExpertPilotPublication
+    registry: VerifiedExpertPilotRegistry
+    completions: tuple[VerifiedExpertPilotReviewCompletion, ...]
+    prepared: PreparedExpertPilotAdjudication
+    reviewer_private_keys: dict[str, Ed25519PrivateKey]
+    desired_labels: dict[str, str]
+    publication_dir: Path
+    registry_path: Path
+    completion_dir: Path
+    issuer_public_key_hex: str
+
+
+def test_protocol_pre_registers_six_runs_and_preserves_stronger_quality_gates() -> None:
+    loaded_pilot = load_expert_pilot(
+        protocol_path=PILOT_PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+    protocol, _ = load_expert_pilot_evaluation_protocol(
+        path=EVALUATION_PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+        loaded_pilot=loaded_pilot,
+    )
+
+    assert len(protocol.model_runs) == 6
+    assert {run.model_id for run in protocol.model_runs} == {
+        "openai:gpt-5.4-mini",
+        "openai:gpt-5.6-luna",
+    }
+    assert protocol.expected_record_count == 33
+    assert protocol.minimum_worst_decision_coverage == 0.8
+    assert protocol.minimum_case_precision == 0.7
+    assert protocol.minimum_case_recall == 0.7
+    assert protocol.minimum_case_decision_coverage == 0.7
+    assert protocol.minimum_exact_decision_repeatability == 1.0
+    assert protocol.agent_numeric_judgments_allowed is False
+
+
+def test_protocol_rejects_duplicate_run_artifact_bytes() -> None:
+    payload = json.loads(EVALUATION_PROTOCOL_PATH.read_text(encoding="utf-8"))
+    payload["model_runs"][1]["artifact"]["sha256"] = payload["model_runs"][0][
+        "artifact"
+    ]["sha256"]
+
+    with pytest.raises(ValidationError, match="artifact bytes must be unique"):
+        EvidenceSelectionExpertPilotEvaluationProtocol.model_validate_json(
+            json.dumps(payload)
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("fixture", "fixture mismatch"),
+        ("case", "inventory mismatch"),
+        ("role", "case-role mismatch"),
+    ],
+)
+def test_registered_runs_must_match_frozen_benchmark_partitions(
+    mutation: str,
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loaded_pilot = load_expert_pilot(
+        protocol_path=PILOT_PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+    protocol = EvidenceSelectionExpertPilotEvaluationProtocol.model_validate_json(
+        EVALUATION_PROTOCOL_PATH.read_bytes()
+    )
+    target = protocol.model_runs[0].artifact
+    _, original_bytes = read_verified_artifact(
+        reference=target,
+        repository_root=Path.cwd(),
+    )
+    payload = json.loads(original_bytes)
+    if mutation == "fixture":
+        payload["fixture_sha256"] = "0" * 64
+    elif mutation == "case":
+        payload["record_results"][0]["case_id"] = "wrong-case"
+    else:
+        payload["score"]["case_results"][0]["evaluation_role"] = "canary"
+    mutated_bytes = json.dumps(payload).encode("utf-8")
+
+    def _read_artifact(*, reference, repository_root):
+        if reference.path == target.path:
+            return Path(reference.path), mutated_bytes
+        return read_verified_artifact(
+            reference=reference,
+            repository_root=repository_root,
+        )
+
+    monkeypatch.setattr(
+        expert_pilot_review_loader,
+        "read_verified_artifact",
+        _read_artifact,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        load_expert_pilot_evaluation_protocol(
+            path=EVALUATION_PROTOCOL_PATH,
+            repository_root=Path.cwd(),
+            loaded_pilot=loaded_pilot,
+        )
+
+
+def test_signed_human_chain_builds_diagnostic_result_without_adoption_claim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_pass = _build_synthetic_first_pass(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        disagreement=True,
+    )
+    adjudication = _complete_adjudication(tmp_path=tmp_path, study=first_pass)
+    gold = _gold(study=first_pass, adjudication=adjudication)
+    model_runs = load_registered_model_runs(
+        protocol=first_pass.evaluation_protocol,
+        repository_root=Path.cwd(),
+    )
+    prepared_safety = prepare_expert_pilot_safety_audit(
+        loaded_pilot=first_pass.loaded_pilot,
+        evaluation_protocol_sha256=first_pass.evaluation_protocol_sha256,
+        gold=gold,
+        model_runs=model_runs,
+    )
+    safety = _complete_safety(
+        tmp_path=tmp_path,
+        study=first_pass,
+        gold=gold,
+        prepared=prepared_safety,
+        adjudication=adjudication,
+    )
+
+    result = build_expert_pilot_result(
+        protocol=first_pass.evaluation_protocol,
+        gold=gold,
+        registry=first_pass.registry,
+        model_runs=model_runs,
+        prepared_safety=prepared_safety,
+        safety=safety,
+    )
+
+    assert gold.score_eligible_record_count == 33
+    assert gold.first_pass_agreement_count == 32
+    assert gold.first_pass_selection_agreement_count == 32
+    assert gold.first_pass_sufficiency_agreement_count == 33
+    assert result.expert_study_status == "externally_attested"
+    assert result.external_identity_attestation_verified is True
+    assert (
+        result.issuer_public_key_sha256
+        == hashlib.sha256(bytes.fromhex(first_pass.issuer_public_key_hex)).hexdigest()
+    )
+    assert result.model_adoption_decision == "not_evaluated_diagnostic_only"
+    assert result.production_readiness_claim is False
+    assert result.trusted_graph_readiness_claim is False
+    candidate = next(
+        summary
+        for summary in result.model_summaries
+        if summary.model_role == "candidate"
+    )
+    assert candidate.exact_decision_repeatability is not None
+    assert candidate.exact_decision_repeatability < 1.0
+    assert candidate.gate_status == "failed"
+
+
+def test_forged_reviewer_signature_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(ValueError, match="Ed25519 signature"):
+        _build_synthetic_first_pass(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            forged_first_completion=True,
+        )
+
+
+def test_registry_must_bind_exact_packet_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(ValueError, match="loaded study protocols"):
+        _build_synthetic_first_pass(
+            tmp_path=tmp_path,
+            monkeypatch=monkeypatch,
+            wrong_publication_hash=True,
+        )
+
+
+def test_reviewer_cannot_supply_numeric_confidence() -> None:
+    payload = {
+        "candidate_id": "candidate-0123456789abcdef",
+        "selection_label": "select",
+        "packet_sufficiency": "sufficient",
+        "supporting_spans": ["Literal source text"],
+        "reviewer_explanation": "The source directly meets the frozen criteria.",
+        "confidence": 0.99,
+    }
+
+    with pytest.raises(ValidationError, match="confidence"):
+        EvidenceSelectionExpertPilotReviewFinding.model_validate(payload)
+
+
+def test_incomplete_adjudication_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    study = _build_synthetic_first_pass(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        disagreement=True,
+    )
+    path = _write_adjudication(
+        tmp_path=tmp_path,
+        study=study,
+        findings=(),
+    )
+
+    with pytest.raises(ValueError, match="exactly follow request item order"):
+        load_and_verify_adjudication_completion(
+            path=path,
+            prepared=study.prepared,
+            registry=study.registry,
+            loaded_pilot=study.loaded_pilot,
+        )
+
+
+def test_insufficient_gold_makes_all_model_gates_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    study = _build_synthetic_first_pass(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        disagreement=True,
+    )
+    adjudication = _complete_adjudication(
+        tmp_path=tmp_path,
+        study=study,
+        insufficient=True,
+    )
+    gold = _gold(study=study, adjudication=adjudication)
+    model_runs = load_registered_model_runs(
+        protocol=study.evaluation_protocol,
+        repository_root=Path.cwd(),
+    )
+    prepared_safety = prepare_expert_pilot_safety_audit(
+        loaded_pilot=study.loaded_pilot,
+        evaluation_protocol_sha256=study.evaluation_protocol_sha256,
+        gold=gold,
+        model_runs=model_runs,
+    )
+    safety = _complete_safety(
+        tmp_path=tmp_path,
+        study=study,
+        gold=gold,
+        prepared=prepared_safety,
+        adjudication=adjudication,
+    )
+    result = build_expert_pilot_result(
+        protocol=study.evaluation_protocol,
+        gold=gold,
+        registry=study.registry,
+        model_runs=model_runs,
+        prepared_safety=prepared_safety,
+        safety=safety,
+    )
+
+    assert gold.score_eligible_record_count == 32
+    assert result.comparison_status == "unavailable"
+    assert all(
+        summary.gate_status == "unavailable" for summary in result.model_summaries
+    )
+    assert all(run.metrics is None for run in result.model_run_results)
+
+
+def test_cli_recomputes_and_atomically_publishes_verified_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    study = _build_synthetic_first_pass(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        disagreement=True,
+    )
+    adjudication = _complete_adjudication(tmp_path=tmp_path, study=study)
+    gold = _gold(study=study, adjudication=adjudication)
+    model_runs = load_registered_model_runs(
+        protocol=study.evaluation_protocol,
+        repository_root=Path.cwd(),
+    )
+    prepared_safety = prepare_expert_pilot_safety_audit(
+        loaded_pilot=study.loaded_pilot,
+        evaluation_protocol_sha256=study.evaluation_protocol_sha256,
+        gold=gold,
+        model_runs=model_runs,
+    )
+    _complete_safety(
+        tmp_path=tmp_path,
+        study=study,
+        gold=gold,
+        prepared=prepared_safety,
+        adjudication=adjudication,
+    )
+    output_dir = tmp_path / "verified-result"
+    module = _load_import_script()
+
+    exit_code = module.main(
+        (
+            "finalize",
+            "--pilot-protocol",
+            str(PILOT_PROTOCOL_PATH),
+            "--evaluation-protocol",
+            str(EVALUATION_PROTOCOL_PATH),
+            "--packet-publication",
+            str(study.publication_dir),
+            "--reviewer-registry",
+            str(study.registry_path),
+            "--issuer-public-key-hex",
+            study.issuer_public_key_hex,
+            "--issuer-key-id",
+            "issuer-key-synthetic-root",
+            "--first-pass-completions",
+            str(study.completion_dir),
+            "--adjudication-completion",
+            str(tmp_path / "adjudication-completion.json"),
+            "--safety-completion",
+            str(tmp_path / "safety-completion.json"),
+            "--output-dir",
+            str(output_dir),
+        )
+    )
+
+    assert exit_code == 0
+    assert {path.name for path in output_dir.iterdir()} == {
+        "adjudication_request.json",
+        "gold.json",
+        "safety_request.json",
+        "result.json",
+        "result.md",
+    }
+    result_payload = json.loads(
+        (output_dir / "result.json").read_text(encoding="utf-8")
+    )
+    assert result_payload["model_adoption_decision"] == (
+        "not_evaluated_diagnostic_only"
+    )
+    assert result_payload["production_readiness_claim"] is False
+
+
+def test_not_assessable_safety_finding_keeps_diagnostic_gate_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    study = _build_synthetic_first_pass(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        disagreement=True,
+    )
+    adjudication = _complete_adjudication(tmp_path=tmp_path, study=study)
+    gold = _gold(study=study, adjudication=adjudication)
+    model_runs = load_registered_model_runs(
+        protocol=study.evaluation_protocol,
+        repository_root=Path.cwd(),
+    )
+    prepared_safety = prepare_expert_pilot_safety_audit(
+        loaded_pilot=study.loaded_pilot,
+        evaluation_protocol_sha256=study.evaluation_protocol_sha256,
+        gold=gold,
+        model_runs=model_runs,
+    )
+    safety = _complete_safety(
+        tmp_path=tmp_path,
+        study=study,
+        gold=gold,
+        prepared=prepared_safety,
+        adjudication=adjudication,
+        assessment="not_assessable",
+    )
+    result = build_expert_pilot_result(
+        protocol=study.evaluation_protocol,
+        gold=gold,
+        registry=study.registry,
+        model_runs=model_runs,
+        prepared_safety=prepared_safety,
+        safety=safety,
+    )
+
+    assert result.comparison_status == "unavailable"
+    assert all(
+        summary.gate_status == "unavailable" for summary in result.model_summaries
+    )
+    assert all(run.metrics is not None for run in result.model_run_results)
+
+
+def _build_synthetic_first_pass(
+    *,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    disagreement: bool = False,
+    forged_first_completion: bool = False,
+    wrong_publication_hash: bool = False,
+) -> _SyntheticFirstPass:
+    monkeypatch.setenv(SIGNING_KEY_ENV, "synthetic-test-producer-key")
+    loaded_pilot = load_expert_pilot(
+        protocol_path=PILOT_PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+    evaluation_protocol, evaluation_sha = load_expert_pilot_evaluation_protocol(
+        path=EVALUATION_PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+        loaded_pilot=loaded_pilot,
+    )
+    publication_dir = tmp_path / "packet-publication"
+    publish_expert_pilot_packets(loaded=loaded_pilot, output_dir=publication_dir)
+    publication = load_expert_pilot_publication(
+        directory=publication_dir,
+        loaded_pilot=loaded_pilot,
+    )
+    issuer_private_key = Ed25519PrivateKey.generate()
+    reviewer_keys = {
+        slot: Ed25519PrivateKey.generate()
+        for slot in (
+            *loaded_pilot.protocol.independent_reviewer_slots,
+            loaded_pilot.protocol.adjudicator_slot,
+        )
+    }
+    registry_payload = EvidenceSelectionExpertPilotReviewerRegistryPayload(
+        schema_version="evidence_selection_expert_pilot_reviewer_registry.v1",
+        study_id=loaded_pilot.protocol.study_id,
+        pilot_protocol_sha256=loaded_pilot.protocol_sha256,
+        evaluation_protocol_sha256=evaluation_sha,
+        publication_manifest_sha256=(
+            "0" * 64 if wrong_publication_hash else publication.manifest_sha256
+        ),
+        issuer_id="synthetic-test-credential-authority",
+        valid_from=evaluation_protocol.registered_at,
+        valid_until=evaluation_protocol.registered_at + timedelta(days=1),
+        credentials=tuple(
+            EvidenceSelectionExpertPilotReviewerCredential(
+                reviewer_id=f"synthetic-human-{index}",
+                subject_identity_id=f"verified-subject-synthetic-{index}",
+                reviewer_slot=slot,
+                review_role=(
+                    "independent_first_pass"
+                    if slot in loaded_pilot.protocol.independent_reviewer_slots
+                    else "adjudicator_and_safety_reviewer"
+                ),
+                key_id=f"reviewer-key-synthetic-{index}",
+                public_key_hex=reviewer_keys[slot]
+                .public_key()
+                .public_bytes_raw()
+                .hex(),
+                identity_assurance="issuer_verified_real_person",
+                qualification_claim="domain_qualified_human",
+                independence_claim=(
+                    "independent_of_model_development_and_other_reviewers"
+                ),
+                conflict_of_interest_declaration="no_conflict_declared",
+            )
+            for index, slot in enumerate(reviewer_keys, start=1)
+        ),
+    )
+    signed_registry = _sign(
+        payload=registry_payload,
+        private_key=issuer_private_key,
+        wrapper=EvidenceSelectionExpertPilotSignedReviewerRegistry,
+        issuer_key_id="issuer-key-synthetic-root",
+    )
+    registry_path = tmp_path / "reviewer-registry.json"
+    _write_model(registry_path, signed_registry)
+    registry = load_and_verify_reviewer_registry(
+        path=registry_path,
+        issuer_public_key_hex=issuer_private_key.public_key().public_bytes_raw().hex(),
+        issuer_key_id="issuer-key-synthetic-root",
+        loaded_pilot=loaded_pilot,
+        evaluation_protocol_sha256=evaluation_sha,
+        publication_manifest_sha256=publication.manifest_sha256,
+    )
+    model_runs = load_registered_model_runs(
+        protocol=evaluation_protocol,
+        repository_root=Path.cwd(),
+    )
+    candidate_run_one = next(
+        run for run in model_runs if run.reference.run_id == "candidate-run-1"
+    )
+    desired_labels = {
+        result.record_id: (
+            result.prediction_decision
+            if result.prediction_decision in {"select", "reject"}
+            else "reject"
+        )
+        for result in candidate_run_one.evaluation.record_results
+    }
+    disagreement_record = next(iter(desired_labels)) if disagreement else None
+    completion_dir = tmp_path / "first-pass-completions"
+    completion_dir.mkdir()
+    for bundle_index, bundle in enumerate(
+        publication.bundles_by_packet_id.values(),
+        start=1,
+    ):
+        packet = bundle.reviewer_packet
+        credential = registry.credentials_by_slot[packet.reviewer_slot]
+        findings = []
+        for candidate, binding in zip(
+            packet.candidates,
+            bundle.machine_sidecar.candidate_bindings,
+            strict=True,
+        ):
+            label = desired_labels[binding.record_id]
+            if (
+                binding.record_id == disagreement_record
+                and packet.reviewer_slot
+                == loaded_pilot.protocol.independent_reviewer_slots[1]
+            ):
+                label = "reject" if label == "select" else "select"
+            findings.append(
+                EvidenceSelectionExpertPilotReviewFinding(
+                    candidate_id=candidate.candidate_id,
+                    selection_label=label,
+                    packet_sufficiency="sufficient",
+                    supporting_spans=(candidate.title,),
+                    reviewer_explanation=(
+                        "Synthetic test finding exercises the signed categorical path."
+                    ),
+                )
+            )
+        payload = EvidenceSelectionExpertPilotReviewCompletionPayload(
+            schema_version="evidence_selection_expert_pilot_review_completion.v1",
+            study_id=packet.study_id,
+            packet_id=packet.packet_id,
+            reviewer_slot=packet.reviewer_slot,
+            review_case_id=packet.review_case_id,
+            reviewer_id=credential.reviewer_id,
+            reviewer_packet_sha256=bundle.machine_sidecar.reviewer_packet_sha256,
+            evaluation_protocol_sha256=evaluation_sha,
+            completed_at=evaluation_protocol.registered_at
+            + timedelta(minutes=bundle_index),
+            findings=tuple(findings),
+        )
+        signed = _sign(
+            payload=payload,
+            private_key=reviewer_keys[packet.reviewer_slot],
+            wrapper=EvidenceSelectionExpertPilotSignedReviewCompletion,
+            reviewer_key_id=credential.key_id,
+        )
+        if forged_first_completion and bundle_index == 1:
+            signed = signed.model_copy(update={"signature_hex": "0" * 128})
+        _write_model(completion_dir / f"{packet.packet_id}.json", signed)
+    completions = load_and_verify_first_pass_completions(
+        directory=completion_dir,
+        publication=publication,
+        registry=registry,
+        evaluation_protocol=evaluation_protocol,
+        evaluation_protocol_sha256=evaluation_sha,
+    )
+    prepared = prepare_expert_pilot_adjudication(
+        loaded_pilot=loaded_pilot,
+        evaluation_protocol_sha256=evaluation_sha,
+        registry=registry,
+        completions=completions,
+    )
+    return _SyntheticFirstPass(
+        loaded_pilot=loaded_pilot,
+        evaluation_protocol=evaluation_protocol,
+        evaluation_protocol_sha256=evaluation_sha,
+        publication=publication,
+        registry=registry,
+        completions=completions,
+        prepared=prepared,
+        reviewer_private_keys=reviewer_keys,
+        desired_labels=desired_labels,
+        publication_dir=publication_dir,
+        registry_path=registry_path,
+        completion_dir=completion_dir,
+        issuer_public_key_hex=issuer_private_key.public_key().public_bytes_raw().hex(),
+    )
+
+
+def _complete_adjudication(
+    *,
+    tmp_path: Path,
+    study: _SyntheticFirstPass,
+    insufficient: bool = False,
+) -> VerifiedExpertPilotAdjudication:
+    findings = tuple(
+        EvidenceSelectionExpertPilotAdjudicationFinding(
+            adjudication_item_id=item.adjudication_item_id,
+            selection_label=study.desired_labels[
+                study.prepared.record_id_by_item_id[item.adjudication_item_id]
+            ],
+            packet_sufficiency="insufficient" if insufficient else "sufficient",
+            supporting_spans=() if insufficient else (item.title,),
+            reviewer_explanation="Synthetic third-reviewer test resolution.",
+        )
+        for item in study.prepared.request.items
+    )
+    path = _write_adjudication(tmp_path=tmp_path, study=study, findings=findings)
+    adjudication = load_and_verify_adjudication_completion(
+        path=path,
+        prepared=study.prepared,
+        registry=study.registry,
+        loaded_pilot=study.loaded_pilot,
+    )
+    assert adjudication is not None
+    return adjudication
+
+
+def _write_adjudication(
+    *,
+    tmp_path: Path,
+    study: _SyntheticFirstPass,
+    findings: tuple[EvidenceSelectionExpertPilotAdjudicationFinding, ...],
+) -> Path:
+    slot = study.loaded_pilot.protocol.adjudicator_slot
+    credential = study.registry.credentials_by_slot[slot]
+    payload = EvidenceSelectionExpertPilotAdjudicationCompletionPayload(
+        schema_version="evidence_selection_expert_pilot_adjudication_completion.v1",
+        study_id=study.loaded_pilot.protocol.study_id,
+        adjudicator_slot=slot,
+        reviewer_id=credential.reviewer_id,
+        adjudication_request_sha256=canonical_payload_sha256(study.prepared.request),
+        completed_at=max(
+            completion.signed_completion.payload.completed_at
+            for completion in study.completions
+        )
+        + timedelta(minutes=1),
+        findings=findings,
+    )
+    signed = _sign(
+        payload=payload,
+        private_key=study.reviewer_private_keys[slot],
+        wrapper=EvidenceSelectionExpertPilotSignedAdjudicationCompletion,
+        reviewer_key_id=credential.key_id,
+    )
+    path = tmp_path / "adjudication-completion.json"
+    _write_model(path, signed)
+    return path
+
+
+def _gold(
+    *,
+    study: _SyntheticFirstPass,
+    adjudication: VerifiedExpertPilotAdjudication | None,
+) -> EvidenceSelectionExpertPilotGoldArtifact:
+    return build_expert_pilot_gold(
+        loaded_pilot=study.loaded_pilot,
+        evaluation_protocol_sha256=study.evaluation_protocol_sha256,
+        publication=study.publication,
+        registry=study.registry,
+        completions=study.completions,
+        prepared=study.prepared,
+        adjudication=adjudication,
+    )
+
+
+def _complete_safety(
+    *,
+    tmp_path: Path,
+    study: _SyntheticFirstPass,
+    gold: EvidenceSelectionExpertPilotGoldArtifact,
+    prepared: PreparedExpertPilotSafetyAudit,
+    adjudication: VerifiedExpertPilotAdjudication | None,
+    assessment: SafetyAssessment = "supported",
+):
+    slot = study.loaded_pilot.protocol.adjudicator_slot
+    credential = study.registry.credentials_by_slot[slot]
+    payload = EvidenceSelectionExpertPilotSafetyCompletionPayload(
+        schema_version="evidence_selection_expert_pilot_safety_completion.v1",
+        study_id=study.loaded_pilot.protocol.study_id,
+        safety_reviewer_slot=slot,
+        reviewer_id=credential.reviewer_id,
+        safety_request_sha256=canonical_payload_sha256(prepared.request),
+        frozen_gold_sha256=canonical_payload_sha256(gold),
+        completed_at=(
+            adjudication.signed_completion.payload.completed_at
+            if adjudication is not None
+            else max(
+                completion.signed_completion.payload.completed_at
+                for completion in study.completions
+            )
+        )
+        + timedelta(minutes=1),
+        findings=tuple(
+            EvidenceSelectionExpertPilotSafetyFinding(
+                audit_item_id=item.audit_item_id,
+                assessment=assessment,
+                claim_spans=(),
+                source_support_spans=(
+                    (item.title,) if assessment == "supported" else ()
+                ),
+                reviewer_explanation="Synthetic source-supported safety finding.",
+            )
+            for item in prepared.request.items
+        ),
+    )
+    signed = _sign(
+        payload=payload,
+        private_key=study.reviewer_private_keys[slot],
+        wrapper=EvidenceSelectionExpertPilotSignedSafetyCompletion,
+        reviewer_key_id=credential.key_id,
+    )
+    path = tmp_path / "safety-completion.json"
+    _write_model(path, signed)
+    return load_and_verify_safety_completion(
+        path=path,
+        prepared=prepared,
+        registry=study.registry,
+        loaded_pilot=study.loaded_pilot,
+        earliest_time=(
+            adjudication.signed_completion.payload.completed_at
+            if adjudication is not None
+            else max(
+                completion.signed_completion.payload.completed_at
+                for completion in study.completions
+            )
+        ),
+    )
+
+
+def _sign(
+    *,
+    payload: BaseModel,
+    private_key: Ed25519PrivateKey,
+    wrapper,
+    **identity: str,
+):
+    return wrapper(
+        payload=payload,
+        signature_algorithm="ed25519",
+        signature_hex=private_key.sign(canonical_payload_bytes(payload)).hex(),
+        **identity,
+    )
+
+
+def _write_model(path: Path, model: BaseModel) -> None:
+    path.write_text(model.model_dump_json(indent=2) + "\n", encoding="utf-8")
+
+
+def _load_import_script() -> ModuleType:
+    module_name = "import_evidence_selection_expert_pilot_reviews"
+    spec = importlib.util.spec_from_file_location(module_name, IMPORT_SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError("unable to load expert-pilot import CLI")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_expert_pilot_attestation.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_expert_pilot_attestation.py
@@ -6,7 +6,7 @@ import hashlib
 import importlib.util
 import json
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timedelta
 from pathlib import Path
 from types import ModuleType
@@ -36,6 +36,9 @@ from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilo
 from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.evaluation_contracts import (
     EvidenceSelectionExpertPilotEvaluationProtocol,
     EvidenceSelectionExpertPilotGoldArtifact,
+)
+from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.publication import (
+    publish_expert_pilot_stage,
 )
 from artana_evidence_api.evidence_selection.diagnostics.benchmark_v2.expert_pilot.review_contracts import (
     EvidenceSelectionExpertPilotAdjudicationCompletionPayload,
@@ -84,6 +87,7 @@ EVALUATION_PROTOCOL_PATH = Path(
 )
 SIGNING_KEY_ENV = "ARTANA_EVIDENCE_SHADOW_REVIEW_PACKET_SIGNING_KEY"
 IMPORT_SCRIPT_PATH = Path("scripts/import_evidence_selection_expert_pilot_reviews.py")
+SAFETY_BLINDING_KEY = bytes.fromhex("ab" * 32)
 
 
 @dataclass(frozen=True, slots=True)
@@ -216,6 +220,33 @@ def test_signed_human_chain_builds_diagnostic_result_without_adoption_claim(
         evaluation_protocol_sha256=first_pass.evaluation_protocol_sha256,
         gold=gold,
         model_runs=model_runs,
+        blinding_key=SAFETY_BLINDING_KEY,
+    )
+    alternate_safety = prepare_expert_pilot_safety_audit(
+        loaded_pilot=first_pass.loaded_pilot,
+        evaluation_protocol_sha256=first_pass.evaluation_protocol_sha256,
+        gold=gold,
+        model_runs=model_runs,
+        blinding_key=bytes.fromhex("cd" * 32),
+    )
+    assert tuple(
+        (item.blinded_run_id, item.audit_item_id)
+        for item in prepared_safety.request.items
+    ) != tuple(
+        (item.blinded_run_id, item.audit_item_id)
+        for item in alternate_safety.request.items
+    )
+    enumerable_id = (
+        "blinded-run-"
+        + hashlib.sha256(
+            (
+                f"{first_pass.loaded_pilot.protocol.study_id}"
+                "\x1fcurrent-run-1\x1fsafety-run"
+            ).encode()
+        ).hexdigest()[:12]
+    )
+    assert all(
+        item.blinded_run_id != enumerable_id for item in prepared_safety.request.items
     )
     safety = _complete_safety(
         tmp_path=tmp_path,
@@ -281,6 +312,40 @@ def test_registry_must_bind_exact_packet_publication(
         )
 
 
+def test_publication_rejects_producer_signed_stale_bundles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(SIGNING_KEY_ENV, "synthetic-test-producer-key")
+    loaded_pilot = load_expert_pilot(
+        protocol_path=PILOT_PROTOCOL_PATH,
+        repository_root=Path.cwd(),
+    )
+    stale_pilot = replace(
+        loaded_pilot,
+        protocol=loaded_pilot.protocol.model_copy(
+            update={"study_id": "semantic-relevance-stale-study"}
+        ),
+        protocol_sha256="0" * 64,
+    )
+    publication_dir = tmp_path / "stale-publication"
+    publish_expert_pilot_packets(
+        loaded=stale_pilot,
+        output_dir=publication_dir,
+    )
+    manifest_path = publication_dir / "publication_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["study_id"] = loaded_pilot.protocol.study_id
+    manifest["protocol_sha256"] = loaded_pilot.protocol_sha256
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="exactly match the frozen pilot"):
+        load_expert_pilot_publication(
+            directory=publication_dir,
+            loaded_pilot=loaded_pilot,
+        )
+
+
 def test_reviewer_cannot_supply_numeric_confidence() -> None:
     payload = {
         "candidate_id": "candidate-0123456789abcdef",
@@ -293,6 +358,33 @@ def test_reviewer_cannot_supply_numeric_confidence() -> None:
 
     with pytest.raises(ValidationError, match="confidence"):
         EvidenceSelectionExpertPilotReviewFinding.model_validate(payload)
+
+
+def test_adjudication_and_safety_spans_must_be_nonblank_and_trimmed() -> None:
+    with pytest.raises(ValidationError, match="nonblank"):
+        EvidenceSelectionExpertPilotAdjudicationFinding(
+            adjudication_item_id="adjudication-0123456789abcdef",
+            selection_label="select",
+            packet_sufficiency="sufficient",
+            supporting_spans=("",),
+            reviewer_explanation="Literal evidence is required.",
+        )
+    with pytest.raises(ValidationError, match="nonblank"):
+        EvidenceSelectionExpertPilotSafetyFinding(
+            audit_item_id="safety-0123456789abcdef",
+            assessment="supported",
+            claim_spans=(),
+            source_support_spans=("   ",),
+            reviewer_explanation="Literal source support is required.",
+        )
+
+
+def test_stage_publication_rejects_empty_artifact_name(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="flat and nonempty"):
+        publish_expert_pilot_stage(
+            output_dir=tmp_path / "invalid-stage",
+            content_by_name={"": "content"},
+        )
 
 
 def test_incomplete_adjudication_is_rejected(
@@ -343,6 +435,7 @@ def test_insufficient_gold_makes_all_model_gates_unavailable(
         evaluation_protocol_sha256=study.evaluation_protocol_sha256,
         gold=gold,
         model_runs=model_runs,
+        blinding_key=SAFETY_BLINDING_KEY,
     )
     safety = _complete_safety(
         tmp_path=tmp_path,
@@ -388,6 +481,7 @@ def test_cli_recomputes_and_atomically_publishes_verified_result(
         evaluation_protocol_sha256=study.evaluation_protocol_sha256,
         gold=gold,
         model_runs=model_runs,
+        blinding_key=SAFETY_BLINDING_KEY,
     )
     _complete_safety(
         tmp_path=tmp_path,
@@ -396,6 +490,12 @@ def test_cli_recomputes_and_atomically_publishes_verified_result(
         prepared=prepared_safety,
         adjudication=adjudication,
     )
+    blinding_key_path = tmp_path / "safety-blinding.key"
+    blinding_key_path.write_text(
+        SAFETY_BLINDING_KEY.hex() + "\n",
+        encoding="ascii",
+    )
+    blinding_key_path.chmod(0o600)
     output_dir = tmp_path / "verified-result"
     module = _load_import_script()
 
@@ -418,6 +518,8 @@ def test_cli_recomputes_and_atomically_publishes_verified_result(
             str(study.completion_dir),
             "--adjudication-completion",
             str(tmp_path / "adjudication-completion.json"),
+            "--safety-blinding-key-file",
+            str(blinding_key_path),
             "--safety-completion",
             str(tmp_path / "safety-completion.json"),
             "--output-dir",
@@ -462,6 +564,7 @@ def test_not_assessable_safety_finding_keeps_diagnostic_gate_unavailable(
         evaluation_protocol_sha256=study.evaluation_protocol_sha256,
         gold=gold,
         model_runs=model_runs,
+        blinding_key=SAFETY_BLINDING_KEY,
     )
     safety = _complete_safety(
         tmp_path=tmp_path,


### PR DESCRIPTION
## Summary

- pre-register the exact six PR150 live-agent runs, benchmark inventory, metric definitions, safety scope, and preserved quality gates
- verify issuer-certified human identities plus reviewer-signed categorical first pass, adjudication, and post-gold safety artifacts
- compute agreement, quality, canary, repeatability, and overclaim metrics deterministically with fail-closed unavailable states
- publish each stage atomically and preserve explicit no-adoption, no-production-calibration, and no-trusted-graph claims

## Adversarial hardening

- reject duplicate run bytes, fixture drift, case/record remapping, and model-authored primary/canary remapping
- reconstruct the exact frozen packet/sidecar bundles before trusting imported reviews
- use retained secret-backed safety identifiers that cannot be enumerated from public run IDs
- reject blank literal spans, empty publication names, forged signatures, numeric reviewer confidence, incomplete adjudication/gold, and not-assessable safety completion
- bind the issuer public-key fingerprint into the verified chain

## Validation

- `make artana-evidence-api-service-checks`
- focused expert-pilot and benchmark suite: 47 passed
- strict mypy: 578 API source files plus registered scripts
- architecture size and structure checks
- `pre-commit run --all-files`
- commit and push hooks passed without skipping

## Honest current state

No real reviewer artifacts exist yet. The default benchmark therefore remains `33 visible / 0 score-eligible / expert study pending`. Synthetic cryptographic rehearsals validate the workflow but do not count as expert evidence or establish production/trusted-graph readiness.