### PR TITLE
Document Luna evaluation and trusted claim recovery plan

### DIFF
--- a/docs/validation/codex-agent-expert-evaluation-protocol.md
+++ b/docs/validation/codex-agent-expert-evaluation-protocol.md
@@ -1,0 +1,252 @@
+# Codex Agent-Expert Evaluation Protocol
+
+## Purpose
+
+Use Artana as the system under test and Codex as an external evaluation
+laboratory. Artana runs its existing evidence workflow with
+`openai:gpt-5.6-luna`; independent Codex subagents inspect the frozen results,
+challenge them, research authoritative sources, and produce categorical review
+findings. This protocol does not add an agent council or reviewer logic to the
+Artana product.
+
+The outcome is diagnostic evidence about quality and usefulness. It is not
+human-expert gold, does not make records expert-eligible, and cannot authorize
+trusted-graph promotion.
+
+## Fixed Boundaries
+
+- Use one evaluation branch: `alvaro/luna-expert-agent-evaluation`.
+- Do not change Artana extraction, ranking, linking, promotion, or graph logic.
+- Do not add deterministic semantic fallbacks.
+- Do not write reviewer conclusions into the trusted graph.
+- Do not import Codex reviews as human completions or expert attestations.
+- Reviewer agents receive no production credentials and may perform only
+  read-only research operations. They return findings to the parent task; they
+  do not write evaluation artifacts or mutate local or remote systems.
+- Stop after the evaluation report. Findings become explicit future decisions;
+  they do not trigger an automatic implementation loop.
+
+## System Under Test
+
+- Configured model: `openai:gpt-5.6-luna`.
+- Preflight must report the normalized execution model
+  `openai/gpt-5.6-luna` before a run counts.
+- Run the same frozen case set three times because the model currently has no
+  dated snapshot in the Artana registry.
+- A run is invalid if the agent does not complete, the configured model is not
+  the executed model, or any fallback output is credited as agent evidence.
+- Preserve the exact commit, model identifier, prompt/configuration hashes,
+  source-case hashes, run timestamps, and Artana output digests.
+
+## Codex Review Council
+
+The parent Codex task is the operator and final diagnostic adjudicator. Before
+review begins, it freezes a reviewer-assignment manifest containing each agent
+run ID, exact model ID, role, prompt hash, packet hash, tool policy, assignment,
+and start time. It dispatches separate subagents with isolated instructions and
+no access to other reviewers' conclusions during their first pass.
+
+| Reviewer | Primary question |
+|---|---|
+| Claim and entailment | Does the cited source actually support the relation and its direction, qualifiers, population, and outcome? |
+| Entity and identifier | Are genes, variants, diseases, interventions, outcomes, and CURIEs correctly resolved? |
+| Specificity and usefulness | Is the relation precise and actionable, or merely a generic restatement? |
+| Contradiction and negatives | Did Artana ignore null results, exclusions, conflicts, corrections, or contrary evidence? |
+| Novelty and hypothesis | Is a new finding being preserved honestly as a hypothesis rather than discarded or promoted as established fact? |
+| Provenance and safety | Can every conclusion be traced to the supplied evidence and reproduced without fallback or hidden context? |
+
+Every evaluated claim receives at least two independent first-pass reviews in
+each applicable review mode. Packet-only and source-enriched judgments are
+assigned to different agent sessions; no agent authors both judgments for the
+same claim. High-impact disagreements, possible false claims, and possible
+missed novel findings receive a fresh adversarial review before parent
+adjudication.
+
+## Browsing And Tool Use
+
+Source-enriched review agents may browse the internet and use available tools
+when that can improve their analysis. Packet-only agents may not browse, use
+network tools, inspect the repository, or run shell commands. They receive only
+the bounded frozen packet content in an isolated session. Any attempted access
+outside that content invalidates the review.
+
+Source-enriched reviewers run in an isolated workspace containing only the
+content-addressed frozen packet and explicitly enumerated, operator-approved
+inputs. They have no repository checkout, benchmark labels, prior reviews,
+production credentials, live Artana API, or database access. Permitted
+read-only tools include:
+
+- web search and browser inspection;
+- PubMed and PMC article records and full text;
+- ClinVar variant records and review status;
+- ClinicalTrials.gov registrations and current status;
+- DOI, Crossref, journal, and publisher correction or retraction metadata;
+- relevant government, standards-body, registry, and primary research sources;
+- shell inspection and structured-data analysis tools restricted to the
+  isolated input workspace;
+- browser automation when a primary source requires interactive access.
+
+Source-enriched agents receive no write-capable API tokens, production database
+credentials, signing keys, or trusted-graph credentials. Browser and shell
+activity must be preserved in the tool transcript. A review is invalid if the
+agent mutates a source, repository file, Artana state, graph state, or another
+reviewer's artifact, or reads any local path outside its enumerated input
+manifest. Live Artana state is never a reviewer input; only frozen,
+content-addressed exports may be supplied.
+
+Broad web search may discover a source, but a diagnostic biomedical conclusion
+must cite the primary publication, authoritative registry, official trial
+record, or publisher correction whenever one exists. Blogs, search snippets,
+AI summaries, and unsourced secondary pages cannot independently verify a
+claim.
+
+For every external fact, the reviewer records:
+
+- source URL and authoritative identifier;
+- title or record name;
+- source version or retrieval timestamp when available;
+- exact supporting passage or structured field;
+- whether the source supports, contradicts, or only contextualizes the claim;
+- any correction, retraction, conflict, or temporal-classification issue.
+
+Agents may use tools to derive insight, but they may not hide the tool result,
+invent a source, or convert a search result into unsupported certainty.
+
+## Two Separate Judgments
+
+Browsing must not repair Artana's output after the fact. Two independent agent
+pools record two categorical judgments:
+
+1. `packet_only`: produced first in a network-disabled, repository-blind session
+   using only Artana's frozen evidence and provenance. The parent publishes the
+   result without replacement and records its digest before any source-enriched
+   reviewer starts.
+2. `source_enriched`: produced by a fresh agent session after consulting
+   authoritative external sources. It may see the frozen Artana packet, but it
+   may not see packet-only decisions, benchmark labels, or other reviews.
+
+An externally supported fact can reveal that Artana missed useful knowledge or
+supplied insufficient evidence. It cannot retroactively make the `packet_only`
+result sufficient. Both pools remain blinded to benchmark labels until their
+no-replace first-pass artifacts and digests are frozen. This separation is
+mandatory for honest measurement.
+
+## Reviewer Output Contract
+
+Agents provide categories, explanations, evidence spans, and citations. They do
+not produce confidence percentages, precision estimates, or other numeric
+scores that deterministic calculation can derive later.
+
+Packet-only and source-enriched findings use the same categorical schema but
+are stored in separate artifacts. Each artifact records its review mode, unique
+agent run ID, model ID, prompt hash, input packet hash, tool-policy hash, start
+and completion timestamps, and parent-observed result digest.
+
+Required categorical fields:
+
+| Field | Allowed values |
+|---|---|
+| `claim_status` | `supported`, `contradicted`, `uncertain`, `novel_hypothesis`, `insufficient_evidence` |
+| `source_identity` | `matched`, `mismatched`, `unresolved` |
+| `grounding_status` | `both_entities_and_relation_grounded`, `partially_grounded`, `ungrounded` |
+| `entity_status` | `verified`, `conflicting`, `unresolved`, `not_applicable` |
+| `specificity_status` | `specific_and_useful`, `specific_low_value`, `generic`, `overstated` |
+| `integrity_status` | `clear`, `correction_review_required`, `expression_of_concern`, `retracted`, `unresolved` |
+| `review_action` | `keep`, `revise`, `reject`, `abstain`, `route_to_human` |
+| `impact` | `critical`, `major`, `moderate`, `minor` |
+
+Each finding also contains a plain-language rationale, Artana evidence spans,
+external evidence spans when used, source citations, and a falsification note
+describing what would change the decision.
+
+## Execution Loop
+
+1. **Pre-register measurement:** Before reviews, freeze the metric names,
+   category mapping, denominators, exclusions, abstention handling,
+   repeated-run aggregation, disagreement precedence, thresholds, and exact
+   calculation-command or script hash. Post-hoc metrics cannot count.
+2. **Preflight:** Verify service health, database migrations, API access, and
+   the resolved Luna model. Fail closed on any mismatch.
+3. **Run Artana:** Execute three Luna runs over the same frozen benchmark and
+   selected real-world cases. Do not retry a failed case with fallback logic.
+4. **Freeze outputs:** Publish without replacement and hash the complete Artana
+   outputs and provenance before any reviewer begins.
+5. **Freeze assignments:** Publish the reviewer-assignment manifest before
+   dispatch. A unique artifact path is reserved for every agent run and claim.
+6. **Packet-only first pass:** Send only bounded packet content to isolated,
+   network-disabled, repository-blind Codex sessions. Publish and hash every
+   result without replacement before source research begins.
+7. **Source-enriched first pass:** Dispatch fresh Codex sessions that cannot see
+   packet-only findings or labels. They may browse and use read-only tools under
+   the source rules above. Preserve their complete source and tool ledgers.
+8. **Freeze first passes:** Publish and hash all source-enriched results without
+   replacement. Benchmark labels remain inaccessible. The parent may now
+   compare reviewer findings with each other, but not with labels.
+9. **Adversarial pass:** While still label-blind, fresh subagents attempt to
+   falsify supported claims, rescue wrongly rejected novel hypotheses, and
+   identify missing negative or contradictory evidence.
+10. **Adjudication:** While still label-blind, the parent Codex task resolves
+    diagnostic disagreements from the frozen record and cited sources.
+    Unresolved cases remain `uncertain` or `route_to_human`.
+11. **Freeze adjudication:** Publish and hash adversarial findings and
+    adjudication without replacement. No review category may change after this
+    point.
+12. **Label-provenance preflight and unblind:** Verify the frozen label artifact,
+    provenance, attestation, and `score_eligible` state. Only then load labels.
+    Ineligible labels permit diagnostic concordance only.
+13. **Deterministic measurement:** The pre-registered calculation counts frozen
+    categorical outcomes. No agent-authored number is a metric input. Changes
+    to metric semantics invalidate the run rather than silently rescoring it.
+14. **Report and stop:** Publish the evidence-backed result, limitations, and
+    diagnostic recommendation. Do not continue into product changes
+    automatically.
+
+## Required Artifacts
+
+Store one immutable evaluation bundle under
+`reports/luna-agent-expert-evaluation/<run-id>/`:
+
+- `run-manifest.json`: commit, model, configuration, case, and artifact hashes;
+- `metric-protocol.json`: pre-registered definitions, denominators, thresholds,
+  aggregation rules, and calculation-command or script hash;
+- `reviewer-assignments.json`: roles, unique agent run IDs, model IDs, prompt
+  hashes, input hashes, tool policies, and reserved artifact paths;
+- `prompts/<agent-run-id>.txt`: exact immutable prompt bytes supplied to each
+  reviewer;
+- `tool-policies/<agent-run-id>.md`: exact tool and access policy supplied to
+  each reviewer;
+- `artana-output/`: untouched results from every Luna run;
+- `reviews/packet-only/<agent-run-id>/`: independent network-disabled findings;
+- `reviews/source-enriched/<agent-run-id>/`: independent tool-enabled findings;
+- `raw-responses/<agent-run-id>.txt`: complete unedited reviewer responses;
+- `tool-ledgers/<agent-run-id>.jsonl`: source retrievals and read-only tool use;
+- `source-ledger.jsonl`: authoritative sources, retrieval facts, and spans;
+- `adversarial-findings.json`: attempted falsifications and rescued hypotheses;
+- `adjudication.json`: parent decisions and unresolved disagreements;
+- `metrics.json`: deterministic counts and rates with explicit denominators;
+- `root-manifest.json` and `root-manifest.sha256`: the complete no-replace
+  artifact inventory and root digest, also recorded outside the bundle;
+- `evaluation-report.md`: plain-language conclusions and limitations.
+
+The parent task is the only artifact publisher. It refuses an existing output
+path, verifies all first-pass digests before unblinding, and records any tool or
+publication-policy violation as an invalid review rather than repairing it.
+
+## Decision Rules
+
+The final report separates three claims:
+
+- **Engineering validity:** Luna ran as configured, completed, and did not use
+  credited fallback evidence.
+- **Label-provenance result:** precision and recall may be reported only for
+  independently human-attested, `score_eligible` labels bound to the frozen
+  protocol. Comparisons with AI-adjudicated, synthetic, pending, or otherwise
+  ineligible labels are named `diagnostic_label_concordance`; they are not
+  benchmark precision, gold, or an adoption gate.
+- **Agent-expert usefulness:** diagnostic agreement and source-backed findings
+  from Codex reviewers, explicitly called internal Codex diagnostic consistency
+  rather than human-expert precision or independent validation.
+
+A strong diagnostic result can justify proceeding to a small human pilot. It
+cannot establish human usability, clinical correctness, or trusted-graph
+readiness by itself.

