### PR TITLE
Add PubMed source-integrity preflight

### DIFF
--- a/docs/validation/reports/2026-07-14-pr156-pubmed-source-integrity-preflight.md
+++ b/docs/validation/reports/2026-07-14-pr156-pubmed-source-integrity-preflight.md
@@ -1,0 +1,93 @@
+# PR 156 PubMed Source-Integrity Preflight
+
+## Goal
+
+Add authoritative PubMed identity and publication-integrity facts before the
+semantic selection agent judges a candidate. Preserve uncertain, corrected,
+retracted, mismatched, and novel candidates for review instead of converting
+absence or uncertainty into a false claim.
+
+## Implemented
+
+- The live PubMed gateway now retrieves bounded NCBI EFetch XML for preview
+  records after ESearch and ESummary.
+- The parser uses `defusedxml`, matches records by PMID, and captures canonical
+  title, abstract, DOI, publication types, and `CommentsCorrectionsList`
+  relationships.
+- Source findings are categorical: identity is `matched`, `mismatched`, or
+  `unresolved`; integrity is `clear`, `correction_review`,
+  `expression_of_concern`, `retracted`, or `unresolved`.
+- The agent still owns semantic relevance. Deterministic policy only converts an
+  agent-selected candidate into a lifecycle state.
+- A PubMed selection passes only when an allowlisted NCBI EFetch validation is
+  bound to the same PMID and reports `matched` plus `clear`.
+- Missing, invalid, mismatched, corrected, concerning, retracted, or unresolved
+  validation becomes `source_integrity_review`. The original agent selection is
+  retained as `shadow_decision=selected` and
+  `would_have_been_selected=true`; it is not changed to `skipped`.
+- EFetch failures and partial responses preserve the ESummary candidate with an
+  explicit unresolved finding.
+
+## Adversarial Findings Addressed
+
+- Closed the legacy bypass where a PubMed record with no validation could still
+  be selected.
+- Bound clear validations to the same PMID so a finding from another article
+  cannot be reused.
+- Required the allowlisted `ncbi_pubmed` plus `efetch_xml` provenance categories
+  before a clear result can pass.
+- Replaced a broad exception catch with expected HTTP, rate-limit, Unicode, and
+  hardened-XML failures; programming errors are no longer silently hidden.
+- Avoided a new service-root module by placing PubMed integrity parsing in the
+  existing source-authority package.
+- Added reordered, missing, mismatched DOI, malicious XML, correction,
+  expression-of-concern, retraction, unresolved, emerging-hypothesis, malformed
+  contract, wrong-PMID, duplicate-PMID, and publication-type fallback regression
+  cases.
+
+## Validation Evidence
+
+| Gate | Result |
+| --- | --- |
+| Focused PubMed and semantic-screening tests | PASS: 73 tests |
+| Full Evidence API test suite with ephemeral PostgreSQL | PASS |
+| Evidence API lint and strict type check | PASS: 582 typed source files |
+| Boundary and generated-contract checks | PASS |
+| Agent-output boundary check | PASS |
+| Semantic baseline and benchmark integrity checks | PASS |
+| Architecture size and structure checks | PASS |
+| Live NCBI MED13 smoke test | PASS: 2 of 2 previews matched, clear, and contained abstracts |
+| Live NCBI retracted-publication smoke test | PASS: 3 of 3 categorized retracted from `RetractionIn` |
+
+The live MED13 smoke test resolved PMIDs `29773993` and `41130977`. The live
+retracted-publication smoke test resolved PMIDs `41329731`, `41629425`, and
+`40605964`; each carried an NCBI `RetractionIn` relationship and was categorized
+as `retracted`.
+
+## Safety Interpretation
+
+This PR does not ask an LLM to produce a numeric source-quality score. NCBI
+provides source facts, the agent provides categorical semantic judgment with
+evidence, and deterministic code applies the lifecycle gate.
+
+`not found` does not mean `false`. A new hypothesis with unresolved external
+validation remains visible in review with its original semantic selection
+preserved. It cannot enter the selected lane until its source identity and
+integrity are resolved.
+
+## Remaining Boundary
+
+This is the PubMed discovery and semantic-selection slice only. It does not yet:
+
+- validate ClinVar, ClinicalTrials.gov, PMC full text, or publisher correction
+  metadata;
+- revalidate a previously clear publication immediately before trusted graph
+  promotion;
+- establish the biomedical truth of a claim merely because its source is
+  authentic and unretracted;
+- replace independent expert review or the blocked trusted-graph readiness
+  gates.
+
+The next source-validation PR should add the same categorical, non-lossy policy
+to ClinVar and ClinicalTrials.gov. A later promotion-boundary PR must recheck
+freshness and correction status before trusted graph promotion.