--- a/docs/validation/codex-agent-expert-evaluation-protocol.md
+++ b/docs/validation/codex-agent-expert-evaluation-protocol.md
@@ -209,8 +209,9 @@ write-once archive is allowed only when its URI and digest are committed in the
 run manifest; an ignored top-level `reports/` directory cannot satisfy this
 protocol.
 
-- `run-manifest.json`: commit, model, configuration, case, artifact hashes, and
-  the URI plus digest for any externally archived artifact;
+- `run-manifest.json`: commit, model, configuration, case, frozen-label,
+  label-provenance, label-attestation, and artifact hashes, plus the URI and
+  digest for any externally archived artifact;
 - `provider-receipts.json`: one record per credited semantic call containing
   the retrievable provider response ID, expected and retrieved model IDs,
   completion status, normalized prompt hash, canonical provider-output hash,
@@ -233,9 +234,20 @@ protocol.
 - `source-ledger.jsonl`: authoritative sources, retrieval facts, and spans;
 - `adversarial-findings.json`: attempted falsifications and rescued hypotheses;
 - `adjudication.json`: parent decisions and unresolved disagreements;
+- `frozen-labels.json`: the exact categorical labels, case identities, and
+  per-label `score_eligible` state loaded only after the no-replace review
+  artifacts are frozen;
+- `label-provenance.json`: source dataset or snapshot identities, immutable
+  input hashes, label-production and adjudication lineage, and the protocol
+  version governing eligibility;
+- `label-attestation.json`: the independent human attestation identity or
+  pseudonymous reviewer ID, role and qualification, attested artifact hashes,
+  completion timestamp, conflict disclosure, and categorical eligibility
+  decision; it must not contain PHI or secrets;
 - `metrics.json`: deterministic counts and rates with explicit denominators;
 - `root-manifest.json` and `root-manifest.sha256`: the complete no-replace
-  artifact inventory and root digest, also recorded outside the bundle;
+  artifact inventory and root digest, including all frozen-label, provenance,
+  and attestation artifacts, also recorded outside the bundle;
 - `evaluation-report.md`: plain-language conclusions and limitations.
 
 The parent task is the only artifact publisher. It refuses an existing output

--- a/docs/validation/codex-agent-expert-evaluation-protocol.md
+++ b/docs/validation/codex-agent-expert-evaluation-protocol.md
@@ -203,10 +203,19 @@ describing what would change the decision.
 
 ## Required Artifacts
 
-Store one immutable evaluation bundle under
-`reports/luna-agent-expert-evaluation/<run-id>/`:
+Store one immutable evaluation bundle under the versioned path
+`docs/validation/reports/luna-agent-expert-evaluation/<run-id>/`. An external
+write-once archive is allowed only when its URI and digest are committed in the
+run manifest; an ignored top-level `reports/` directory cannot satisfy this
+protocol.
 
-- `run-manifest.json`: commit, model, configuration, case, and artifact hashes;
+- `run-manifest.json`: commit, model, configuration, case, artifact hashes, and
+  the URI plus digest for any externally archived artifact;
+- `provider-receipts.json`: one record per credited semantic call containing
+  the retrievable provider response ID, expected and retrieved model IDs,
+  completion status, normalized prompt hash, canonical provider-output hash,
+  structured-payload hash, retrieval timestamp, and categorical verification
+  result;
 - `metric-protocol.json`: pre-registered definitions, denominators, thresholds,
   aggregation rules, and calculation-command or script hash;
 - `reviewer-assignments.json`: roles, unique agent run IDs, model IDs, prompt
@@ -215,7 +224,8 @@ Store one immutable evaluation bundle under
   reviewer;
 - `tool-policies/<agent-run-id>.md`: exact tool and access policy supplied to
   each reviewer;
-- `artana-output/`: untouched results from every Luna run;
+- `artana-output/`: untouched results from every Luna run, each joined to its
+  `provider-receipts.json` record;
 - `reviews/packet-only/<agent-run-id>/`: independent network-disabled findings;
 - `reviews/source-enriched/<agent-run-id>/`: independent tool-enabled findings;
 - `raw-responses/<agent-run-id>.txt`: complete unedited reviewer responses;

--- a/docs/validation/evidence-excellence-progress-tracker.md
+++ b/docs/validation/evidence-excellence-progress-tracker.md
@@ -6,6 +6,14 @@ This is the living tracker for raising Artana Evidence from "useful relation
 candidate extraction" to a high-confidence, agent-driven, evidence-grounded
 trusted graph system.
 
+Current recovery plan after the July 14 Luna agent-expert evaluation:
+
+- `docs/validation/trusted-claim-recovery-plan.md`
+
+That plan is the canonical source for new trusted-claim work. The PR plans
+listed below are historical execution records and must not override its current
+baseline, safety rules, or readiness decision.
+
 Next trusted-readiness PR plans:
 
 - PR11-PR16 foundation plan:

--- a/docs/validation/reports/2026-07-14-luna-agent-expert-baseline.md
+++ b/docs/validation/reports/2026-07-14-luna-agent-expert-baseline.md
@@ -62,7 +62,7 @@ packet or independently validate every count above.
 |---|---|
 | `docs/validation/reports/semantic-model-comparisons/2026-07-13-pr6-gpt-5.6-luna-v3/semantic_model_comparison_manifest.json` | `601b430bc34fe368a1656abdb1594b730188ccbd9bf2a89a94232212164be7a8` |
 | `docs/validation/reports/semantic-model-comparisons/2026-07-13-pr6-gpt-5.6-luna-v3/semantic_model_comparison_report.json` | `f159482dd5cab13c32b04487df5ff66808439309abfe166012a06fddc708763b` |
-| `docs/validation/codex-agent-expert-evaluation-protocol.md` | `1f44e9a2f8745633d0e92bdef7d60986171e9f17c1a797a84cc4eacde991b966` |
+| `docs/validation/codex-agent-expert-evaluation-protocol.md` | `07b9885622f4469769f9a84576db99f721ae0dc38bfa79da45b6828f91614713` |
 
 ## Replacement Requirement
 

--- a/docs/validation/reports/2026-07-14-luna-agent-expert-baseline.md
+++ b/docs/validation/reports/2026-07-14-luna-agent-expert-baseline.md
@@ -1,0 +1,73 @@
+# July 14 Luna Agent-Expert Baseline
+
+Created: 2026-07-14
+
+Versioned: 2026-07-16
+
+Status: historical diagnostic baseline; not confirmatory readiness evidence
+
+## Purpose
+
+This record preserves the July 14 diagnostic counts used to prioritize the
+Trusted Claim Recovery Plan. The original report was written below the ignored
+top-level `reports/` directory and was not committed. It is therefore not
+available in a fresh checkout and cannot receive immutable-run,
+provider-authentication, or scientific-readiness credit.
+
+The counts remain useful as explicit root-cause observations. Later PRs must
+replace them with prospectively frozen, hash-addressed artifacts rather than
+silently treating this reconstruction as equivalent to the missing raw run.
+
+## Recorded Counts
+
+The 100-case relation set was run three times. The separate 47-case review set
+was deliberately risk-enriched and does not estimate prevalence.
+
+| Measure | Recorded result | Denominator |
+|---|---:|---:|
+| Strict agent completion | 300 | 300 attempts |
+| Credited deterministic fallback | 0 | 300 attempts |
+| Invalid structured agent results | 0 | 300 attempts |
+| Stable cases across three runs | 88 | 100 cases |
+| Worst-run generic relation rate | 36.76% | worst of three 100-case runs |
+| Worst-run verified CURIE match rate | 75.86% | worst of three 100-case runs |
+| Negative-control leakage | 1 | frozen negative controls |
+| Source-reviewed packet sufficiency | 8 | 47 review cases |
+| Final reviewer action `keep` | 1 | 47 review cases |
+| Strong source provenance | 2 | 47 review cases |
+| Generic or overstated outcomes | 13 | 47 review cases |
+
+Recorded decision: **not ready for automatic trusted-graph promotion**.
+
+## Provenance Boundary
+
+The missing original report prevents an independent reviewer from checking its
+case-level outputs, provider response IDs, prompt and fixture hashes, or exact
+metric implementation. Consequently:
+
+- these values may establish failure hypotheses but not a merge-quality delta;
+- they may not satisfy a scientific precision, recall, or readiness gate;
+- they may not be used as a frozen baseline for model comparison;
+- any later report must link raw categorical outputs and deterministic scoring;
+- any semantic provider call receiving credit must include retrievable provider
+  response IDs and matching canonical output hashes.
+
+## Committed Supporting Evidence
+
+The following earlier committed artifacts support narrower execution and
+fallback observations. They do not reconstruct the missing 47-case review
+packet or independently validate every count above.
+
+| Artifact | SHA-256 |
+|---|---|
+| `docs/validation/reports/semantic-model-comparisons/2026-07-13-pr6-gpt-5.6-luna-v3/semantic_model_comparison_manifest.json` | `601b430bc34fe368a1656abdb1594b730188ccbd9bf2a89a94232212164be7a8` |
+| `docs/validation/reports/semantic-model-comparisons/2026-07-13-pr6-gpt-5.6-luna-v3/semantic_model_comparison_report.json` | `f159482dd5cab13c32b04487df5ff66808439309abfe166012a06fddc708763b` |
+| `docs/validation/codex-agent-expert-evaluation-protocol.md` | `1f44e9a2f8745633d0e92bdef7d60986171e9f17c1a797a84cc4eacde991b966` |
+
+## Replacement Requirement
+
+The next scientific experiment must freeze its source snapshots, complete
+n-ary gold labels, prompts, model settings, categorical outputs, provider
+receipts, and deterministic scorer before execution. Its worst-run metrics and
+paired case transitions replace this historical baseline for scientific
+decisions.

--- a/docs/validation/trusted-claim-recovery-plan.md
+++ b/docs/validation/trusted-claim-recovery-plan.md
@@ -239,16 +239,20 @@ Strict live-agent regression template:
 set -a
 source .env.postgres
 set +a
+export ARTANA_AI_EVIDENCE_EXTRACTION_MODEL=openai:gpt-5.6-luna
 uv run python scripts/run_relation_feasibility_audit.py \
   --extractor agent \