--- a/services/artana_evidence_api/evidence_selection/semantic/screening.py
+++ b/services/artana_evidence_api/evidence_selection/semantic/screening.py
@@ -31,6 +31,9 @@ from artana_evidence_api.evidence_selection.semantic.model import (
 from artana_evidence_api.evidence_selection.semantic.validation import (
     assess_validated_semantic_batch,
 )
+from artana_evidence_api.evidence_selection.source_integrity.policy import (
+    apply_source_integrity_policy,
+)
 from artana_evidence_api.evidence_selection_candidate_screening import (
     screen_candidate_searches,
 )
@@ -249,6 +252,18 @@ class AgentEvidenceSelectionCandidateScreener:
                 if decision.decision is EvidenceSelectionDecisionState.SKIPPED:
                     skipped.append(decision)
                     continue
+                source_integrity_decision = decision
+                if decision.record_index is not None:
+                    source_integrity_decision = apply_source_integrity_policy(
+                        decision=decision,
+                        record=records[decision.record_index],
+                    )
+                if (
+                    source_integrity_decision.decision
+                    is EvidenceSelectionDecisionState.DEFERRED
+                ):
+                    deferred.append(source_integrity_decision)
+                    continue
                 if selected_count >= search_limit:
                     deferred.append(
                         decision.with_decision(
@@ -260,10 +275,10 @@ class AgentEvidenceSelectionCandidateScreener:
                         ),
                     )
                     continue
-                selected.append(decision)
+                selected.append(source_integrity_decision)
                 selected_count += 1
                 mark_decision_seen(
-                    decision=decision,
+                    decision=source_integrity_decision,
                     existing_keys=existing_keys,
                     existing_hashes=existing_hashes,
                 )

--- a/services/artana_evidence_api/evidence_selection/source_integrity/__init__.py
+++ b/services/artana_evidence_api/evidence_selection/source_integrity/__init__.py
@@ -1,0 +1,21 @@
+"""Authoritative source-integrity contracts and lifecycle policy."""
+
+from artana_evidence_api.evidence_selection.source_integrity.contracts import (
+    AuthoritativeSourceValidation,
+    SourceIdentityStatus,
+    SourceIntegrityStatus,
+    SourceValidationRelation,
+    parse_authoritative_source_validation,
+)
+from artana_evidence_api.evidence_selection.source_integrity.policy import (
+    apply_source_integrity_policy,
+)
+
+__all__ = [
+    "AuthoritativeSourceValidation",
+    "SourceIdentityStatus",
+    "SourceIntegrityStatus",
+    "SourceValidationRelation",
+    "apply_source_integrity_policy",
+    "parse_authoritative_source_validation",
+]

--- a/services/artana_evidence_api/evidence_selection/source_integrity/contracts.py
+++ b/services/artana_evidence_api/evidence_selection/source_integrity/contracts.py
@@ -1,0 +1,80 @@
+"""Categorical contracts for authoritative source-integrity findings."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from enum import StrEnum
+from typing import Literal
+
+from artana_evidence_api.types.common import JSONObject
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+
+class SourceIdentityStatus(StrEnum):
+    """Whether the authority returned the record that was requested."""
+
+    MATCHED = "matched"
+    MISMATCHED = "mismatched"
+    UNRESOLVED = "unresolved"
+
+
+class SourceIntegrityStatus(StrEnum):
+    """Categorical publication-integrity status reported by an authority."""
+
+    CLEAR = "clear"
+    CORRECTION_REVIEW = "correction_review"
+    EXPRESSION_OF_CONCERN = "expression_of_concern"
+    RETRACTED = "retracted"
+    UNRESOLVED = "unresolved"
+
+
+class SourceValidationRelation(BaseModel):
+    """One authority-provided relationship to another source record."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    relation_type: str = Field(min_length=1)
+    target_id: str | None = None
+    citation: str = Field(min_length=1)
+
+
+class AuthoritativeSourceValidation(BaseModel):
+    """Typed, categorical source facts used by deterministic safety policy."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: Literal["authoritative_source_validation.v1"]
+    authority: str = Field(min_length=1)
+    validation_method: str = Field(min_length=1)
+    authority_record_id: str | None = None
+    source_identity: SourceIdentityStatus
+    source_integrity: SourceIntegrityStatus
+    explanation: str = Field(min_length=1)
+    relations: tuple[SourceValidationRelation, ...] = ()
+
+    def to_json(self) -> JSONObject:
+        """Serialize the validated contract at the source-record boundary."""
+
+        return self.model_dump(mode="json")
+
+
+def parse_authoritative_source_validation(
+    raw_validation: object,
+) -> AuthoritativeSourceValidation | None:
+    """Return a strict validation contract or ``None`` for untrusted payloads."""
+
+    if not isinstance(raw_validation, Mapping):
+        return None
+    try:
+        return AuthoritativeSourceValidation.model_validate(raw_validation)
+    except ValidationError:
+        return None
+
+
+__all__ = [
+    "AuthoritativeSourceValidation",
+    "SourceIdentityStatus",
+    "SourceIntegrityStatus",
+    "SourceValidationRelation",
+    "parse_authoritative_source_validation",
+]

--- a/services/artana_evidence_api/evidence_selection/source_integrity/policy.py
+++ b/services/artana_evidence_api/evidence_selection/source_integrity/policy.py
@@ -1,0 +1,89 @@
+"""Non-lossy lifecycle policy for authoritative source-integrity findings."""
+
+from __future__ import annotations
+
+from artana_evidence_api.evidence_selection.source_integrity.contracts import (
+    AuthoritativeSourceValidation,
+    SourceIdentityStatus,
+    SourceIntegrityStatus,
+    parse_authoritative_source_validation,
+)
+from artana_evidence_api.evidence_selection_candidates import (
+    EvidenceSelectionCandidateDecision,
+    EvidenceSelectionDecisionDeferralReason,
+    EvidenceSelectionDecisionRelevance,
+    EvidenceSelectionDecisionState,
+)
+from artana_evidence_api.types.common import JSONObject
+
+_SOURCE_VALIDATION_FIELD = "source_validation"
+
+
+def apply_source_integrity_policy(
+    *,
+    decision: EvidenceSelectionCandidateDecision,
+    record: JSONObject,
+) -> EvidenceSelectionCandidateDecision:
+    """Defer unsafe selections without converting uncertainty into rejection."""
+
+    if decision.decision is not EvidenceSelectionDecisionState.SELECTED:
+        return decision
+    raw_validation = record.get(_SOURCE_VALIDATION_FIELD)
+    if raw_validation is None and decision.source_key != "pubmed":
+        return decision
+    validation = parse_authoritative_source_validation(raw_validation)
+    if _is_clear_match(validation=validation, record=record):
+        return decision
+    return decision.with_decision(
+        decision=EvidenceSelectionDecisionState.DEFERRED,
+        relevance_label=EvidenceSelectionDecisionRelevance.NEEDS_HUMAN_REVIEW,
+        reason=_review_reason(
+            validation=validation,
+            validation_was_missing=raw_validation is None,
+        ),
+        deferral_reason=(
+            EvidenceSelectionDecisionDeferralReason.SOURCE_INTEGRITY_REVIEW
+        ),
+        shadow_decision=EvidenceSelectionDecisionState.SELECTED,
+        would_have_been_selected=True,
+    )
+
+
+def _is_clear_match(
+    *,
+    validation: AuthoritativeSourceValidation | None,
+    record: JSONObject,
+) -> bool:
+    if validation is None:
+        return False
+    pmid = record.get("pmid")
+    return (
+        validation.authority == "ncbi_pubmed"
+        and validation.validation_method == "efetch_xml"
+        and isinstance(pmid, str)
+        and pmid.strip() == validation.authority_record_id
+        and validation.source_identity is SourceIdentityStatus.MATCHED
+        and validation.source_integrity is SourceIntegrityStatus.CLEAR
+    )
+
+
+def _review_reason(
+    *,
+    validation: AuthoritativeSourceValidation | None,
+    validation_was_missing: bool,
+) -> str:
+    if validation is None:
+        problem = "missing" if validation_was_missing else "invalid"
+        return (
+            f"The authority validation payload was {problem}, so this agent-selected "
+            "record requires source-integrity review. The candidate was preserved."
+        )
+    return (
+        "The semantic agent selected this record, but authoritative source review "
+        f"is required: identity={validation.source_identity.value}, "
+        f"integrity={validation.source_integrity.value}. "
+        "The candidate was preserved without treating uncertainty as false."
+    )
+
+
+__all__ = ["apply_source_integrity_policy"]

--- a/services/artana_evidence_api/evidence_selection/source_integrity/pubmed.py
+++ b/services/artana_evidence_api/evidence_selection/source_integrity/pubmed.py
@@ -1,0 +1,308 @@
+"""Parse authoritative PubMed XML into stable source-validation facts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from html import unescape
+from typing import Final
+from xml.etree.ElementTree import Element
+
+from artana_evidence_api.evidence_selection.source_integrity.contracts import (
+    AuthoritativeSourceValidation,
+    SourceIdentityStatus,
+    SourceIntegrityStatus,
+    SourceValidationRelation,
+)
+from artana_evidence_api.types.common import JSONObject, JSONValue
+from defusedxml import ElementTree
+
+_PUBMED_AUTHORITY: Final = "ncbi_pubmed"
+_RETRACTION_RELATIONS: Final = frozenset(
+    {
+        "partialretractionin",
+        "partialretractionof",
+        "retractionin",
+        "retractionof",
+    },
+)
+_EXPRESSION_OF_CONCERN_RELATIONS: Final = frozenset(
+    {"expressionofconcernin", "expressionofconcernfor"},
+)
+_CORRECTION_RELATIONS: Final = frozenset(
+    {
+        "correctedandrepublishedin",
+        "correctedandrepublishedfrom",
+        "erratumin",
+        "erratumfor",
+    },
+)
+_RETRACTION_PUBLICATION_TYPES: Final = frozenset(
+    {"retracted publication", "retraction of publication"},
+)
+_EXPRESSION_OF_CONCERN_PUBLICATION_TYPES: Final = frozenset(
+    {"expression of concern"},
+)
+_CORRECTION_PUBLICATION_TYPES: Final = frozenset(
+    {"corrected and republished article", "published erratum"},
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PubMedAuthoritativeArticle:
+    """Canonical PubMed article fields and authority-provided relationships."""
+
+    pmid: str
+    title: str | None
+    abstract: str | None
+    doi: str | None
+    publication_types: tuple[str, ...]
+    relations: tuple[SourceValidationRelation, ...]
+
+
+def parse_pubmed_articles(xml_payload: str) -> dict[str, PubMedAuthoritativeArticle]:
+    """Parse bounded NCBI EFetch XML into records keyed by PMID."""
+
+    root = ElementTree.fromstring(xml_payload)
+    articles: dict[str, PubMedAuthoritativeArticle] = {}
+    duplicate_pmids: set[str] = set()
+    for node in root.findall(".//PubmedArticle"):
+        parsed = _parse_article(node)
+        if parsed is None or parsed.pmid in duplicate_pmids:
+            continue
+        if parsed.pmid in articles:
+            articles.pop(parsed.pmid)
+            duplicate_pmids.add(parsed.pmid)
+            continue
+        articles[parsed.pmid] = parsed
+    return articles
+
+
+def enrich_pubmed_preview_records(
+    *,
+    preview_records: list[JSONObject],
+    authoritative_articles: Mapping[str, PubMedAuthoritativeArticle],
+) -> list[JSONObject]:
+    """Merge canonical fields and categorical validation into preview records."""
+
+    return [
+        _enrich_preview_record(
+            record=record,
+            authoritative_article=authoritative_articles.get(_record_pmid(record)),
+        )
+        for record in preview_records
+    ]
+
+
+def unresolved_pubmed_preview_records(
+    preview_records: list[JSONObject],
+) -> list[JSONObject]:
+    """Preserve records when authority validation is temporarily unresolved."""
+
+    return [
+        dict(
+            record,
+            source_validation=AuthoritativeSourceValidation(
+                schema_version="authoritative_source_validation.v1",
+                authority=_PUBMED_AUTHORITY,
+                validation_method="efetch_xml",
+                authority_record_id=_record_pmid(record) or None,
+                source_identity=SourceIdentityStatus.UNRESOLVED,
+                source_integrity=SourceIntegrityStatus.UNRESOLVED,
+                explanation=(
+                    "NCBI PubMed source validation could not be completed; absence "
+                    "of a validation result is not evidence that the candidate is "
+                    "false."
+                ),
+            ).to_json(),
+        )
+        for record in preview_records
+    ]
+
+
+def _parse_article(node: Element) -> PubMedAuthoritativeArticle | None:
+    pmid = _text(node.find("./MedlineCitation/PMID"))
+    if pmid is None:
+        return None
+    title = _text(node.find("./MedlineCitation/Article/ArticleTitle"))
+    abstract = _abstract_text(node)
+    doi = _article_id(node, id_type="doi") or _elocation_doi(node)
+    publication_types = tuple(
+        value
+        for publication_type in node.findall(
+            "./MedlineCitation/Article/PublicationTypeList/PublicationType",
+        )
+        if (value := _text(publication_type)) is not None
+    )
+    relations = tuple(
+        relation
+        for relation_node in node.findall(
+            "./MedlineCitation/CommentsCorrectionsList/CommentsCorrections",
+        )
+        if (relation := _parse_relation(relation_node)) is not None
+    )
+    return PubMedAuthoritativeArticle(
+        pmid=pmid,
+        title=title,
+        abstract=abstract,
+        doi=doi,
+        publication_types=publication_types,
+        relations=relations,
+    )
+
+
+def _abstract_text(node: Element) -> str | None:
+    sections: list[str] = []
+    for abstract_node in node.findall(
+        "./MedlineCitation/Article/Abstract/AbstractText",
+    ):
+        section_text = _text(abstract_node)
+        if section_text is None:
+            continue
+        label = (abstract_node.attrib.get("Label") or "").strip()
+        sections.append(f"{label}: {section_text}" if label else section_text)
+    return "\n".join(sections) or None
+
+
+def _article_id(node: Element, *, id_type: str) -> str | None:
+    for article_id in node.findall("./PubmedData/ArticleIdList/ArticleId"):
+        if (article_id.attrib.get("IdType") or "").strip().lower() == id_type:
+            return _text(article_id)
+    return None
+
+
+def _elocation_doi(node: Element) -> str | None:
+    for location in node.findall("./MedlineCitation/Article/ELocationID"):
+        if (location.attrib.get("EIdType") or "").strip().lower() == "doi":
+            return _text(location)
+    return None
+
+
+def _parse_relation(node: Element) -> SourceValidationRelation | None:
+    relation_type = (node.attrib.get("RefType") or "").strip()
+    citation = _text(node.find("./RefSource"))
+    if not relation_type or citation is None:
+        return None
+    return SourceValidationRelation(
+        relation_type=relation_type,
+        target_id=_text(node.find("./PMID")),
+        citation=citation,
+    )
+
+
+def _enrich_preview_record(
+    *,
+    record: JSONObject,
+    authoritative_article: PubMedAuthoritativeArticle | None,
+) -> JSONObject:
+    enriched = dict(record)
+    if authoritative_article is None:
+        return unresolved_pubmed_preview_records([enriched])[0]
+    identity = _identity_status(record, authoritative_article)
+    integrity = _integrity_status(
+        relations=authoritative_article.relations,
+        publication_types=authoritative_article.publication_types,
+    )
+    if authoritative_article.title is not None:
+        enriched["title"] = authoritative_article.title
+    if authoritative_article.abstract is not None:
+        enriched["abstract"] = authoritative_article.abstract
+    if authoritative_article.doi is not None:
+        enriched["doi"] = authoritative_article.doi
+    if authoritative_article.publication_types:
+        enriched["publication_types"] = list(
+            authoritative_article.publication_types,
+        )
+    enriched["source_validation"] = AuthoritativeSourceValidation(
+        schema_version="authoritative_source_validation.v1",
+        authority=_PUBMED_AUTHORITY,
+        validation_method="efetch_xml",
+        authority_record_id=authoritative_article.pmid,
+        source_identity=identity,
+        source_integrity=integrity,
+        explanation=_validation_explanation(identity=identity, integrity=integrity),
+        relations=authoritative_article.relations,
+    ).to_json()
+    return enriched
+
+
+def _identity_status(
+    record: JSONObject,
+    article: PubMedAuthoritativeArticle,
+) -> SourceIdentityStatus:
+    if _record_pmid(record) != article.pmid:
+        return SourceIdentityStatus.MISMATCHED
+    summary_doi = _normalized_scalar(record.get("doi"))
+    if (
+        summary_doi is not None
+        and article.doi is not None
+        and summary_doi.casefold() != article.doi.casefold()
+    ):
+        return SourceIdentityStatus.MISMATCHED
+    return SourceIdentityStatus.MATCHED
+
+
+def _integrity_status(
+    *,
+    relations: tuple[SourceValidationRelation, ...],
+    publication_types: tuple[str, ...],
+) -> SourceIntegrityStatus:
+    relation_types = {
+        relation.relation_type.replace(" ", "").casefold() for relation in relations
+    }
+    normalized_publication_types = {
+        publication_type.casefold() for publication_type in publication_types
+    }
+    if (
+        relation_types & _RETRACTION_RELATIONS
+        or normalized_publication_types & _RETRACTION_PUBLICATION_TYPES
+    ):
+        return SourceIntegrityStatus.RETRACTED
+    if (
+        relation_types & _EXPRESSION_OF_CONCERN_RELATIONS
+        or normalized_publication_types & _EXPRESSION_OF_CONCERN_PUBLICATION_TYPES
+    ):
+        return SourceIntegrityStatus.EXPRESSION_OF_CONCERN
+    if (
+        relation_types & _CORRECTION_RELATIONS
+        or normalized_publication_types & _CORRECTION_PUBLICATION_TYPES
+    ):
+        return SourceIntegrityStatus.CORRECTION_REVIEW
+    return SourceIntegrityStatus.CLEAR
+
+
+def _validation_explanation(
+    *,
+    identity: SourceIdentityStatus,
+    integrity: SourceIntegrityStatus,
+) -> str:
+    return (
+        "NCBI PubMed EFetch verified the requested source identity and publication "
+        f"integrity categories: identity={identity.value}, integrity={integrity.value}."
+    )
+
+
+def _record_pmid(record: Mapping[str, JSONValue]) -> str:
+    return _normalized_scalar(record.get("pmid")) or ""
+
+
+def _normalized_scalar(value: JSONValue | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _text(node: Element | None) -> str | None:
+    if node is None:
+        return None
+    normalized = " ".join(unescape("".join(node.itertext())).split())
+    return normalized or None
+
+
+__all__ = [
+    "PubMedAuthoritativeArticle",
+    "enrich_pubmed_preview_records",
+    "parse_pubmed_articles",
+    "unresolved_pubmed_preview_records",
+]

--- a/services/artana_evidence_api/evidence_selection_candidates.py
+++ b/services/artana_evidence_api/evidence_selection_candidates.py
@@ -46,6 +46,7 @@ class EvidenceSelectionDecisionDeferralReason(StrEnum):
     SHADOW_MODE = "shadow_mode"
     SEMANTIC_REVIEW = "semantic_review"
     SEMANTIC_AGENT_FAILURE = "semantic_agent_failure"
+    SOURCE_INTEGRITY_REVIEW = "source_integrity_review"
 
 
 @dataclass(frozen=True, slots=True)

--- a/services/artana_evidence_api/pubmed_search.py
+++ b/services/artana_evidence_api/pubmed_search.py
@@ -4,19 +4,28 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import logging
 import os
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, TypeVar
+from xml.etree.ElementTree import ParseError
 
 import httpx
+from artana_evidence_api.evidence_selection.source_integrity.pubmed import (
+    enrich_pubmed_preview_records,
+    parse_pubmed_articles,
+    unresolved_pubmed_preview_records,
+)
 from artana_evidence_api.request_context import build_request_id_headers
 from artana_evidence_api.runtime.http_response_limits import (
     async_limited_json_from_response,
+    async_limited_text_from_response,
 )
 from artana_evidence_api.types.common import JSONObject, JSONValue
+from defusedxml.common import DefusedXmlException
 
 if TYPE_CHECKING:
     from artana_evidence_api.pubmed_discovery import AdvancedQueryParameters
@@ -41,6 +50,9 @@ _ENV_NCBI_API_KEY = "NCBI_API_KEY"
 _ENV_NCBI_EMAIL = "NCBI_EMAIL"
 _ENV_NCBI_TOOL = "NCBI_TOOL"
 _ENV_TESTING = "TESTING"
+
+_ResponsePayload = TypeVar("_ResponsePayload")
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -211,8 +223,7 @@ def _resolve_pubmed_search_backend() -> str:
     if normalized in {"live", "real", _BACKEND_NCBI}:
         return _BACKEND_NCBI
     msg = (
-        "Unsupported ARTANA_PUBMED_SEARCH_BACKEND value. "
-        "Use 'deterministic' or 'ncbi'."
+        "Unsupported ARTANA_PUBMED_SEARCH_BACKEND value. Use 'deterministic' or 'ncbi'."
     )
     raise ValueError(msg)
 
@@ -351,6 +362,15 @@ class NCBIPubMedSearchGateway(PubMedSearchGateway):
             },
         )
 
+    def _build_fetch_params(self, article_ids: list[str]) -> dict[str, str | int]:
+        return self._attach_ncbi_metadata(
+            {
+                "db": "pubmed",
+                "id": ",".join(article_ids),
+                "retmode": "xml",
+            },
+        )
+
     async def _fetch_preview_records(
         self,
         client: httpx.AsyncClient,
@@ -384,7 +404,51 @@ class NCBIPubMedSearchGateway(PubMedSearchGateway):
                 preview_records.append(
                     self._build_preview_record(article_id, raw_summary),
                 )
-        return preview_records
+        return await self._enrich_with_authoritative_source(
+            client=client,
+            preview_records=preview_records,
+        )
+
+    async def _enrich_with_authoritative_source(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        preview_records: list[JSONObject],
+    ) -> list[JSONObject]:
+        if not preview_records:
+            return []
+        article_ids = [
+            pmid
+            for record in preview_records
+            if isinstance((pmid := record.get("pmid")), str) and pmid
+        ]
+        if not article_ids:
+            return unresolved_pubmed_preview_records(preview_records)
+        try:
+            xml_payload = await self._request_text_with_retry(
+                client,
+                "GET",
+                "efetch.fcgi",
+                params=self._build_fetch_params(article_ids),
+                context="PubMed EFetch response",
+            )
+            authoritative_articles = parse_pubmed_articles(xml_payload)
+        except (
+            DefusedXmlException,
+            ParseError,
+            PubMedSearchRateLimitError,
+            UnicodeError,
+            httpx.HTTPError,
+        ) as exc:
+            _LOGGER.warning(
+                "PubMed source validation was unresolved (%s).",
+                type(exc).__name__,
+            )
+            return unresolved_pubmed_preview_records(preview_records)
+        return enrich_pubmed_preview_records(
+            preview_records=preview_records,
+            authoritative_articles=authoritative_articles,
+        )
 
     async def _request_json_with_retry(
         self,
@@ -395,16 +459,53 @@ class NCBIPubMedSearchGateway(PubMedSearchGateway):
         params: Mapping[str, str | int],
         context: str,
     ) -> object:
+        return await self._request_with_retry(
+            client,
+            method,
+            path,
+            params=params,
+            decoder=lambda response: async_limited_json_from_response(
+                response,
+                context=context,
+            ),
+        )
+
+    async def _request_text_with_retry(
+        self,
+        client: httpx.AsyncClient,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, str | int],
+        context: str,
+    ) -> str:
+        return await self._request_with_retry(
+            client,
+            method,
+            path,
+            params=params,
+            decoder=lambda response: async_limited_text_from_response(
+                response,
+                context=context,
+            ),
+        )
+
+    async def _request_with_retry(
+        self,
+        client: httpx.AsyncClient,
+        method: str,
+        path: str,
+        *,
+        params: Mapping[str, str | int],
+        decoder: Callable[[httpx.Response], Awaitable[_ResponsePayload]],
+    ) -> _ResponsePayload:
         for delay_seconds in _PUBMED_429_RETRY_DELAYS_SECONDS:
             await self._rate_limiter.acquire()
             try:
                 async with client.stream(method, path, params=params) as response:
                     if not self._is_retryable_response(response):
                         response.raise_for_status()
-                        return await async_limited_json_from_response(
-                            response,
-                            context=context,
-                        )
+                        return await decoder(response)
                     retry_delay_seconds = self._retry_delay_seconds(
                         response,
                         delay_seconds,
@@ -424,10 +525,7 @@ class NCBIPubMedSearchGateway(PubMedSearchGateway):
                     retry_after_seconds=retry_after_seconds,
                 )
             final_response.raise_for_status()
-            return await async_limited_json_from_response(
-                final_response,
-                context=context,
-            )
+            return await decoder(final_response)
 
     @staticmethod
     def _is_retryable_response(response: httpx.Response) -> bool:

--- a/services/artana_evidence_api/runtime/http_response_limits.py
+++ b/services/artana_evidence_api/runtime/http_response_limits.py
@@ -182,6 +182,24 @@ async def async_limited_json_from_response(
     )
 
 
+async def async_limited_text_from_response(
+    response: httpx.Response,
+    *,
+    context: str,
+    max_bytes: int | None = None,
+) -> str:
+    """Decode a streamed async text response after bounding its body size."""
+
+    return _decode_text(
+        await _aread_limited_response(
+            response,
+            context=context,
+            max_bytes=max_bytes,
+        ),
+        context=context,
+    )
+
+
 async def async_get_limited_text(
     client: httpx.AsyncClient,
     url: str,

--- a/services/artana_evidence_api/source_plugins/pubmed.py
+++ b/services/artana_evidence_api/source_plugins/pubmed.py
@@ -11,6 +11,9 @@ from artana_evidence_api.direct_source_search import (
     DirectSourceSearchRecord,
     PubMedSourceSearchResponse,
 )
+from artana_evidence_api.evidence_selection.source_integrity.contracts import (
+    parse_authoritative_source_validation,
+)
 from artana_evidence_api.pubmed_discovery import (
     AdvancedQueryParameters,
     DiscoverySearchJob,
@@ -210,12 +213,13 @@ class PubMedSourcePlugin:
     def normalize_record(self, record: JSONObject) -> JSONObject:
         """Return normalized PubMed preview/article record fields."""
 
-        return compact_json_object(
+        normalized = compact_json_object(
             {
                 "pmid": string_field(record, "pmid", "pubmed_id", "uid"),
                 "title": string_field(record, "title"),
                 "abstract": string_field(record, "abstract"),
                 "journal": string_field(record, "journal", "source"),
+                "doi": string_field(record, "doi"),
                 "publication_date": string_field(
                     record,
                     "publication_date",
@@ -228,6 +232,12 @@ class PubMedSourcePlugin:
                 ),
             },
         )
+        source_validation = parse_authoritative_source_validation(
+            record.get("source_validation"),
+        )
+        if source_validation is not None:
+            normalized["source_validation"] = source_validation.to_json()
+        return normalized
 
     def provider_external_id(self, record: JSONObject) -> str | None:
         """Return the PMID used as PubMed's provider record identifier."""
@@ -405,7 +415,10 @@ def build_pubmed_execution_plugin(
     del marrvel_discovery_service_factory
     if pubmed_discovery_service_factory is None:
         return PUBMED_PLUGIN
-    return PubMedSourcePlugin(discovery_service_factory=pubmed_discovery_service_factory)
+    return PubMedSourcePlugin(
+        discovery_service_factory=pubmed_discovery_service_factory
+    )
+
 
 __all__ = [
     "PUBMED_PLUGIN",

--- a/services/artana_evidence_api/tests/unit/test_evidence_selection_semantic_screening.py
+++ b/services/artana_evidence_api/tests/unit/test_evidence_selection_semantic_screening.py
@@ -40,6 +40,8 @@ from artana_evidence_api.evidence_selection.semantic.screening import (
 )
 from artana_evidence_api.evidence_selection_candidates import (
     EvidenceSelectionCandidateSearch,
+    EvidenceSelectionDecisionRelevance,
+    EvidenceSelectionDecisionState,
     record_hash,
 )
 from artana_evidence_api.pubmed_discovery import AdvancedQueryParameters
@@ -59,21 +61,56 @@ _BASELINE_REPORT_PATH = Path(
     "docs/validation/reports/2026-07-11-pr-semantic-pr1-failure-corpus-baseline.json",
 )
 _TEST_SEARCH_ID = UUID("11111111-1111-4111-8111-111111111111")
+
+
+def _source_validation(
+    *,
+    identity: str,
+    integrity: str,
+    authority_record_id: str = "1",
+) -> JSONObject:
+    return {
+        "schema_version": "authoritative_source_validation.v1",
+        "authority": "ncbi_pubmed",
+        "validation_method": "efetch_xml",
+        "authority_record_id": authority_record_id,
+        "source_identity": identity,
+        "source_integrity": integrity,
+        "explanation": "Categorical source-integrity finding.",
+        "relations": [],
+    }
+
+
 _TEST_RECORDS: tuple[JSONObject, ...] = (
     {
         "pmid": "1",
         "title": "EGFR T790M response in treated patients",
         "abstract": "EGFR T790M response was observed after targeted treatment.",
+        "source_validation": _source_validation(
+            identity="matched",
+            integrity="clear",
+            authority_record_id="1",
+        ),
     },
     {
         "pmid": "2",
         "title": "KRAS colorectal review",
         "abstract": "A narrative review of KRAS colorectal cancer biology.",
+        "source_validation": _source_validation(
+            identity="matched",
+            integrity="clear",
+            authority_record_id="2",
+        ),
     },
     {
         "pmid": "3",
         "title": "EGFR commentary",
         "abstract": "EGFR commentary with no stated variant or patient outcome.",
+        "source_validation": _source_validation(
+            identity="matched",
+            integrity="clear",
+            authority_record_id="3",
+        ),
     },
 )
 
@@ -272,6 +309,178 @@ async def test_agent_screening_maps_categories_to_deterministic_actions() -> Non
     assert runner.contexts[0].exclusion_criteria == (
         "Exclude review articles without primary patient evidence",
     )
+
+
+@pytest.mark.asyncio
+async def test_clear_source_validation_preserves_agent_selection() -> None:
+    record: JSONObject = {
+        **_TEST_RECORDS[0],
+        "knowledge_status": "emerging_hypothesis",
+        "source_validation": _source_validation(
+            identity="matched",
+            integrity="clear",
+        ),
+    }
+    runner = _FakeSemanticRunner(
+        _contract(
+            _assessment(
+                index=0,
+                decision="select",
+                objective="direct",
+                record=record,
+            ),
+        ),
+    )
+
+    result = await AgentEvidenceSelectionCandidateScreener(
+        model_runner=runner,
+    ).screen(context=_screening_context(records=(record,)))
+
+    assert len(result.selected_records) == 1
+    assert result.skipped_records == ()
+    assert result.deferred_records == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("identity", "integrity"),
+    [
+        ("matched", "correction_review"),
+        ("matched", "expression_of_concern"),
+        ("matched", "retracted"),
+        ("mismatched", "clear"),
+        ("unresolved", "unresolved"),
+    ],
+)
+async def test_source_integrity_review_preserves_agent_selected_candidate(
+    identity: str,
+    integrity: str,
+) -> None:
+    record: JSONObject = {
+        **_TEST_RECORDS[0],
+        "knowledge_status": "new_hypothesis",
+        "source_validation": _source_validation(
+            identity=identity,
+            integrity=integrity,
+        ),
+    }
+    runner = _FakeSemanticRunner(
+        _contract(
+            _assessment(
+                index=0,
+                decision="select",
+                objective="direct",
+                record=record,
+            ),
+        ),
+    )
+
+    result = await AgentEvidenceSelectionCandidateScreener(
+        model_runner=runner,
+    ).screen(context=_screening_context(records=(record,)))
+
+    assert result.selected_records == ()
+    assert result.skipped_records == ()
+    assert len(result.deferred_records) == 1
+    preserved = result.deferred_records[0]
+    assert preserved.deferral_reason == "source_integrity_review"
+    assert (
+        preserved.original_relevance_label
+        is EvidenceSelectionDecisionRelevance.STRONG_FIT
+    )
+    assert preserved.shadow_decision is EvidenceSelectionDecisionState.SELECTED
+    assert preserved.would_have_been_selected is True
+    assert "preserved" in preserved.reason
+
+
+@pytest.mark.asyncio
+async def test_invalid_source_validation_fails_closed_without_rejecting_candidate() -> (
+    None
+):
+    record: JSONObject = {
+        **_TEST_RECORDS[0],
+        "source_validation": {"authority": "ncbi_pubmed"},
+    }
+    runner = _FakeSemanticRunner(
+        _contract(
+            _assessment(
+                index=0,
+                decision="select",
+                objective="direct",
+                record=record,
+            ),
+        ),
+    )
+
+    result = await AgentEvidenceSelectionCandidateScreener(
+        model_runner=runner,
+    ).screen(context=_screening_context(records=(record,)))
+
+    assert result.selected_records == ()
+    assert result.skipped_records == ()
+    assert len(result.deferred_records) == 1
+    assert result.deferred_records[0].deferral_reason == "source_integrity_review"
+    assert result.deferred_records[0].would_have_been_selected is True
+
+
+@pytest.mark.asyncio
+async def test_missing_pubmed_validation_fails_closed_without_rejecting_candidate() -> (
+    None
+):
+    record: JSONObject = {
+        "pmid": "1",
+        "title": "New mechanistic hypothesis",
+        "abstract": "A newly reported mechanism requiring expert review.",
+    }
+    runner = _FakeSemanticRunner(
+        _contract(
+            _assessment(
+                index=0,
+                decision="select",
+                objective="direct",
+                record=record,
+            ),
+        ),
+    )
+
+    result = await AgentEvidenceSelectionCandidateScreener(
+        model_runner=runner,
+    ).screen(context=_screening_context(records=(record,)))
+
+    assert result.selected_records == ()
+    assert result.skipped_records == ()
+    assert result.deferred_records[0].deferral_reason == "source_integrity_review"
+    assert result.deferred_records[0].shadow_decision == "selected"
+    assert result.deferred_records[0].would_have_been_selected is True
+
+
+@pytest.mark.asyncio
+async def test_clear_validation_for_another_record_cannot_bypass_review() -> None:
+    source_validation = _source_validation(identity="matched", integrity="clear")
+    source_validation["authority_record_id"] = "another-pmid"
+    record: JSONObject = {
+        **_TEST_RECORDS[0],
+        "source_validation": source_validation,
+    }
+    runner = _FakeSemanticRunner(
+        _contract(
+            _assessment(
+                index=0,
+                decision="select",
+                objective="direct",
+                record=record,
+            ),
+        ),
+    )
+
+    result = await AgentEvidenceSelectionCandidateScreener(
+        model_runner=runner,
+    ).screen(context=_screening_context(records=(record,)))
+
+    assert result.selected_records == ()
+    assert result.skipped_records == ()
+    assert result.deferred_records[0].deferral_reason == "source_integrity_review"
+    assert result.deferred_records[0].would_have_been_selected is True
 
 
 @pytest.mark.asyncio
@@ -721,7 +930,10 @@ async def test_agent_evaluation_counts_invalid_agent_without_fallback() -> None:
     assert evaluation.quality_gate_passed is False
 
 
-def _screening_context() -> EvidenceSelectionScreeningContext:
+def _screening_context(
+    *,
+    records: tuple[JSONObject, ...] = _TEST_RECORDS,
+) -> EvidenceSelectionScreeningContext:
     space_id = uuid4()
     owner_id = uuid4()
     search_id = _TEST_SEARCH_ID
@@ -731,6 +943,7 @@ def _screening_context() -> EvidenceSelectionScreeningContext:
             space_id=space_id,
             owner_id=owner_id,
             search_id=search_id,
+            records=records,
         ),
         created_by=owner_id,
     )
@@ -749,10 +962,10 @@ def _screening_context() -> EvidenceSelectionScreeningContext:
             EvidenceSelectionCandidateSearch(
                 source_key="pubmed",
                 search_id=search_id,
-                max_records=3,
+                max_records=len(records),
             ),
         ),
-        max_records_per_search=3,
+        max_records_per_search=len(records),
         direct_source_search_store=store,
         document_store=HarnessDocumentStore(),
     )
@@ -798,9 +1011,10 @@ def _pubmed_search(
     space_id: UUID,
     owner_id: UUID,
     search_id: UUID,
+    records: tuple[JSONObject, ...] = _TEST_RECORDS,
 ) -> PubMedSourceSearchResponse:
     now = datetime.now(UTC)
-    records = list(_TEST_RECORDS)
+    record_list = list(records)
     capture = source_result_capture_metadata(
         source_key="pubmed",
         capture_stage=SourceCaptureStage.SEARCH_RESULT,
@@ -810,7 +1024,7 @@ def _pubmed_search(
         search_id=str(search_id),
         query="EGFR T790M treatment response",
         query_payload={"search_term": "EGFR T790M treatment response"},
-        result_count=len(records),
+        result_count=len(record_list),
         provenance={"provider": "semantic_screening_test"},
     )
     return PubMedSourceSearchResponse(
@@ -823,9 +1037,9 @@ def _pubmed_search(
             search_term="EGFR T790M treatment response",
             max_results=len(records),
         ),
-        total_results=len(records),
-        record_count=len(records),
-        records=records,
+        total_results=len(record_list),
+        record_count=len(record_list),
+        records=record_list,
         created_at=now,
         updated_at=now,
         completed_at=now,

--- a/services/artana_evidence_api/tests/unit/test_pubmed_discovery.py
+++ b/services/artana_evidence_api/tests/unit/test_pubmed_discovery.py
@@ -175,6 +175,12 @@ async def test_ncbi_pubmed_gateway_retries_rate_limit_and_succeeds(
                     },
                 },
             )
+        if request.url.path.endswith("/efetch.fcgi"):
+            return httpx.Response(
+                status_code=200,
+                request=request,
+                text=_efetch_xml("111", "222"),
+            )
         raise AssertionError(f"Unexpected request path: {request.url.path}")
 
     from artana_evidence_api import pubmed_search
@@ -197,6 +203,20 @@ async def test_ncbi_pubmed_gateway_retries_rate_limit_and_succeeds(
     assert sleep_calls == [1.0, 2.0]
     assert payload.article_ids == ["111", "222"]
     assert payload.total_count == 2
+    assert payload.preview_records[0]["abstract"] == "Authoritative abstract 111."
+    assert payload.preview_records[0]["source_validation"] == {
+        "schema_version": "authoritative_source_validation.v1",
+        "authority": "ncbi_pubmed",
+        "validation_method": "efetch_xml",
+        "authority_record_id": "111",
+        "source_identity": "matched",
+        "source_integrity": "clear",
+        "explanation": (
+            "NCBI PubMed EFetch verified the requested source identity and "
+            "publication integrity categories: identity=matched, integrity=clear."
+        ),
+        "relations": [],
+    }
 
 
 @pytest.mark.asyncio
@@ -246,6 +266,12 @@ async def test_ncbi_pubmed_gateway_retries_transient_server_errors(
                     },
                 },
             )