-  --output-dir reports/relation_feasibility/<date>-<plan-id>-run-01
+  --output-dir \
+    docs/validation/reports/relation_feasibility/<date>-<plan-id>-run-01
 ```
 
 For semantic PRs, repeat into `run-02` and `run-03`, then evaluate worst-run
 results with the existing readiness gate. Do not overwrite a prior run or retry
 only failed cases. Store the exact command, environment-name allowlist, model,
 prompt/configuration hashes, and output hashes in the evidence report. Never
-record secret values.
+record secret values. The run preflight and manifest must both prove that the
+configured and retrieved provider model is exactly `openai:gpt-5.6-luna`; a
+runtime-default substitution invalidates the run.
 
 ## TG-01: Truthful Safety Floor
 

--- a/docs/validation/trusted-claim-recovery-plan.md
+++ b/docs/validation/trusted-claim-recovery-plan.md
@@ -6,7 +6,8 @@ Status: Draft for execution review, implementation not started
 
 Baseline commit: `884ede20340d7fce7b28994f1bed617b222d2213`
 
-Baseline evaluation: `reports/luna-agent-expert-evaluation/2026-07-14-run-01/evaluation-report.md`
+Baseline evaluation:
+`docs/validation/reports/2026-07-14-luna-agent-expert-baseline.md`
 
 This is the canonical implementation and progress plan after the July 14 Luna
 agent-expert evaluation. It replaces the earlier open-ended trusted-graph
@@ -54,23 +55,26 @@ technically ready for trusted promotion without enabling that promotion.
 
 ## July 14 Baseline
 
-The following numbers are deterministic counts over frozen categorical agent
-findings. The 47-case set is risk-enriched, so its counts diagnose failures and
-do not estimate whole-corpus prevalence.
+The following values are unverified historical notes transcribed from the July
+14 evaluation session. The missing original raw report prevents independent
+recalculation, so these values identify failure hypotheses only. They are not a
+factual scientific baseline and receive no confirmatory, readiness, or
+before/after credit. The 47-case set was reported as risk-enriched and therefore
+would not estimate whole-corpus prevalence even if its artifacts were present.
 
-| Measure | Baseline | Interpretation |
+| Measure | Historical note | Interpretation |
 |---|---:|---|
-| Strict agent completion | 300/300 | The live `openai:gpt-5.6-luna` path completes. |
-| Credited fallback | 0 | Fallback did not masquerade as agent evidence. |
-| Invalid agent results | 0 | Structured extraction completed. |
-| Stable cases across three runs | 88/100 | Twelve cases changed under identical inputs. |
-| Worst-run generic relation rate | 36.76% | Generic output is far above the 5% limit. |
-| Worst-run verified CURIE match rate | 75.86% | Entity grounding is below the 95% target. |
-| Negative-control leakage | 1 | One explicit negative produced a candidate. |
-| Source-reviewed packet sufficiency | 8/47 | Most packets could not support the claim on their own. |
-| Final action `keep` | 1/47 | Most risk cases required revision, rejection, or human routing. |
-| Strong provenance | 2/47 | Source identity and locators are usually missing. |
-| Generic or overstated outcomes | 13/47 | The tuple often loses scientifically material context. |
+| Strict agent completion | 300/300 | Reported completion; must be re-established from committed provider evidence. |
+| Credited fallback | 0 | Reported fallback count; not a current safety proof. |
+| Invalid agent results | 0 | Reported structured-output count; not independently reproducible. |
+| Stable cases across three runs | 88/100 | Suggests a repeatability failure requiring a frozen rerun. |
+| Worst-run generic relation rate | 36.76% | Suggests generic output substantially exceeded the planned 5% limit. |
+| Worst-run verified CURIE match rate | 75.86% | Suggests entity grounding was below the planned 95% target. |
+| Negative-control leakage | 1 | Suggests at least one positive candidate escaped a negative control. |
+| Source-reviewed packet sufficiency | 8/47 | Suggests most risk packets lacked self-contained support. |
+| Final action `keep` | 1/47 | Suggests most risk cases required revision, rejection, or human routing. |
+| Strong provenance | 2/47 | Suggests source identity and locators were usually missing. |
+| Generic or overstated outcomes | 13/47 | Suggests binary tuples lost scientifically material context. |
 
 Current decision: **not ready for automatic trusted-graph promotion**.
 
@@ -805,15 +809,15 @@ single unsafe failure. Track each dimension independently.
 
 | Dimension | Baseline | Required end state | Owning PR | Current evidence | Status |
 |---|---|---|---|---|---|
-| Agent execution | 300/300, fallback 0 | Preserve 100%, fallback 0 | All | July 14 report | passing |
+| Agent execution | Historical note: 300/300, fallback 0 | Establish 100%, fallback 0 from committed provider evidence | All | Original July 14 raw report missing | not_evaluable |
 | Truthful trust | Heuristic and symbolic-authority gaps found | No non-agent semantic trust or fake authority | TG-01 | Pending | not_started |
-| Source traceability | 2/47 strong provenance | 100% eligible claims strong | TG-02 | Pending | not_started |
-| Claim completeness | 13/47 generic/overstated outcomes | Complete polarity/state/qualifiers | TG-03 | Pending | not_started |
+| Source traceability | Historical note: 2/47 strong provenance | 100% eligible claims strong | TG-02 | Original July 14 raw report missing | not_evaluable |
+| Claim completeness | Historical note: 13/47 generic/overstated outcomes | Complete polarity/state/qualifiers | TG-03 | Original July 14 raw report missing | not_evaluable |
 | Lossless persistence | Triple-oriented write path | Zero ClaimFrame field loss | TG-04 | Pending | not_started |
 | Semantic verification | Heuristic can return `ENTAILS` | Independent categorical agent verifier | TG-05 | Pending | not_started |
-| Entity grounding | 75.86% worst-run diagnostic rate | At least 95%, wrong links 0 | TG-06 | Pending | not_started |
+| Entity grounding | Historical note: 75.86% worst-run diagnostic rate | At least 95%, wrong links 0 | TG-06 | Original July 14 raw report missing | not_evaluable |
 | Safe projection | Review flags can accompany assertive tuples | Zero unsafe or lossy positive edges | TG-07 | Pending | not_started |
-| Real-source proof | 8/47 sufficient risk packets | All TG-08 gates on 60+ real sources | TG-08 | Pending | not_started |
+| Real-source proof | Historical note: 8/47 sufficient risk packets | All TG-08 gates on 60+ real sources | TG-08 | Original July 14 raw report missing | not_evaluable |
 | Human-expert proof | None | Authenticated independent expert study | Future governance | Not available | blocked |
 
 ## Stop And Reassess Rules

--- a/docs/validation/trusted-claim-recovery-plan.md
+++ b/docs/validation/trusted-claim-recovery-plan.md
@@ -1,0 +1,852 @@
+# Trusted Claim Recovery Plan
+
+Created: 2026-07-14
+
+Status: Draft for execution review, implementation not started
+
+Baseline commit: `884ede20340d7fce7b28994f1bed617b222d2213`
+
+Baseline evaluation: `reports/luna-agent-expert-evaluation/2026-07-14-run-01/evaluation-report.md`
+
+This is the canonical implementation and progress plan after the July 14 Luna
+agent-expert evaluation. It replaces the earlier open-ended trusted-graph
+roadmaps as the source of truth for new work. Older plans remain historical
+evidence and must not be used to claim current readiness.
+
+## Objective
+
+Move Artana from a useful relation-candidate generator to a system that creates
+traceable, qualified, independently verified biomedical claims and only then
+projects safe claims into graph relations.
+
+The target flow is:
+
+```text
+source document
+  -> immutable source identity and exact evidence locator
+  -> agent-extracted qualified ClaimFrame
+  -> independent agent semantic verification
+  -> authoritative entity verification
+  -> persisted claim and evidence ledger
+  -> deterministic, fail-closed projection decision
+  -> optional graph relation
+```
+
+The claim ledger is the scientific record. A graph edge is a derived view. A
+lossy edge must never replace the qualified claim from which it was derived.
+
+## Honest Finish Lines
+
+This plan distinguishes two finish lines so that agent evaluation is not
+misrepresented as human-expert proof:
+
+1. **Agent-verified technical readiness:** source-local claims are traceable,
+   qualified, independently agent-verified, authoritatively grounded, stable,
+   and protected by fail-closed graph rules. This plan can reach this level.
+2. **Human-expert trusted readiness:** independently authenticated biomedical
+   experts validate a frozen real-source study. This remains blocked until
+   human reviewers are available.
+
+Until product governance explicitly defines otherwise, agent-generated claims
+must be capped at `verified_evidence`; they must not be described as
+human-validated or clinical truth. The implementation may make the graph
+technically ready for trusted promotion without enabling that promotion.
+
+## July 14 Baseline
+
+The following numbers are deterministic counts over frozen categorical agent
+findings. The 47-case set is risk-enriched, so its counts diagnose failures and
+do not estimate whole-corpus prevalence.
+
+| Measure | Baseline | Interpretation |
+|---|---:|---|
+| Strict agent completion | 300/300 | The live `openai:gpt-5.6-luna` path completes. |
+| Credited fallback | 0 | Fallback did not masquerade as agent evidence. |
+| Invalid agent results | 0 | Structured extraction completed. |
+| Stable cases across three runs | 88/100 | Twelve cases changed under identical inputs. |
+| Worst-run generic relation rate | 36.76% | Generic output is far above the 5% limit. |
+| Worst-run verified CURIE match rate | 75.86% | Entity grounding is below the 95% target. |
+| Negative-control leakage | 1 | One explicit negative produced a candidate. |
+| Source-reviewed packet sufficiency | 8/47 | Most packets could not support the claim on their own. |
+| Final action `keep` | 1/47 | Most risk cases required revision, rejection, or human routing. |
+| Strong provenance | 2/47 | Source identity and locators are usually missing. |
+| Generic or overstated outcomes | 13/47 | The tuple often loses scientifically material context. |
+
+Current decision: **not ready for automatic trusted-graph promotion**.
+
+## Non-Negotiable Rules
+
+These rules apply to every PR in this plan.
+
+1. **Agent-first semantics:** biomedical extraction and semantic verification
+   are performed by agents. Deterministic fallback may support triage but may
+   never receive agent credit or satisfy a semantic trust gate.
+2. **Categorical agent output:** agents return closed categories, exact evidence
+   spans, explanations, and falsification notes. Agents do not author numeric
+   confidence, relevance, precision, recall, calibration, or readiness scores.
+3. **Deterministic metrics:** code computes all counts, rates, thresholds, and
+   readiness decisions from frozen categorical artifacts.
+4. **Source measurements stay source measurements:** an extracted effect size,
+   p-value, threshold, dose, or date is allowed only when copied from an exact
+   source span and labeled `source_measurement`; it is not model confidence.
+5. **Two different questions:** source-local entailment asks whether the cited
+   document supports the claim. External corroboration asks whether other
+   authoritative sources agree. External research may not repair a packet that
+   lacks source-local evidence.
+6. **Novel knowledge is preserved:** uncorroborated but plausible findings stay
+   as `HYPOTHESIS` or `UNCERTAIN` claims with provenance. They are routed for
+   review, not discarded and not projected as established positive relations.
+7. **Claim before edge:** null, negated, provisional, and hypothesis statements
+   remain first-class claims. A warning flag on an assertive edge is not an
+   acceptable substitute.
+8. **Authoritative identifiers only:** symbolic placeholders such as
+   `ClinVar:BRAF_V600E` cannot count as verified identifiers. Trust requires a
+   namespace-specific authoritative record or computed identifier.
+9. **Fail closed:** missing source, locator, verifier, authoritative entity,
+   qualifier, polarity, or required service response blocks projection.
+10. **No threshold weakening:** a PR may improve a metric or strengthen a safety
+    invariant. It may not lower a threshold to manufacture green status.
+11. **No circular validation:** fixture labels, local dictionaries, and the
+    implementation under test cannot independently validate one another.
+12. **No infrastructure-only loop:** no new harness work may start unless it is
+    required to measure a product field introduced by the same or immediately
+    preceding PR.
+
+## Progress Tracking
+
+GitHub assigns the final PR number when a branch is opened. Keep the stable
+`TG-0x` identifier in commit messages, reports, and this tracker so the plan
+does not need to be renumbered.
+
+Allowed status values are `not_started`, `in_progress`, `evidence_pending`,
+`ready_for_review`, `merged`, and `blocked`.
+
+| Plan ID | GitHub PR | Suggested branch | Depends on | Status | Primary proof |
+|---|---:|---|---|---|---|
+| TG-01 | TBD | `alvaro/trusted-claims-tg01-truthful-safety` | None | not_started | Existing unsafe evidence cannot become trusted. |
+| TG-02 | TBD | `alvaro/trusted-claims-tg02-source-provenance` | TG-01 | not_started | Every eligible claim has authoritative source identity and an exact locator. |
+| TG-03 | TBD | `alvaro/trusted-claims-tg03-claim-frame` | TG-02 | not_started | Agent extraction preserves polarity, state, qualifiers, and evidence. |
+| TG-04 | TBD | `alvaro/trusted-claims-tg04-claim-persistence` | TG-03 | not_started | Qualified claims round-trip through Evidence API and Graph DB without loss. |
+| TG-05 | TBD | `alvaro/trusted-claims-tg05-agent-verifier` | TG-04 | not_started | Independent agent verification replaces heuristic semantic trust. |
+| TG-06 | TBD | `alvaro/trusted-claims-tg06-authoritative-grounding` | TG-04 | not_started | Every promotion-eligible entity resolves to an authoritative identifier. |
+| TG-07 | TBD | `alvaro/trusted-claims-tg07-safe-projection` | TG-05, TG-06 | not_started | Only complete supported claims project to positive graph relations. |
+| TG-08 | TBD | `alvaro/trusted-claims-tg08-real-source-proof` | TG-07 | not_started | Repeated real-source runs satisfy every agent-readiness gate. |
+
+Dependency graph:
+
+```text
+TG-01 -> TG-02 -> TG-03 -> TG-04
+                              |-> TG-05 -|
+                              |-> TG-06 -|-> TG-07 -> TG-08
+```
+
+TG-05 and TG-06 may run in parallel after TG-04. The other PRs are ordered
+because they change a shared contract or depend on evidence produced earlier.
+
+## Standard PR Loop
+
+Every PR follows this loop and records each result in its evidence report.
+
+- [ ] Freeze the parent commit, input cases, prompts, model identifier, and
+      baseline artifact hashes before implementation.
+- [ ] State one falsifiable hypothesis and name the root cause being changed.
+- [ ] Review existing unit, integration, contract, and end-to-end tests.
+- [ ] Add failing unit and regression tests for the identified failure.
+- [ ] Add at least one adversarial test that attempts unsafe promotion.
+- [ ] Implement one responsibility at the service that owns it.
+- [ ] Run focused tests and the changed service's lint, type, boundary, and
+      contract checks.
+- [ ] Run Postgres-backed integration tests when persistence or an API contract
+      changes.
+- [ ] Run the strict live-agent path with `openai:gpt-5.6-luna`; fallback stays
+      disabled and cannot receive credit.
+- [ ] Run three identical live passes when the PR changes extraction,
+      verification, grounding, or projection semantics.
+- [ ] Freeze outputs before independent agent review.
+- [ ] Request an adversarial reviewer that did not implement the PR. The review
+      must cite files, cases, or artifact evidence; a generic approval is not
+      review evidence.
+- [ ] Fix valid findings, rerun affected validation, and record unresolved risk.
+- [ ] Run `git diff --check` and `make service-checks` without skipping hooks.
+- [ ] Publish a deterministic before/after report under
+      `docs/validation/reports/` and link raw immutable artifacts.
+- [ ] Merge only when the PR-specific gate and the global merge gate pass.
+
+## Global Merge Gate
+
+A PR is not merge-ready until all applicable statements are true:
+
+- its hypothesis is supported or it demonstrably strengthens a fail-closed
+  invariant;
+- focused unit and regression tests pass;
+- relevant integration, migration, and generated contract tests pass;
+- the relevant service gate and `make service-checks` pass;
+- strict agent completion is 100%, credited fallback is 0, and invalid agent
+  output is 0 for live-semantic PRs;
+- no new negative, null-result, contradiction, or hypothesis leakage appears;
+- agent outputs remain categorical and all numeric metrics are deterministic;
+- the evidence summary contains exact commands, commit, model, case hashes,
+  artifact paths, metric denominators, and before/after results;
+- an independent adversarial review has no unresolved high-severity finding;
+- documentation names remaining blockers and does not claim human expertise;
+- GitHub has no unresolved actionable review thread, required checks are green,
+  the branch is conflict-free, and required approval is present.
+
+## Validation Command Matrix
+
+Use the repository's existing targets. Focused pytest commands belong in each
+PR evidence report because the exact test files may change during
+implementation.
+
+Evidence API changes:
+
+```bash
+make artana-evidence-api-lint
+make artana-evidence-api-type-check
+make artana-evidence-api-boundary-check
+make artana-evidence-api-contract-check
+make artana-evidence-api-test
+make artana-evidence-api-service-checks
+```
+
+Graph DB changes:
+
+```bash
+make graph-service-lint
+make graph-service-type-check
+make graph-service-boundary-check
+make graph-service-contract-check
+make graph-service-test
+make graph-service-checks
+```
+
+Cross-service, migration, or generated-contract changes:
+
+```bash
+make setup-postgres
+make artana-evidence-api-service-checks
+make graph-service-checks
+make service-checks
+```
+
+Strict live-agent regression template:
+
+```bash
+set -a
+source .env.postgres
+set +a
+uv run python scripts/run_relation_feasibility_audit.py \
+  --extractor agent \
+  --output-dir reports/relation_feasibility/<date>-<plan-id>-run-01
+```
+
+For semantic PRs, repeat into `run-02` and `run-03`, then evaluate worst-run
+results with the existing readiness gate. Do not overwrite a prior run or retry
+only failed cases. Store the exact command, environment-name allowlist, model,
+prompt/configuration hashes, and output hashes in the evidence report. Never
+record secret values.
+
+## TG-01: Truthful Safety Floor
+
+**Hypothesis:** current candidates can satisfy the `trusted` tier using
+heuristic semantic support, internal-only source references, and symbolic
+variant identifiers. Blocking those paths will remove false trust even if the
+trusted count temporarily falls to zero.
+
+**Root cause:** trust checks validate a result shape, not the authority that
+produced it. `_heuristic_support` can return `ENTAILS`; `trust_ladder.py` accepts
+that category without requiring an independent agent verifier; and the verified
+dictionary contains symbolic ClinVar-like values also used by fixtures.
+
+**Primary files:**
+
+- `services/artana_evidence_api/document_extraction_support/evidence_support_verifier.py`
+- `services/artana_evidence_api/document_extraction_support/trust_ladder.py`
+- `services/artana_evidence_api/document_extraction_support/entity_grounding/verified_dictionary.py`
+- `services/artana_evidence_db/validation/claim_ai_evidence_validation.py`
+- `services/artana_evidence_db/validation/trusted_evidence_floor.py`
+
+**Implementation scope:**
+
+- Make semantic verification origin explicit and closed: `agent`, `heuristic`,
+  or `unavailable`.
+- Prevent `heuristic` and `unavailable` results from satisfying trusted or
+  verified semantic floors.
+- Add source-authority and exact-locator failures to both Evidence API and Graph
+  DB trust checks.
+- Reject symbolic ClinVar placeholders as verified identifiers. Quarantine
+  affected dictionary entries and fixtures instead of silently rewriting them.
+- Keep heuristic support available only as clearly labeled triage metadata.
+
+**Required tests:**
+
+- Unit: a heuristic `ENTAILS` result remains an agent candidate and cannot be
+  trusted.
+- Unit: missing verification origin fails closed.
+- Unit: symbolic ClinVar values cannot set `trusted_identifier=true`.
+- Regression: forged metadata cannot bypass Graph DB trust enforcement.
+- Integration: the old proposal write path cannot create a trusted claim from
+  an internal `harness_proposal:*` reference alone.
+- Adversarial: mutate each trust metadata field independently and prove none can
+  create a trusted result.
+
+**Merge gate:**
+
+- heuristic-supported trusted count: `0`;
+- symbolic-placeholder verified count: `0`;
+- internal-only-source trusted count: `0`;
+- fallback and invalid-agent counts: `0`;
+- Graph DB independently rejects every forged case;
+- any reduction in trusted-candidate count is reported as truthful quarantine,
+  not as a quality regression.
+
+**Evidence report:**
+`docs/validation/reports/<date>-tg01-truthful-safety.md`
+
+## TG-02: Authoritative Source Provenance And Exact Locators
+
+**Hypothesis:** a claim cannot be independently checked because the current
+packet often identifies an internal proposal rather than the actual publication
+or registry record and exact source location.
+
+**Root cause:** source identity, retrieval version, and evidence location are
+not one required end-to-end contract from ingestion through Graph DB.
+
+**Primary files:**
+
+- `services/artana_evidence_api/source_document_models.py`
+- `services/artana_evidence_api/source_document_extraction_service.py`
+- `services/artana_evidence_api/document_extraction_contracts.py`
+- `services/artana_evidence_api/proposal_actions.py`
+- `services/artana_evidence_api/types/graph_contracts.py`
+- `services/artana_evidence_db/provenance_model.py`
+- `services/artana_evidence_db/claim_evidence_models.py`
+
+**Implementation scope:**
+
+- Add a typed source identity with source kind, authoritative identifier, URL,
+  retrieved timestamp, version when available, and immutable content hash.
+- Add an exact evidence locator with section, paragraph or sentence identity,
+  character offsets, exact quote, and quote hash. Page/table/figure locators are
+  required when the source format supplies them.
+- Preserve PMID, PMCID, DOI, ClinicalTrials.gov NCT ID, ClinVar accession, and
+  publisher record identity without flattening them into an internal proposal
+  ID.
+- Carry source and locator data through extraction, proposal review, graph
+  client requests, claim evidence, and provenance storage.
+- Refuse promotion when the quote does not match the hashed source snapshot.
+
+**Required tests:**
+
+- Unit: locator offsets recover the exact quote from the source snapshot.
+- Property/regression: Unicode, repeated sentences, section boundaries, and
+  long-document chunks do not shift the locator.
+- Unit: source version or content changes invalidate the quote hash.
+- Contract: Evidence API and Graph DB schemas expose the same required source
+  fields.
+- Migration: old rows remain readable but are explicitly ineligible until
+  provenance is repaired.
+- Integration: a real PubMed/PMC fixture round-trips source identity and locator
+  through both services.
+- Adversarial: external corroboration cannot substitute for a missing local
+  locator.
+
+**Merge gate:**
+
+- promotion-eligible claims with authoritative source identity: `100%`;
+- promotion-eligible claims with a valid exact locator: `100%`;
+- quote/source hash mismatches accepted: `0`;
+- internal-only references counted as authoritative provenance: `0`;
+- provenance survives API serialization and database round-trip without loss.
+
+**Evidence report:**
+`docs/validation/reports/<date>-tg02-source-provenance.md`
+
+## TG-03: Qualified ClaimFrame Agent Extraction
+
+**Hypothesis:** most generic and overstated relations come from collapsing a
+scientific statement directly into `subject - predicate - object` before
+polarity, biological state, study context, and qualifiers are preserved.
+
+**Root cause:** the extraction contract is too small for the information needed
+to distinguish a broad assertion from a conditional observation, null result,
+or hypothesis.
+
+**Primary files:**
+
+- `services/artana_evidence_api/document_extraction_contracts.py`
+- `services/artana_evidence_api/document_extraction_prompting.py`
+- `services/artana_evidence_api/document_extraction_support/llm_fulltext_extraction.py`
+- new focused modules under
+  `services/artana_evidence_api/document_extraction_support/claim_frames/`
+
+**Implementation scope:**
+
+- Introduce a typed `ClaimFrame` with source locator, subject, predicate,
+  object, polarity, epistemic status, biological or variant state, population,
+  intervention, comparator, outcome, study design, treatment setting,
+  timeframe, threshold, and extracted source measurements.
+- Use closed categorical values for polarity and epistemic status.
+- Require every material qualifier present in the cited sentence or local
+  context to be represented or explicitly marked `not_applicable` or
+  `unresolved`.
+- Store exact agent evidence spans and a natural-language extraction rationale.
+- Do not ask the extraction agent for confidence or any numeric quality score.
+- Extract source-native numbers only with an exact span and
+  `origin=source_measurement`.
+- Emit null, negative, provisional, and novel statements as claims with honest
+  semantics instead of assertive edges plus review flags.
+
+**Required tests:**
+
+- Unit: variant state such as `EGFR T790M`, `BRCA1 loss`, and zygosity is not
+  reduced to the bare gene.
+- Unit: disease subtype, population, treatment line, assay cutoff, comparator,
+  endpoint, and timeframe are preserved.
+- Unit: explicit negation and failed thresholds produce `REFUTE`, `UNCERTAIN`,
+  or null-result semantics, never a positive support frame.
+- Unit: hypotheses remain `HYPOTHESIS` even when external corroboration is
+  absent.
+- Regression: long and multi-clause sentences bind qualifiers to the correct
+  subject, predicate, and object.
+- Schema: unknown categories fail validation rather than becoming free text.
+- Live agent: three Luna runs over a frozen qualifier-focused set.
+- Adversarial: attempt to strip each qualifier while retaining the broad triple.
+
+**Merge gate:**
+
+- frozen cases with correct explicit polarity: `100%` diagnostic concordance;
+- required qualifier presence on promotion-eligible frames: `100%`;
+- positive frames emitted from explicit negative/null cases: `0`;
+- agent-authored quality scores: `0`;
+- source measurements without exact source spans: `0`;
+- exact semantic-frame stability across three runs: at least `95%`.
+
+**Evidence report:**
+`docs/validation/reports/<date>-tg03-qualified-claim-frame.md`
+
+## TG-04: Lossless Claim Persistence And Graph Contract
+
+**Hypothesis:** even a correct ClaimFrame cannot protect the graph if the write
+contract converts it back into the old triple-only request.
+
+**Root cause:** Evidence API proposal actions use a narrow claim-create contract
+that bypasses existing Graph DB polarity, participant, qualifier, evidence, and
+projection capabilities.
+
+**Primary files:**
+
+- `services/artana_evidence_api/types/graph_contracts.py`
+- `services/artana_evidence_api/graph_client.py`
+- `services/artana_evidence_api/proposal_actions.py`
+- `services/artana_evidence_db/graph_api_schemas/kernel_relation_schemas.py`
+- `services/artana_evidence_db/relation_claim_models.py`
+- `services/artana_evidence_db/claim_participant_models.py`
+- `services/artana_evidence_db/claim_evidence_models.py`
+- `services/artana_evidence_db/graph_domain_qualifiers.py`
+- relevant forward-only migrations and generated API contracts
+
+**Implementation scope:**
+
+- Add a claim-create request that carries the complete ClaimFrame.
+- Persist claim polarity, participants and roles, qualifier values, source
+  measurements, evidence locators, extraction run identity, prompt/model
+  identity, and agent rationale.
+- Make the claim ledger the first write. Do not create or promote a canonical
+  relation as a side effect of receiving an incomplete claim.
+- Include polarity, material qualifiers, entity state, and source identity in
+  idempotency and claim fingerprints.
+- Route old triple-only records to explicit migration/review status. Do not
+  invent missing qualifiers during migration.
+- Regenerate OpenAPI and TypeScript artifacts when contracts change.
+
+**Required tests:**
+
+- Contract: complete claims serialize identically across both service schemas.
+- Integration: Evidence API writes a claim, participants, qualifiers, evidence,
+  and provenance to Postgres-backed Graph DB.
+- Round-trip: every material ClaimFrame field reads back unchanged.
+- Idempotency: identical claims deduplicate; claims with different polarity,
+  source, variant state, population, or endpoint remain distinct.
+- Migration: legacy incomplete triples stay readable and promotion-ineligible.
+- Failure injection: partial persistence rolls back rather than leaving a claim
+  or edge with missing evidence.
+- End-to-end: no direct legacy proposal path bypasses claim persistence.
+
+**Merge gate:**
+
+- ClaimFrame fields lost in round-trip: `0`;
+- partial write artifacts after injected failure: `0`;
+- incomplete legacy claims auto-promoted: `0`;
+- direct trusted-edge writes from the extraction proposal path: `0`;
+- graph and evidence service contract checks pass with generated artifacts
+  current.
+
+**Evidence report:**
+`docs/validation/reports/<date>-tg04-claim-persistence.md`
+
+## TG-05: Independent Agent Semantic Verifier
+
+**Hypothesis:** the extracting agent's rationale and deterministic text cues are
+not independent evidence that the complete qualified claim is entailed by the
+cited source.
+
+**Root cause:** semantic support currently has a heuristic fallback that can
+return `ENTAILS`, and the trust ladder checks the category without proving an
+independent agent evaluated polarity and qualifiers.
+
+**Primary files:**
+
+- new focused verifier modules under
+  `services/artana_evidence_api/document_extraction_support/agent_verification/`
+- `services/artana_evidence_api/document_extraction_support/evidence_support_verifier.py`
+- `services/artana_evidence_api/document_extraction_support/trust_ladder.py`
+- guarded agent runtime and replay/cache-key modules
+
+**Agent output contract:**
+
+- `support_status`: `entails`, `contradicts`, `insufficient`, or `abstain`;
+- `argument_grounding`: `both`, `partial`, or `none`;
+- `qualifier_fidelity`: `complete`, `incomplete`, `contradicted`, or
+  `not_applicable`;
+- `polarity_fidelity`: `correct`, `incorrect`, or `uncertain`;
+- exact supporting and contradicting spans;
+- explanation and falsification note;
+- no numeric confidence or readiness score.
+
+**Implementation scope:**
+
+- Run a distinct verification call after extraction using the cited source
+  snapshot, exact locator, and complete ClaimFrame.
+- Prevent the verifier from seeing extractor confidence, fixture labels, or
+  downstream trust status.
+- Record verifier model, prompt version, input hash, output hash, and run ID.
+- Fail closed on timeout, invalid category, missing span, or unavailable agent.
+- Keep deterministic cues as diagnostics only; they may detect obvious format
+  failures but cannot produce semantic trust.
+- Deterministically map categorical verifier findings to eligibility.
+
+**Required tests:**
+
+- Unit: every category maps to the intended fail-closed policy.
+- Unit: entailed broad triple plus missing qualifier is not eligible.
+- Unit: correct entities with wrong direction or polarity are rejected.
+- Unit: verifier timeout, malformed output, or cache mismatch blocks trust.
+- Regression: deterministic heuristic `ENTAILS` never substitutes for the agent.
+- Cache: model, prompt, ClaimFrame, source, or locator changes invalidate replay.
+- Live agent: three Luna verifier passes over positives, negatives, nulls,
+  hypotheses, multi-clause claims, and qualifier traps.
+- Adversarial: a separate agent attempts to approve claims using outside facts
+  not present in the cited source.
+
+**Merge gate:**
+
+- promotion-eligible claims with independent agent verification: `100%`;
+- heuristic semantic results counted as agent verification: `0`;
+- qualifier-incomplete or polarity-wrong claims eligible: `0`;
+- malformed/unavailable verifier results eligible: `0`;
+- categorical verifier stability across three identical runs: at least `95%`;
+- all numeric verifier metrics are computed deterministically.
+
+**Evidence report:**
+`docs/validation/reports/<date>-tg05-agent-verifier.md`
+
+## TG-06: Authoritative Entity And Variant Grounding
+
+**Hypothesis:** a correct statement is unsafe to connect when the system cannot
+prove which gene, variant, disease, drug, process, or phenotype each mention
+means.
+
+**Root cause:** model hints, local aliases, symbolic variant labels, and fixture
+expectations are mixed with authoritative verification.
+
+**Primary files:**
+
+- `services/artana_evidence_api/document_extraction_support/entity_grounding/`
+- `services/artana_evidence_api/document_extraction_support/entity_curie_linking.py`
+- graph dictionary governance and entity validation modules
+- frozen authoritative-source fixtures under the relevant test trees
+
+**Implementation scope:**
+
+- Define an allowlist of entity kinds and authoritative namespaces.
+- Use authoritative identifiers appropriate to each type, including numeric
+  ClinVar Variation IDs or accessions and GA4GH VRS computed identifiers for
+  variants where applicable.
+- Separate the agent's candidate resolution from deterministic authority
+  verification. The agent returns a candidate, category, explanation, and
+  evidence; code verifies identifier syntax, type, record existence, and
+  source/version provenance.
+- Represent allele, zygosity, copy-number state, loss/gain, fusion, expression,
+  and protein consequence separately from the bare gene.
+- Return `verified`, `ambiguous`, `unresolved`, or `invalid`; do not force a
+  nearest match.
+- Preserve ambiguous and unresolved novel claims for review while blocking
+  relation projection.
+
+**Required tests:**
+
+- Unit: symbolic ClinVar placeholders are invalid as authoritative IDs.
+- Unit: bare-gene grounding cannot replace a material variant or state.
+- Unit: namespace and entity type must agree.
+- Unit: ambiguous aliases abstain instead of choosing the first match.
+- Snapshot: authoritative record version and content hash are retained.
+- Integration: authoritative-source adapters fail closed on unavailable,
+  mismatched, retired, or redirected records.
+- Regression: the benchmark cannot use the same local dictionary entry as both
+  expected truth and independent verification.
+- Live agent: three runs over genes, variants, diseases, drugs, processes,
+  phenotypes, and deliberately ambiguous mentions.
+- Adversarial: attempt identifier spoofing, namespace confusion, paralog
+  substitution, and bare-gene collapse.
+
+**Merge gate:**
+
+- wrong authoritative links among eligible claims: `0`;
+- promotion-eligible endpoints with verified authority records: `100%`;
+- symbolic-placeholder verified identifiers: `0`;
+- material variant/state collapsed to a bare gene: `0`;
+- frozen diagnostic verified-CURIE match rate: at least `95%`;
+- unresolved novel claims preserved for review: `100%`.
+
+**Evidence report:**
+`docs/validation/reports/<date>-tg06-authoritative-grounding.md`
+
+## TG-07: Safe Claim-To-Relation Projection
+
+**Hypothesis:** a graph relation is safe only when its complete source claim is
+supported, authoritatively grounded, representable without qualifier loss, and
+still linked to its evidence.
+
+**Root cause:** projection and trust have been treated as metadata on relation
+candidates instead of as a deterministic policy over persisted qualified
+claims.
+
+**Primary files:**
+
+- `services/artana_evidence_db/claim_projection_readiness_service.py`
+- `services/artana_evidence_db/claim_projection_readiness_support.py`
+- `services/artana_evidence_db/relation_projection_invariant_service.py`
+- `services/artana_evidence_db/relation_projection_materialization_service.py`
+- `services/artana_evidence_db/relation_projection_source_service.py`
+- `services/artana_evidence_db/relation_autopromotion_policy.py`
+
+**Implementation scope:**
+
+- Compute projection eligibility deterministically from persisted claim facts.
+- Require authoritative source and locator, independent agent entailment,
+  verified participants, canonical predicate, explicit polarity, and complete
+  representable qualifiers.
+- Project only supported positive claims into positive canonical relations.
+- Keep `REFUTE`, `UNCERTAIN`, `HYPOTHESIS`, null-result, unresolved, and
+  qualifier-incomplete records queryable in the claim ledger without positive
+  projection.
+- Preserve a reversible pointer from every relation to its source claims,
+  evidence locators, verifier artifacts, and authority records.
+- Include material qualifiers in projection fingerprints so scoped claims do
+  not collapse into a broad edge.
+- Invalidate or rematerialize projections when a source, claim, entity,
+  verifier result, correction, or retraction changes.
+
+**Required tests:**
+
+- Unit decision table for every missing or failing prerequisite.
+- Unit: negative, null, uncertain, and hypothesis claims create no positive
+  canonical edge.
+- Unit: qualifier loss blocks projection rather than broadening the claim.
+- Unit: contradictory claims coexist in the ledger without becoming one
+  misleading edge.
+- Integration: complete claim projects exactly once and remains traceable.
+- Idempotency/concurrency: retries and races do not duplicate relations.
+- Invalidation: correction, retraction, or verifier reversal withdraws the
+  derived projection while retaining audit history.
+- End-to-end: neither Evidence API nor direct Graph API callers can bypass the
+  projection policy.
+- Adversarial: forged trust metadata, direct route calls, partial claims, and
+  stale verifier artifacts all fail.
+
+**Merge gate:**
+
+- positive projections from negative/null/uncertain/hypothesis claims: `0`;
+- projections with missing source, locator, verifier, or authoritative entity:
+  `0`;
+- projections that drop a material qualifier: `0`;
+- projected relations without reversible claim/evidence lineage: `0`;
+- duplicate projections under retry or concurrency: `0`;
+- Graph DB rejects all policy bypass attempts independently of Evidence API.
+
+**Evidence report:**
+`docs/validation/reports/<date>-tg07-safe-projection.md`
+
+## TG-08: Frozen Real-Source Proof And Release Decision
+
+**Hypothesis:** after the product contract is repaired, Artana will create
+specific, traceable, stable, independently verified claims from real biomedical
+sources rather than only performing well against repository-authored fixtures.
+
+**Root cause addressed:** previous scorecards relied heavily on synthetic or
+repository-authored cases and measured broad triple concordance. They did not
+prove source-local fidelity of the complete claim.
+
+**Study set:**
+
+- at least 60 real, immutable source documents;
+- balanced coverage of strong direct findings, explicit negatives and nulls,
+  variants and biological state, population and treatment qualifiers,
+  provisional or novel hypotheses, and long or contradictory documents;
+- topic coverage across oncology, rare disease, cardiology, pharmacogenomics,
+  molecular mechanisms, and clinical trials;
+- no test case may be created from the same dictionary record used to verify
+  its expected entity mapping;
+- source snapshots, case-selection rules, hashes, prompts, and metric semantics
+  are frozen before the first run.
+
+**Execution:**
+
+- Run the complete agent path three times with `openai:gpt-5.6-luna` and no
+  deterministic semantic fallback.
+- Freeze each run before review.
+- Run independent packet-only and source-enriched agent reviewers using the
+  categorical contract in
+  `docs/validation/codex-agent-expert-evaluation-protocol.md`.
+- Allow source-enriched agents to browse authoritative sources, but keep
+  source-local sufficiency separate from external-world corroboration.
+- Run fresh adversarial agents against every proposed keep decision, negative
+  control, novel hypothesis, unstable claim, and high-impact disagreement.
+- Compute every metric deterministically from frozen categorical findings.
+- Publish raw artifacts, hashes, source ledger, disagreements, adjudication,
+  metric protocol, deterministic scorecard, and plain-language report.
+
+**Agent-readiness gates:**
+
+| Gate | Target |
+|---|---:|
+| Agent completion | 100% in every run |
+| Credited fallback | 0 |
+| Invalid agent output | 0 |
+| Authoritative source identity and exact locator | 100% of eligible claims |
+| Independent agent semantic verification | 100% of eligible claims |
+| Heuristic semantic verification receiving agent credit | 0 |
+| Authoritatively verified entities | 100% of eligible claim endpoints |
+| Wrong authoritative entity links | 0 |
+| Positive projection from negative/null/hypothesis claims | 0 |
+| Material qualifier loss in projected relations | 0 |
+| Strong provenance in reviewed eligible packets | 100% |
+| Source-local packet sufficiency | at least 90% diagnostic rate |
+| Generic or overstated reviewed claims | at most 5% diagnostic rate |
+| Exact semantic stability across three runs | at least 95% |
+| High-severity unsupported auto-projections | 0 |
+| Novel hypotheses preserved or explicitly routed | 100% |
+
+The packet sufficiency, specificity, and stability rates are internal
+agent-diagnostic measures until human experts review the frozen study. They may
+authorize the `verified_evidence` lane, not a claim of human-expert precision.
+
+**Merge and release gate:**
+
+- all earlier PR evidence is linked and hash-verifiable;
+- every agent-readiness gate above passes without threshold changes;
+- independent adversarial review has no unresolved high-severity issue;
+- three repeated runs pass on worst-run metrics, not only means;
+- the report clearly separates technical readiness, diagnostic agent findings,
+  and absent human-expert validation;
+- if any hard gate fails, the decision remains `not_ready` and the report names
+  the exact failing cases. Do not start another broad PR loop automatically.
+
+**Evidence report:**
+`docs/validation/reports/<date>-tg08-real-source-readiness.md`
+
+## Evidence Summary Template
+
+Every PR must create one report using this shape:
+
+```markdown
+# TG-0X Evidence Summary
+
+- GitHub PR:
+- Branch:
+- Commit:
+- Parent commit:
+- Hypothesis:
+- Root cause:
+- Implementation responsibility:
+- Frozen input manifest and hash:
+- Model and normalized execution model:
+- Prompt/configuration hashes:
+
+## Before And After
+
+| Gate | Baseline | Current | Target | Denominator | Result |
+|---|---:|---:|---:|---:|---|
+
+## Validation
+
+- Focused unit/regression tests:
+- Integration/migration/contract tests:
+- Service checks:
+- Strict live-agent runs:
+- Artifact hashes:
+- Independent reviewer:
+- Adversarial findings and resolutions:
+
+## Decision
+
+- Merge gate: pass/fail
+- Safety invariants strengthened:
+- Product quality improved:
+- Remaining blockers:
+- Human-expert evidence present: yes/no
+```
+
+## Final Readiness Matrix
+
+Do not collapse progress into one weighted score. A high average can hide a
+single unsafe failure. Track each dimension independently.
+
+| Dimension | Baseline | Required end state | Owning PR | Current evidence | Status |
+|---|---|---|---|---|---|
+| Agent execution | 300/300, fallback 0 | Preserve 100%, fallback 0 | All | July 14 report | passing |
+| Truthful trust | Heuristic and symbolic-authority gaps found | No non-agent semantic trust or fake authority | TG-01 | Pending | not_started |
+| Source traceability | 2/47 strong provenance | 100% eligible claims strong | TG-02 | Pending | not_started |
+| Claim completeness | 13/47 generic/overstated outcomes | Complete polarity/state/qualifiers | TG-03 | Pending | not_started |
+| Lossless persistence | Triple-oriented write path | Zero ClaimFrame field loss | TG-04 | Pending | not_started |
+| Semantic verification | Heuristic can return `ENTAILS` | Independent categorical agent verifier | TG-05 | Pending | not_started |
+| Entity grounding | 75.86% worst-run diagnostic rate | At least 95%, wrong links 0 | TG-06 | Pending | not_started |
+| Safe projection | Review flags can accompany assertive tuples | Zero unsafe or lossy positive edges | TG-07 | Pending | not_started |
+| Real-source proof | 8/47 sufficient risk packets | All TG-08 gates on 60+ real sources | TG-08 | Pending | not_started |
+| Human-expert proof | None | Authenticated independent expert study | Future governance | Not available | blocked |
+
+## Stop And Reassess Rules
+
+Stop the implementation sequence and perform a root-cause review when any of
+the following occurs:
+
+- two consecutive PRs add validation machinery without improving a product
+  field or strengthening a safety invariant;
+- the same failure class remains unchanged after two attempted product fixes;
+- a PR needs to lower a threshold or relabel an output to appear successful;
+- live-agent completion, fallback, invalid-output, negative-control, or wrong-ID
+  safety regresses;
+- packet sufficiency or qualifier fidelity does not materially improve after
+  TG-03 and TG-04;
+- the implementation starts using external corroboration to excuse missing
+  source-local evidence;
+- a new broad benchmark is proposed before the current frozen failures are
+  closed;
+- agent evaluation is presented as human-expert precision.
+
+At a stop point, publish a short decision record with: observed failure, root
+cause hypothesis, evidence for and against it, whether to revise the approach,
+and the smallest next experiment. Do not continue the PR sequence by inertia.
+
+## Good Stopping Points
+
+- **After TG-01:** the system is more truthful but may have zero trusted claims.
+  This is a safe operational stop.
+- **After TG-04:** Artana has a traceable claim ledger even before automatic
+  projection. Candidate discovery and human review can use it safely.
+- **After TG-07:** the product path is technically complete; automatic trusted
+  promotion may remain disabled while real-source proof runs.
+- **After TG-08:** decide whether to enable the agent-verified lane, repeat a
+  narrowly targeted failure experiment, or wait for human experts. Do not open
+  another general excellence loop without a newly observed root cause.

--- a/docs/validation/trusted-claim-recovery-plan.md
+++ b/docs/validation/trusted-claim-recovery-plan.md
@@ -240,15 +240,18 @@ set -a
 source .env.postgres
 set +a
 export ARTANA_AI_EVIDENCE_EXTRACTION_MODEL=openai:gpt-5.6-luna
+RUN_DIR=docs/validation/reports/relation_feasibility/<date>-<plan-id>-run-01
+test ! -e "$RUN_DIR"
 uv run python scripts/run_relation_feasibility_audit.py \
   --extractor agent \
-  --output-dir \
-    docs/validation/reports/relation_feasibility/<date>-<plan-id>-run-01
+  --output-dir "$RUN_DIR"
 ```
 
 For semantic PRs, repeat into `run-02` and `run-03`, then evaluate worst-run