+        if request.url.path.endswith("/efetch.fcgi"):
+            return httpx.Response(
+                status_code=200,
+                request=request,
+                text=_efetch_xml("111"),
+            )
         raise AssertionError(f"Unexpected request path: {request.url.path}")
 
     from artana_evidence_api import pubmed_search
@@ -265,6 +291,50 @@ async def test_ncbi_pubmed_gateway_retries_transient_server_errors(
     assert summary_attempts == 1
     assert sleep_calls == [1.0]
     assert payload.article_ids == ["111"]
+
+
+@pytest.mark.asyncio
+async def test_ncbi_pubmed_gateway_preserves_preview_when_efetch_is_malformed() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/esearch.fcgi"):
+            return httpx.Response(
+                status_code=200,
+                request=request,
+                json={"esearchresult": {"count": "1", "idlist": ["111"]}},
+            )
+        if request.url.path.endswith("/esummary.fcgi"):
+            return httpx.Response(
+                status_code=200,
+                request=request,
+                json={
+                    "result": {
+                        "uids": ["111"],
+                        "111": {"title": "Emerging result"},
+                    },
+                },
+            )
+        if request.url.path.endswith("/efetch.fcgi"):
+            return httpx.Response(
+                status_code=200,
+                request=request,
+                text="<malformed",
+            )
+        raise AssertionError(f"Unexpected request path: {request.url.path}")
+
+    gateway = NCBIPubMedSearchGateway(
+        settings=NCBIPubMedGatewaySettings(timeout_seconds=1.0),
+        transport=httpx.MockTransport(handler),
+    )
+
+    payload = await gateway.run_search(
+        AdvancedQueryParameters(search_term="emerging hypothesis"),
+    )
+
+    assert payload.preview_records[0]["title"] == "Emerging result"
+    validation = payload.preview_records[0]["source_validation"]
+    assert isinstance(validation, dict)
+    assert validation["source_identity"] == "unresolved"
+    assert validation["source_integrity"] == "unresolved"
 
 
 @pytest.mark.asyncio
@@ -424,3 +494,20 @@ def test_get_search_job_translates_platform_session_id_back_to_space_id(
 
     assert response is not None
     assert response.session_id == harness_space_id
+
+
+def _efetch_xml(*pmids: str) -> str:
+    articles = "".join(
+        (
+            "<PubmedArticle><MedlineCitation>"
+            f"<PMID>{pmid}</PMID>"
+            "<Article>"
+            f"<ArticleTitle>Canonical result {pmid}</ArticleTitle>"
+            f"<Abstract><AbstractText>Authoritative abstract {pmid}.</AbstractText>"
+            "</Abstract>"
+            "</Article>"
+            "</MedlineCitation></PubmedArticle>"
+        )
+        for pmid in pmids
+    )
+    return f"<PubmedArticleSet>{articles}</PubmedArticleSet>"

--- a/services/artana_evidence_api/tests/unit/test_pubmed_plugin.py
+++ b/services/artana_evidence_api/tests/unit/test_pubmed_plugin.py
@@ -66,8 +66,14 @@ def test_pubmed_plugin_matches_legacy_query_playbook() -> None:
 
     assert legacy_playbook is not None
     assert plugin.build_query_payload(intent) == legacy_playbook.build_payload(intent)
-    assert plugin.supported_objective_intents == legacy_playbook.supported_objective_intents
-    assert plugin.result_interpretation_hints == legacy_playbook.result_interpretation_hints
+    assert (
+        plugin.supported_objective_intents
+        == legacy_playbook.supported_objective_intents
+    )
+    assert (
+        plugin.result_interpretation_hints
+        == legacy_playbook.result_interpretation_hints
+    )
     assert plugin.non_goals == legacy_playbook.non_goals
     assert plugin.handoff_eligible is legacy_playbook.handoff_eligible
 
@@ -80,8 +86,12 @@ def test_pubmed_plugin_matches_legacy_record_policy() -> None:
     assert legacy_policy is not None
     assert plugin.handoff_target_kind == legacy_policy.handoff_target_kind
     assert plugin.direct_search_supported is legacy_policy.direct_search_supported
-    assert plugin.provider_external_id(record) == legacy_policy.provider_external_id(record)
-    assert plugin.recommends_variant_aware(record) is legacy_policy.recommends_variant_aware(record)
+    assert plugin.provider_external_id(record) == legacy_policy.provider_external_id(
+        record
+    )
+    assert plugin.recommends_variant_aware(
+        record
+    ) is legacy_policy.recommends_variant_aware(record)
     assert plugin.normalize_record(record) == legacy_policy.normalize_record(record)
 
 
@@ -150,6 +160,34 @@ def test_pubmed_plugin_normalizes_pubdate_to_publication_date() -> None:
         "title": "MED13 and congenital heart disease",
         "journal": "Journal of MED13",
         "publication_date": "2025 Dec",
+    }
+
+
+def test_pubmed_plugin_preserves_authoritative_source_validation() -> None:
+    plugin = PubMedSourcePlugin()
+    source_validation = {
+        "schema_version": "authoritative_source_validation.v1",
+        "authority": "ncbi_pubmed",
+        "validation_method": "efetch_xml",
+        "authority_record_id": "12345",
+        "source_identity": "matched",
+        "source_integrity": "clear",
+        "explanation": "Verified by NCBI PubMed EFetch.",
+        "relations": [],
+    }
+
+    normalized = plugin.normalize_record(
+        {
+            "pmid": "12345",
+            "doi": "10.1000/example",
+            "source_validation": source_validation,
+        },
+    )
+
+    assert normalized == {
+        "pmid": "12345",
+        "doi": "10.1000/example",
+        "source_validation": source_validation,
     }
 
 

--- a/services/artana_evidence_api/tests/unit/test_pubmed_source_validation.py
+++ b/services/artana_evidence_api/tests/unit/test_pubmed_source_validation.py
@@ -1,0 +1,259 @@
+"""Tests for categorical, authoritative PubMed source validation."""
+
+from __future__ import annotations
+
+import pytest
+from artana_evidence_api.evidence_selection.source_integrity.pubmed import (
+    enrich_pubmed_preview_records,
+    parse_pubmed_articles,
+)
+from defusedxml.common import EntitiesForbidden
+
+
+def test_pubmed_xml_enriches_abstract_and_clear_identity() -> None:
+    articles = parse_pubmed_articles(
+        _article_xml(
+            pmid="12345",
+            doi="10.1000/clear",
+            abstract=(
+                '<AbstractText Label="RESULTS">A specific patient response.</AbstractText>'
+            ),
+        ),
+    )
+
+    records = enrich_pubmed_preview_records(
+        preview_records=[
+            {"pmid": "12345", "title": "Summary title", "doi": "10.1000/clear"},
+        ],
+        authoritative_articles=articles,
+    )
+
+    assert records[0]["title"] == "Canonical title"
+    assert records[0]["abstract"] == "RESULTS: A specific patient response."
+    assert records[0]["publication_types"] == ["Clinical Trial"]
+    validation = records[0]["source_validation"]
+    assert isinstance(validation, dict)
+    assert validation["source_identity"] == "matched"
+    assert validation["source_integrity"] == "clear"
+
+
+@pytest.mark.parametrize(
+    ("relation_type", "expected_integrity"),
+    [
+        ("ErratumIn", "correction_review"),
+        ("ExpressionOfConcernIn", "expression_of_concern"),
+        ("RetractionIn", "retracted"),
+    ],
+)
+def test_pubmed_integrity_relations_are_preserved_and_categorized(
+    relation_type: str,
+    expected_integrity: str,
+) -> None:
+    articles = parse_pubmed_articles(
+        _article_xml(
+            pmid="12345",
+            relation_type=relation_type,
+            related_pmid="67890",
+        ),
+    )
+
+    records = enrich_pubmed_preview_records(
+        preview_records=[{"pmid": "12345", "title": "Summary title"}],
+        authoritative_articles=articles,
+    )
+
+    validation = records[0]["source_validation"]
+    assert isinstance(validation, dict)
+    assert validation["source_integrity"] == expected_integrity
+    assert validation["relations"] == [
+        {
+            "relation_type": relation_type,
+            "target_id": "67890",
+            "citation": "Related publication",
+        },
+    ]
+
+
+def test_non_integrity_update_relation_does_not_block_source() -> None:
+    articles = parse_pubmed_articles(
+        _article_xml(pmid="12345", relation_type="UpdateIn"),
+    )
+
+    records = enrich_pubmed_preview_records(
+        preview_records=[{"pmid": "12345"}],
+        authoritative_articles=articles,
+    )
+
+    validation = records[0]["source_validation"]
+    assert isinstance(validation, dict)
+    assert validation["source_integrity"] == "clear"
+    assert validation["relations"][0]["relation_type"] == "UpdateIn"
+
+
+@pytest.mark.parametrize(
+    ("publication_type", "expected_integrity"),
+    [
+        ("Retracted Publication", "retracted"),
+        ("Retraction of Publication", "retracted"),
+        ("Expression of Concern", "expression_of_concern"),
+        ("Published Erratum", "correction_review"),
+    ],
+)
+def test_publication_type_is_an_independent_integrity_signal(
+    publication_type: str,
+    expected_integrity: str,
+) -> None:
+    articles = parse_pubmed_articles(
+        _article_xml(pmid="12345", publication_type=publication_type),
+    )
+
+    records = enrich_pubmed_preview_records(
+        preview_records=[{"pmid": "12345"}],
+        authoritative_articles=articles,
+    )
+
+    validation = records[0]["source_validation"]
+    assert isinstance(validation, dict)
+    assert validation["source_integrity"] == expected_integrity
+
+
+def test_missing_authoritative_record_is_unresolved_not_false() -> None:
+    records = enrich_pubmed_preview_records(
+        preview_records=[{"pmid": "new-record", "title": "Emerging hypothesis"}],
+        authoritative_articles={},
+    )
+
+    assert records[0]["title"] == "Emerging hypothesis"
+    validation = records[0]["source_validation"]
+    assert isinstance(validation, dict)
+    assert validation["source_identity"] == "unresolved"
+    assert validation["source_integrity"] == "unresolved"
+    assert "not evidence that the candidate is false" in validation["explanation"]
+
+
+def test_authoritative_articles_are_matched_by_pmid_not_response_order() -> None:
+    articles = parse_pubmed_articles(_article_xml(pmid="222"))
+    articles.update(parse_pubmed_articles(_article_xml(pmid="111")))
+
+    records = enrich_pubmed_preview_records(
+        preview_records=[{"pmid": "111"}, {"pmid": "222"}, {"pmid": "333"}],
+        authoritative_articles=articles,
+    )
+
+    assert records[0]["title"] == "Canonical title"
+    assert records[1]["title"] == "Canonical title"
+    first_validation = records[0]["source_validation"]
+    second_validation = records[1]["source_validation"]
+    missing_validation = records[2]["source_validation"]
+    assert isinstance(first_validation, dict)
+    assert isinstance(second_validation, dict)
+    assert isinstance(missing_validation, dict)
+    assert first_validation["authority_record_id"] == "111"
+    assert second_validation["authority_record_id"] == "222"
+    assert missing_validation["source_identity"] == "unresolved"
+
+
+def test_duplicate_authoritative_pmid_fails_closed_as_unresolved() -> None:
+    duplicate_payload = (
+        "<PubmedArticleSet>"
+        + _article_fragment(pmid="12345", publication_type="Clinical Trial")
+        + _article_fragment(
+            pmid="12345",
+            publication_type="Retracted Publication",
+        )
+        + "</PubmedArticleSet>"
+    )
+
+    records = enrich_pubmed_preview_records(
+        preview_records=[{"pmid": "12345"}],
+        authoritative_articles=parse_pubmed_articles(duplicate_payload),
+    )
+
+    validation = records[0]["source_validation"]
+    assert isinstance(validation, dict)
+    assert validation["source_identity"] == "unresolved"
+    assert validation["source_integrity"] == "unresolved"
+
+
+def test_doi_disagreement_is_categorical_identity_mismatch() -> None:
+    articles = parse_pubmed_articles(
+        _article_xml(pmid="12345", doi="10.1000/authority"),
+    )
+
+    records = enrich_pubmed_preview_records(
+        preview_records=[{"pmid": "12345", "doi": "10.1000/other"}],
+        authoritative_articles=articles,
+    )
+
+    validation = records[0]["source_validation"]
+    assert isinstance(validation, dict)
+    assert validation["source_identity"] == "mismatched"
+
+
+def test_pubmed_xml_parser_rejects_external_entities() -> None:
+    malicious_xml = """<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+    <PubmedArticleSet><PubmedArticle><MedlineCitation>
+    <PMID>12345</PMID><Article><ArticleTitle>&xxe;</ArticleTitle></Article>
+    </MedlineCitation></PubmedArticle></PubmedArticleSet>"""
+
+    with pytest.raises(EntitiesForbidden):
+        parse_pubmed_articles(malicious_xml)
+
+
+def _article_xml(
+    *,
+    pmid: str,
+    doi: str | None = None,
+    abstract: str = "<AbstractText>Focused abstract.</AbstractText>",
+    relation_type: str | None = None,
+    related_pmid: str = "67890",
+    publication_type: str = "Clinical Trial",
+) -> str:
+    return (
+        "<PubmedArticleSet>"
+        + _article_fragment(
+            pmid=pmid,
+            doi=doi,
+            abstract=abstract,
+            relation_type=relation_type,
+            related_pmid=related_pmid,
+            publication_type=publication_type,
+        )
+        + "</PubmedArticleSet>"
+    )
+
+
+def _article_fragment(
+    *,
+    pmid: str,
+    doi: str | None = None,
+    abstract: str = "<AbstractText>Focused abstract.</AbstractText>",
+    relation_type: str | None = None,
+    related_pmid: str = "67890",
+    publication_type: str = "Clinical Trial",
+) -> str:
+    article_id = f'<ArticleId IdType="doi">{doi}</ArticleId>' if doi else ""
+    relation = (
+        ""
+        if relation_type is None
+        else (
+            "<CommentsCorrectionsList>"
+            f'<CommentsCorrections RefType="{relation_type}">'
+            "<RefSource>Related publication</RefSource>"
+            f"<PMID>{related_pmid}</PMID>"
+            "</CommentsCorrections>"
+            "</CommentsCorrectionsList>"
+        )
+    )
+    return f"""<PubmedArticle>
+      <MedlineCitation>
+        <PMID>{pmid}</PMID>
+        <Article>
+          <ArticleTitle>Canonical <i>title</i></ArticleTitle>
+          <Abstract>{abstract}</Abstract>
+          <PublicationTypeList><PublicationType>{publication_type}</PublicationType></PublicationTypeList>
+        </Article>
+        {relation}
+      </MedlineCitation>
+      <PubmedData><ArticleIdList>{article_id}</ArticleIdList></PubmedData>
+    </PubmedArticle>"""


### PR DESCRIPTION
## Summary

- enrich live PubMed preview records from bounded, hardened NCBI EFetch XML with canonical abstracts, DOI, publication types, and correction relationships
- add strict categorical identity/integrity contracts and a PMID-bound allowlisted policy before agent-selected records enter the selected lane
- preserve missing, corrected, concerning, retracted, mismatched, invalid, and unresolved candidates as review work with the original agent selection retained
- record implementation and live-validation evidence in the PR156 validation report

## Safety invariants

- the semantic agent still owns biomedical relevance; deterministic code only applies lifecycle safety
- no LLM-authored numeric source quality score was introduced
- PubMed validation is mandatory for selection and only `ncbi_pubmed` + `efetch_xml` + same PMID + `matched` + `clear` can pass
- `not_found` and unresolved validation never become `false` or `skipped`
- malformed XML, missing/duplicate PMIDs, response failures, correction notices, expressions of concern, and retractions fail to review rather than promotion

## Validation

- `make artana-evidence-api-service-checks`
- 73 focused PubMed/semantic tests
- full Evidence API suite against an ephemeral migrated PostgreSQL database
- lint, strict mypy across 582 source files, boundary checks, contract checks, agent-output checks, semantic benchmark integrity, and architecture checks
- live NCBI smoke: MED13 PMIDs `29773993` and `41130977` returned matched/clear with abstracts
- live NCBI retraction smoke: PMIDs `41329731`, `41629425`, and `40605964` categorized retracted from `RetractionIn`

## Remaining boundary

This PR covers PubMed discovery and semantic selection. ClinVar, ClinicalTrials.gov, PMC/publisher correction metadata, and freshness revalidation at trusted graph promotion remain follow-up work. It does not claim trusted-graph readiness or replace independent expert review.