-results with the existing readiness gate. Do not overwrite a prior run or retry
-only failed cases. Store the exact command, environment-name allowlist, model,
+results with the existing readiness gate. The no-clobber preflight is mandatory
+for every run ID; a pre-existing run directory invalidates the command rather
+than authorizing replacement. Do not overwrite a prior run or retry only failed
+cases. Store the exact command, environment-name allowlist, model,
 prompt/configuration hashes, and output hashes in the evidence report. Never
 record secret values. The run preflight and manifest must both prove that the
 configured and retrieved provider model is exactly `openai:gpt-5.6-luna`; a

--- a/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/result.py
+++ b/services/artana_evidence_api/evidence_selection/diagnostics/benchmark_v2/expert_pilot/result.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 _RUNS_PER_MODEL = 3
 ModelRole = Literal["current", "candidate"]
+_MODEL_ROLES: tuple[ModelRole, ...] = ("current", "candidate")
 GateStatus = Literal["passed", "failed", "unavailable"]
 ComparisonStatus = Literal[
     "current_only_passed",
@@ -125,7 +126,7 @@ def build_expert_pilot_result(
             gold=gold,
             protocol=protocol,
         )
-        for role in ("current", "candidate")
+        for role in _MODEL_ROLES
     )
     status_by_role = {summary.model_role: summary.gate_status for summary in summaries}
     comparison_status = _comparison_status(status_by_role)


### PR DESCRIPTION
## Summary
- define the frozen Codex agent-expert evaluation protocol
- record the canonical eight-PR trusted-claim recovery plan and link it from the progress tracker
- fix the closed-set model-role typing defect that blocked the repository type-check hook on current main

## Validation
- `.venv/bin/python -m pytest services/artana_evidence_api/tests/unit/test_evidence_selection_expert_pilot_attestation.py -q` (16 passed)
- `make artana-evidence-api-type-check`
- `.venv/bin/pre-commit run --files ...`
- `make service-checks` (passed, 87.55% coverage)

## Readiness boundary
This PR publishes the plan and diagnostic rules. It does not claim trusted-graph readiness or human-expert validation.