### PR TITLE
TG-04 v2: bind repeated source mentions without agent offsets

### DIFF
--- a/docs/validation/reports/2026-07-11-pr-semantic-pr3-agent-output-registry.json
+++ b/docs/validation/reports/2026-07-11-pr-semantic-pr3-agent-output-registry.json
@@ -310,13 +310,13 @@
         "document_extraction_support/llm_extraction/claim_inventory.py"
       ],
       "prompt_identifiers": [
-        "document_extraction.claim_inventory.v6"
+        "document_extraction.claim_inventory.v7"
       ],
       "schema_id": "document_extraction.claim_inventory.v3",
       "schema_names": [
         "LLMClaimInventoryResult"
       ],
-      "shape_hash": "a4d084f26d113cc7a0f4ebf6584b72a431c7e16f0c7fc5265fb28deeac31ff17"
+      "shape_hash": "5971e1fec819faa32812a0ba5dce46138031eb05df1e55e9c137ef7723b45cda"
     },
     {
       "categorical_fields": [
@@ -432,13 +432,13 @@
         "document_extraction_support/llm_extraction/claim_inventory.py"
       ],
       "prompt_identifiers": [
-        "document_extraction.claim_inventory_completeness.v5"
+        "document_extraction.claim_inventory_completeness.v6"
       ],
       "schema_id": "document_extraction.claim_inventory_completeness.v3",
       "schema_names": [
         "ClaimInventoryCompletenessReview"
       ],
-      "shape_hash": "541c7f78ed01e31d66baaf94a5ab2d4bd67c7efda7e6f46546bd9a21fefa8314"
+      "shape_hash": "c16184f40c2854ff40dfe85c43024e73d9d93e2599de79e9f60fdcfe741e7c23"
     },
     {
       "categorical_fields": [
@@ -545,13 +545,13 @@
         "document_extraction_support/llm_extraction/claim_inventory.py"
       ],
       "prompt_identifiers": [
-        "document_extraction.claim_inventory_recovery.v5"
+        "document_extraction.claim_inventory_recovery.v6"
       ],
       "schema_id": "document_extraction.claim_inventory_recovery.v3",
       "schema_names": [
         "MissingClaimRecoveryResult"
       ],
-      "shape_hash": "59e9df9996c60ae0b9040287bd85ca94cf0b719fb0e8b616a0906c0e856a3b0f"
+      "shape_hash": "ffdc56f2350b801840891aa82eef0f4d51abaee21a6900f8b4ba0d83dc932601"
     },
     {
       "categorical_fields": [

--- a/scripts/validation/claim_events/evidence_binding.py
+++ b/scripts/validation/claim_events/evidence_binding.py
@@ -18,7 +18,8 @@ from artana_evidence_api.document_extraction_support.claim_frames import (
     ClaimInventoryCompletenessReview,
     ClaimInventoryItem,
     bind_claim_inventory,
-    claim_inventory_identity,
+    bind_claim_inventory_item_at_source,
+    claim_inventory_batch_input_sha256,
     coalesce_long_sentence_chunks,
 )
 from artana_evidence_api.document_extraction_support.full_text_chunking import (
@@ -326,7 +327,7 @@ def _take_complete_review_attempt(
     inventory: tuple[BoundClaimInventoryItem, ...],
     context: _PromptContext,
 ) -> Mapping[str, object]:
-    input_sha256 = _inventory_ids_sha256(inventory)
+    input_sha256 = claim_inventory_batch_input_sha256(inventory)
     matches: list[Mapping[str, object]] = []
     for attempt in attempts:
         if attempt.get("input_sha256") != input_sha256:
@@ -406,6 +407,7 @@ def _validate_predictions(
             {
                 "exact_span": event.get("exact_span"),
                 "relation_cue_span": event.get("relation_cue_span"),
+                "relation_cue_anchor": event.get("relation_cue_anchor"),
                 "arguments": _agent_arguments(event.get("arguments")),
                 "source_locator": event.get("source_locator"),
                 "event_type": event.get("event_type"),
@@ -420,12 +422,14 @@ def _validate_predictions(
             raise ValueError("TG-04 prediction source offsets do not match exact_span")
         if context.normalized_source[source_start:source_end] != item.exact_span:
             raise ValueError("TG-04 prediction exact_span differs from frozen source")
-        _validate_scored_mentions(event=event, item=item, source_start=source_start)
-        inventory_id = claim_inventory_identity(
+        bound_claim = bind_claim_inventory_item_at_source(
             item=item,
             source_sha256=context.source_sha256,
+            chunk_index=0,
             source_start=source_start,
         )
+        _validate_scored_mentions(event=event, bound_claim=bound_claim)
+        inventory_id = bound_claim.inventory_id
         if event.get("inventory_id") != inventory_id:
             raise ValueError("TG-04 prediction inventory identity mismatch")
         if inventory_id in inventory:
@@ -437,28 +441,47 @@ def _validate_predictions(
 def _validate_scored_mentions(
     *,
     event: Mapping[str, object],
-    item: ClaimInventoryItem,
-    source_start: int,
+    bound_claim: BoundClaimInventoryItem,
 ) -> None:
+    item = bound_claim.item
     cue = item.relation_cue_span
-    if item.exact_span.count(cue) != 1:
-        raise ValueError("TG-04 scored trigger is ambiguous within its source span")
-    if event.get("trigger_span") != cue or event.get(
-        "trigger_source_start"
-    ) != source_start + item.exact_span.index(cue):
+    trigger = bound_claim.trigger_mention
+    if (
+        event.get("trigger_span") != cue
+        or event.get("trigger_source_start") != trigger.source_start
+    ):
         raise ValueError("TG-04 scored trigger differs from provider-bound inventory")
+    if event.get("trigger_source_mention") != {
+        "exact_span": trigger.exact_span,
+        "source_start": trigger.source_start,
+        "source_end": trigger.source_end,
+    }:
+        raise ValueError("TG-04 scored trigger mention differs from inventory")
     scored_arguments = _sequence(event.get("arguments"), "prediction arguments")
     if len(scored_arguments) != len(item.arguments):
         raise ValueError("TG-04 scored argument count differs from inventory")
-    for scored, argument in zip(scored_arguments, item.arguments, strict=True):
+    for scored, bound_argument in zip(
+        scored_arguments,
+        bound_claim.bound_arguments,
+        strict=True,
+    ):
         scored_argument = _object(scored, "prediction argument")
-        if item.exact_span.count(argument.exact_span) != 1:
-            raise ValueError(
-                "TG-04 scored argument is ambiguous within its source span"
-            )
-        expected_start = source_start + item.exact_span.index(argument.exact_span)
-        if scored_argument.get("source_start") != expected_start:
+        mentions = bound_argument.mentions
+        if (
+            scored_argument.get("source_start")
+            != bound_argument.primary_mention.source_start
+        ):
             raise ValueError("TG-04 scored argument offset differs from inventory")
+        expected_mentions = [
+            {
+                "exact_span": mention.exact_span,
+                "source_start": mention.source_start,
+                "source_end": mention.source_end,
+            }
+            for mention in mentions
+        ]
+        if scored_argument.get("source_mentions") != expected_mentions:
+            raise ValueError("TG-04 scored argument mentions differ from inventory")
 
 
 def _validate_attempt_record(attempt: Mapping[str, object], outcome: object) -> None:
@@ -514,21 +537,17 @@ def _agent_arguments(value: object) -> list[dict[str, object]]:
     return [
         {
             key: argument.get(key)
-            for key in ("role", "event_role", "exact_span", "role_rationale")
+            for key in (
+                "role",
+                "event_role",
+                "exact_span",
+                "mention_anchors",
+                "role_rationale",
+            )
         }
         for item in _sequence(value, "prediction arguments")
         if (argument := _object(item, "prediction argument"))
     ]
-
-
-def _inventory_ids_sha256(inventory: Sequence[BoundClaimInventoryItem]) -> str:
-    return _sha256_text(
-        json.dumps(
-            [claim.inventory_id for claim in inventory],
-            separators=(",", ":"),
-            ensure_ascii=True,
-        ),
-    )
 
 
 def _insert_unique_attempt(

--- a/scripts/validation/claim_events/runner.py
+++ b/scripts/validation/claim_events/runner.py
@@ -281,6 +281,7 @@ def _nary_events(
     events: list[dict[str, object]] = []
     for claim in claims:
         item = claim.item.model_dump(mode="json")
+        trigger_mention = claim.trigger_mention
         exact_span = item.get("exact_span")
         if not isinstance(exact_span, str):
             raise TypeError("TG-04 inventory exact_span must be text")
@@ -288,17 +289,29 @@ def _nary_events(
         if not isinstance(raw_arguments, list):
             raise TypeError("TG-04 inventory arguments must be a list")
         arguments: list[dict[str, object]] = []
-        for raw_argument in raw_arguments:
+        for bound_argument, raw_argument in zip(
+            claim.bound_arguments,
+            raw_arguments,
+            strict=True,
+        ):
             if not isinstance(raw_argument, dict):
                 raise TypeError("TG-04 inventory argument must be an object")
             argument_span = raw_argument.get("exact_span")
             if not isinstance(argument_span, str):
                 raise TypeError("TG-04 inventory argument exact_span must be text")
+            mentions = bound_argument.mentions
             arguments.append(
                 {
                     **raw_argument,
-                    "source_start": claim.source_start
-                    + exact_span.index(argument_span),
+                    "source_start": bound_argument.primary_mention.source_start,
+                    "source_mentions": [
+                        {
+                            "exact_span": mention.exact_span,
+                            "source_start": mention.source_start,
+                            "source_end": mention.source_end,
+                        }
+                        for mention in mentions
+                    ],
                 },
             )
         events.append(
@@ -309,11 +322,14 @@ def _nary_events(
                 "exact_span": exact_span,
                 "source_locator": item.get("source_locator"),
                 "trigger_span": item.get("relation_cue_span"),
-                "trigger_source_start": (
-                    claim.source_start
-                    + exact_span.index(str(item.get("relation_cue_span")))
-                ),
+                "trigger_source_start": trigger_mention.source_start,
+                "trigger_source_mention": {
+                    "exact_span": trigger_mention.exact_span,
+                    "source_start": trigger_mention.source_start,
+                    "source_end": trigger_mention.source_end,
+                },
                 "relation_cue_span": item.get("relation_cue_span"),
+                "relation_cue_anchor": item.get("relation_cue_anchor"),
                 "event_type": item.get("event_type"),
                 "polarity": item.get("polarity"),
                 "epistemic_status": item.get("epistemic_status"),

--- a/services/artana_evidence_api/document_extraction_prompting.py
+++ b/services/artana_evidence_api/document_extraction_prompting.py
@@ -129,7 +129,9 @@ class _SingleClaimFramingEnvelope(BaseModel):
             ClaimFramingDecision.AMBIGUOUS,
         }:
             if relation_count < _MIN_MULTI_FRAME_RELATIONS:
-                raise ValueError(f"{self.decision.value} requires at least two relations")
+                raise ValueError(
+                    f"{self.decision.value} requires at least two relations"
+                )
             if (
                 self.abstention_reason is not None
                 or self.abstention_rationale is not None
@@ -556,11 +558,13 @@ Return every source-local biomedical event or assertion with a relation cue, one
 For each claim:
 - exact_span is the smallest complete verbatim source span that contains the event, every material argument, and the context needed to interpret it; when the same text repeats in the chunk, include enough adjacent verbatim context to make exact_span occur once;
 - arguments contains every material source-native span with one closed participant role: INTERVENTION, CONDITION, POPULATION, VARIANT, OUTCOME, COMPARATOR, TIMEFRAME, STUDY_DESIGN, TREATMENT_SETTING, GENE_OR_PROTEIN, CHEMICAL_OR_DRUG, BIOMARKER, EXPOSURE, BIOLOGICAL_PROCESS, ANATOMY, MEASUREMENT, or OTHER_ENTITY;
+- when an argument has repeated, aliased, or coreferential mentions inside the claim, mention_anchors must copy each intended verbatim mention_span plus adjacent verbatim left_context and/or right_context; include at least one anchor whose mention_span equals the argument exact_span, use aliases or pronouns only when the local source makes the reference explicit, and never return offsets or numeric positions;
 - every argument also has one closed event_role describing what it does in the event: AGENT, THEME, TARGET, CAUSE, EFFECT, CONTEXT, SITE, CSITE, ATLOC, TOLOC, FROMLOC, or MEASURE;
 - do not discard a condition, population, variant, or outcome merely because it is grammatical context rather than a direct verb argument;
 - a VARIANT exact_span includes any attached material state suffix such as -positive, -negative, -mutant, -deficient, -high, or -low;
 - role_rationale explains the source-local role in words without a score;
 - relation_cue_span is the exact verb or phrase that states the relation;
+- when relation_cue_span occurs more than once inside exact_span, relation_cue_anchor must copy that cue as mention_span and identify the intended trigger using adjacent verbatim context; never return an offset;
 - event_type is exactly one of EXPRESSION, TRANSCRIPTION, DEGRADATION, PHOSPHORYLATION, LOCALIZATION, BINDING, REGULATION, POSITIVE_REGULATION, NEGATIVE_REGULATION, INCREASE, DECREASE, ASSOCIATION, TREATMENT_RESPONSE, NO_EFFECT, or OTHER_EXPLICIT; choose the most specific source-explicit category and use OTHER_EXPLICIT only when none of the named categories fits;
 - source_locator is exactly normalized_extraction_text;
 - polarity is one of SUPPORT, REFUTE, UNCERTAIN, HYPOTHESIS, or NULL_RESULT;
@@ -572,12 +576,12 @@ Inventory sibling predicates as separate claims even when they occur in one sent
 
 CLAIM_INVENTORY_COMPLETENESS_SYSTEM_PROMPT = """You independently review whether a supplied claim inventory completely covers one frozen source chunk.
 
-Return one categorical decision only: COMPLETE when every explicit biomedical event and every material typed argument is represented, or INCOMPLETE when at least one event or argument is absent. For INCOMPLETE, return a source-bound descriptor for every missing claim using its complete exact span, typed arguments, event roles, relation cue, event_type, polarity, and epistemic status. event_type is exactly one of EXPRESSION, TRANSCRIPTION, DEGRADATION, PHOSPHORYLATION, LOCALIZATION, BINDING, REGULATION, POSITIVE_REGULATION, NEGATIVE_REGULATION, INCREASE, DECREASE, ASSOCIATION, TREATMENT_RESPONSE, NO_EFFECT, or OTHER_EXPLICIT. For COMPLETE, return no missing descriptors. Include negative, null, uncertain, provisional, hypothesis, and sibling claims. Do not frame final graph endpoints or relation types, rank claims, use outside knowledge, or return confidence, probability, quality, importance, or any other numeric score."""
+Return one categorical decision only: COMPLETE when every explicit biomedical event and every material typed argument is represented, or INCOMPLETE when at least one event or argument is absent. For INCOMPLETE, return a source-bound descriptor for every missing claim using its complete exact span, typed arguments, event roles, relation cue, event_type, polarity, and epistemic status. When an argument is repeated, aliased, or coreferential, copy each intended verbatim mention_span plus adjacent verbatim context, including the canonical exact_span; when a relation cue repeats, do the same for the intended cue; never return numeric offsets. event_type is exactly one of EXPRESSION, TRANSCRIPTION, DEGRADATION, PHOSPHORYLATION, LOCALIZATION, BINDING, REGULATION, POSITIVE_REGULATION, NEGATIVE_REGULATION, INCREASE, DECREASE, ASSOCIATION, TREATMENT_RESPONSE, NO_EFFECT, or OTHER_EXPLICIT. For COMPLETE, return no missing descriptors. Include negative, null, uncertain, provisional, hypothesis, and sibling claims. Do not frame final graph endpoints or relation types, rank claims, use outside knowledge, or return confidence, probability, quality, importance, or any other numeric score."""
 
 
 MISSING_CLAIM_RECOVERY_SYSTEM_PROMPT = """You recover only claims identified as missing by an independent inventory-completeness review.
 
-Return every reviewed missing claim and no existing or additional claim. Copy the complete event span and every typed argument exactly from the frozen source; preserve each argument's event_role, event_type, polarity, and epistemic status; and use source_locator=normalized_extraction_text. event_type is exactly one of EXPRESSION, TRANSCRIPTION, DEGRADATION, PHOSPHORYLATION, LOCALIZATION, BINDING, REGULATION, POSITIVE_REGULATION, NEGATIVE_REGULATION, INCREASE, DECREASE, ASSOCIATION, TREATMENT_RESPONSE, NO_EFFECT, or OTHER_EXPLICIT. Do not frame final graph endpoints or relations, rank claims, use outside knowledge, or return confidence, probability, quality, importance, or any other numeric score. If a reviewed descriptor cannot be recovered exactly, return schema-invalid output rather than inventing content."""
+Return every reviewed missing claim and no existing or additional claim. Copy every reviewed field exactly, including the complete event span, relation cue, typed arguments, event roles, mention anchors, and rationales; preserve event_type, polarity, and epistemic status; and use source_locator=normalized_extraction_text. For repeated, aliased, or coreferential argument mentions, copy the reviewed verbatim mention_span and adjacent context, including the canonical exact_span; for repeated relation cues, copy the reviewed cue mention_span and context; never return numeric offsets. event_type is exactly one of EXPRESSION, TRANSCRIPTION, DEGRADATION, PHOSPHORYLATION, LOCALIZATION, BINDING, REGULATION, POSITIVE_REGULATION, NEGATIVE_REGULATION, INCREASE, DECREASE, ASSOCIATION, TREATMENT_RESPONSE, NO_EFFECT, or OTHER_EXPLICIT. Do not frame final graph endpoints or relations, rank claims, use outside knowledge, or return confidence, probability, quality, importance, or any other numeric score. If a reviewed descriptor cannot be recovered exactly, return schema-invalid output rather than inventing content."""
 
 
 SINGLE_CLAIM_FRAMING_SYSTEM_PROMPT = f"""You frame exactly one source-bound, role-typed biomedical assertion. This is not a search or ranking task.

--- a/services/artana_evidence_api/document_extraction_support/claim_frames/__init__.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_frames/__init__.py
@@ -34,15 +34,23 @@ from artana_evidence_api.document_extraction_support.claim_frames.event_types im
 )
 from artana_evidence_api.document_extraction_support.claim_frames.inventory import (
     CLAIM_INVENTORY_SOURCE_LOCATOR,
+    BoundClaimArgument,
     BoundClaimInventoryItem,
     ClaimFramingAbstentionReason,
     ClaimFramingDecision,
+    ClaimInventoryArgument,
     ClaimInventoryBindingError,
     ClaimInventoryItem,
     bind_claim_inventory,
+    bind_claim_inventory_item_at_source,
+    claim_inventory_batch_input_sha256,
     claim_inventory_identity,
     claim_inventory_input_sha256,
     merge_bound_claim_inventories,
+)
+from artana_evidence_api.document_extraction_support.claim_frames.mentions import (
+    BoundClaimMention,
+    ClaimMentionAnchor,
 )
 from artana_evidence_api.document_extraction_support.claim_frames.normalization import (
     ClaimFrameNormalizationError,
@@ -62,7 +70,9 @@ from artana_evidence_api.document_extraction_support.claim_frames.source_regions
 
 __all__ = [
     "CLAIM_INVENTORY_SOURCE_LOCATOR",
+    "BoundClaimArgument",
     "BoundClaimInventoryItem",
+    "BoundClaimMention",
     "BoundInventoryCompletenessReview",
     "ClaimArgument",
     "ClaimArgumentRole",
@@ -74,9 +84,11 @@ __all__ = [
     "ClaimFramingAbstentionReason",
     "ClaimFramingDecision",
     "ClaimInventoryBindingError",
+    "ClaimInventoryArgument",
     "ClaimInventoryCompletenessReview",
     "ClaimInventoryItem",
     "ClaimLocalSourceRegion",
+    "ClaimMentionAnchor",
     "ClaimQualifier",
     "ClaimSourceMeasurement",
     "EpistemicStatus",
@@ -90,6 +102,8 @@ __all__ = [
     "SourceMeasurementNumber",
     "bind_claim_frame",
     "bind_claim_inventory",
+    "bind_claim_inventory_item_at_source",
+    "claim_inventory_batch_input_sha256",
     "claim_inventory_identity",
     "claim_inventory_input_sha256",
     "bind_inventory_completeness_review",

--- a/services/artana_evidence_api/document_extraction_support/claim_frames/completeness.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_frames/completeness.py
@@ -10,6 +10,7 @@ from artana_evidence_api.document_extraction_support.claim_frames.inventory impo
     ClaimInventoryBindingError,
     ClaimInventoryItem,
     bind_claim_inventory,
+    claim_inventory_input_sha256,
 )
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -116,9 +117,21 @@ def require_recovery_matches_review(
 ) -> None:
     """Require recovery to return exactly the claims named by the review agent."""
 
-    recovered_ids = {claim.inventory_id for claim in recovered_claims}
-    reviewed_ids = {claim.inventory_id for claim in reviewed_missing_claims}
-    if recovered_ids != reviewed_ids:
+    recovered_inputs = {
+        claim.inventory_id: claim_inventory_input_sha256(
+            inventory_id=claim.inventory_id,
+            item=claim.item,
+        )
+        for claim in recovered_claims
+    }
+    reviewed_inputs = {
+        claim.inventory_id: claim_inventory_input_sha256(
+            inventory_id=claim.inventory_id,
+            item=claim.item,
+        )
+        for claim in reviewed_missing_claims
+    }
+    if recovered_inputs != reviewed_inputs:
         raise ClaimInventoryBindingError(
             "missing-claim recovery did not exactly match the completeness review",
         )

--- a/services/artana_evidence_api/document_extraction_support/claim_frames/inventory.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_frames/inventory.py
@@ -19,6 +19,12 @@ from artana_evidence_api.document_extraction_support.claim_frames.contracts impo
 from artana_evidence_api.document_extraction_support.claim_frames.event_types import (
     ClaimEventType,
 )
+from artana_evidence_api.document_extraction_support.claim_frames.mentions import (
+    BoundClaimMention,
+    ClaimMentionAnchor,
+    MentionBindingError,
+    bind_source_mentions,
+)
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 CLAIM_INVENTORY_SOURCE_LOCATOR = "normalized_extraction_text"
@@ -56,6 +62,36 @@ class ClaimFramingAbstentionReason(str, Enum):
     SOURCE_CONFLICT = "SOURCE_CONFLICT"
 
 
+class ClaimInventoryArgument(ClaimArgument):
+    """Semantic argument plus inventory-only source mention selectors."""
+
+    mention_anchors: tuple[ClaimMentionAnchor, ...] = Field(
+        default_factory=tuple,
+        max_length=16,
+    )
+
+    @field_validator("mention_anchors", mode="before")
+    @classmethod
+    def freeze_json_mention_anchors(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("mention_anchors")
+    @classmethod
+    def require_unique_mention_anchors(
+        cls,
+        value: tuple[ClaimMentionAnchor, ...],
+    ) -> tuple[ClaimMentionAnchor, ...]:
+        identities = tuple(
+            (anchor.mention_span, anchor.left_context, anchor.right_context)
+            for anchor in value
+        )
+        if len(set(identities)) != len(identities):
+            raise ValueError("claim inventory mention anchors must be unique")
+        return value
+
+
 class ClaimInventoryItem(BaseModel):
     """One source-local claim boundary identified by the inventory agent."""
 
@@ -63,7 +99,12 @@ class ClaimInventoryItem(BaseModel):
 
     exact_span: str = Field(..., min_length=1, max_length=12000)
     relation_cue_span: str = Field(..., min_length=1, max_length=1000)
-    arguments: tuple[ClaimArgument, ...] = Field(..., min_length=2, max_length=32)
+    relation_cue_anchor: ClaimMentionAnchor | None = None
+    arguments: tuple[ClaimInventoryArgument, ...] = Field(
+        ...,
+        min_length=2,
+        max_length=32,
+    )
     source_locator: Literal["normalized_extraction_text"]
     event_type: ClaimEventType = Field(..., strict=False)
     polarity: Polarity = Field(..., strict=False)
@@ -116,6 +157,15 @@ class ClaimInventoryItem(BaseModel):
 
 
 @dataclass(frozen=True, slots=True)
+class BoundClaimArgument:
+    """One semantic argument and all deterministically localized mentions."""
+
+    argument: ClaimArgument
+    primary_mention: BoundClaimMention
+    mentions: tuple[BoundClaimMention, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class BoundClaimInventoryItem:
     """An inventory item with deterministic source identity and offsets."""
 
@@ -125,6 +175,8 @@ class BoundClaimInventoryItem:
     chunk_index: int
     source_start: int
     source_end: int
+    trigger_mention: BoundClaimMention
+    bound_arguments: tuple[BoundClaimArgument, ...]
 
 
 def bind_claim_inventory(
@@ -139,14 +191,7 @@ def bind_claim_inventory(
 
     if not source_text:
         raise ClaimInventoryBindingError("claim inventory source text is empty")
-    if len(source_sha256) != _SHA256_HEX_LENGTH or any(
-        character not in "0123456789abcdef" for character in source_sha256
-    ):
-        raise ClaimInventoryBindingError("claim inventory source hash must be SHA-256")
-    if chunk_index < 0:
-        raise ClaimInventoryBindingError(
-            "claim inventory chunk index must be nonnegative"
-        )
+    _require_binding_metadata(source_sha256=source_sha256, chunk_index=chunk_index)
     if source_start_offset < 0:
         raise ClaimInventoryBindingError(
             "claim inventory source offset must be nonnegative"
@@ -155,7 +200,10 @@ def bind_claim_inventory(
     bound: list[BoundClaimInventoryItem] = []
     seen_item_fingerprints: set[str] = set()
     for item in items:
-        _require_inventory_item_spans(item=item, source_text=source_text)
+        if source_text.count(item.exact_span) != 1:
+            raise ClaimInventoryBindingError(
+                "claim inventory exact_span must occur exactly once in the source chunk",
+            )
         source_start = source_start_offset + source_text.index(item.exact_span)
         item_fingerprint = claim_inventory_identity(
             item=item,
@@ -163,16 +211,16 @@ def bind_claim_inventory(
             source_start=source_start,
         )
         if item_fingerprint in seen_item_fingerprints:
-            continue
+            raise ClaimInventoryBindingError(
+                "one inventory response cannot repeat a semantic claim",
+            )
         seen_item_fingerprints.add(item_fingerprint)
         bound.append(
-            BoundClaimInventoryItem(
-                inventory_id=item_fingerprint,
+            bind_claim_inventory_item_at_source(
                 item=item,
                 source_sha256=source_sha256,
                 chunk_index=chunk_index,
                 source_start=source_start,
-                source_end=source_start + len(item.exact_span),
             ),
         )
     return tuple(bound)
@@ -194,37 +242,129 @@ def merge_bound_claim_inventories(
     return tuple(merged)
 
 
-def _require_inventory_item_spans(
+def bind_claim_inventory_item_at_source(
     *,
     item: ClaimInventoryItem,
-    source_text: str,
-) -> None:
-    if source_text.count(item.exact_span) != 1:
+    source_sha256: str,
+    chunk_index: int,
+    source_start: int,
+) -> BoundClaimInventoryItem:
+    """Create the sole deterministic binding for one source-located inventory item."""
+
+    _require_binding_metadata(source_sha256=source_sha256, chunk_index=chunk_index)
+    if source_start < 0:
         raise ClaimInventoryBindingError(
-            "claim inventory exact_span must occur exactly once in the source chunk",
+            "claim inventory source offset must be nonnegative"
         )
-    if item.relation_cue_span not in item.exact_span:
-        raise ClaimInventoryBindingError(
-            "claim inventory relation_cue_span is outside exact_span",
-        )
+    trigger_mention = _bind_inventory_trigger(item=item, source_start=source_start)
+    bound_arguments: list[BoundClaimArgument] = []
     for argument in item.arguments:
-        if argument.exact_span not in item.exact_span:
-            raise ClaimInventoryBindingError(
-                "claim inventory argument span is outside exact_span",
-            )
-        if item.exact_span.count(argument.exact_span) != 1:
-            raise ClaimInventoryBindingError(
-                "claim inventory argument span must occur exactly once in exact_span",
-            )
+        mentions = _bind_inventory_argument_mentions(
+            item=item,
+            argument=argument,
+            source_start=source_start,
+        )
         if argument.role is ClaimArgumentRole.VARIANT:
-            argument_end = item.exact_span.index(argument.exact_span) + len(
-                argument.exact_span,
-            )
-            following_text = item.exact_span[argument_end:].casefold()
-            if following_text.startswith(_ATTACHED_VARIANT_STATE_SUFFIXES):
-                raise ClaimInventoryBindingError(
-                    "variant argument omits an attached material state suffix",
-                )
+            for mention in mentions:
+                relative_end = mention.source_end - source_start
+                following_text = item.exact_span[relative_end:].casefold()
+                if following_text.startswith(_ATTACHED_VARIANT_STATE_SUFFIXES):
+                    raise ClaimInventoryBindingError(
+                        "variant argument omits an attached material state suffix",
+                    )
+        bound_arguments.append(
+            BoundClaimArgument(
+                argument=_semantic_argument(argument),
+                primary_mention=_primary_canonical_mention(
+                    argument=argument,
+                    mentions=mentions,
+                ),
+                mentions=mentions,
+            ),
+        )
+    return BoundClaimInventoryItem(
+        inventory_id=claim_inventory_identity(
+            item=item,
+            source_sha256=source_sha256,
+            source_start=source_start,
+        ),
+        item=item,
+        source_sha256=source_sha256,
+        chunk_index=chunk_index,
+        source_start=source_start,
+        source_end=source_start + len(item.exact_span),
+        trigger_mention=trigger_mention,
+        bound_arguments=tuple(bound_arguments),
+    )
+
+
+def _require_binding_metadata(*, source_sha256: str, chunk_index: int) -> None:
+    if len(source_sha256) != _SHA256_HEX_LENGTH or any(
+        character not in "0123456789abcdef" for character in source_sha256
+    ):
+        raise ClaimInventoryBindingError("claim inventory source hash must be SHA-256")
+    if chunk_index < 0:
+        raise ClaimInventoryBindingError(
+            "claim inventory chunk index must be nonnegative"
+        )
+
+
+def _bind_inventory_argument_mentions(
+    *,
+    item: ClaimInventoryItem,
+    argument: ClaimInventoryArgument,
+    source_start: int,
+) -> tuple[BoundClaimMention, ...]:
+    try:
+        return bind_source_mentions(
+            canonical_span=argument.exact_span,
+            source_span=item.exact_span,
+            anchors=argument.mention_anchors,
+            source_start_offset=source_start,
+        )
+    except MentionBindingError as exc:
+        raise ClaimInventoryBindingError(
+            f"claim inventory argument mention binding failed: {exc}",
+        ) from exc
+
+
+def _bind_inventory_trigger(
+    *,
+    item: ClaimInventoryItem,
+    source_start: int,
+) -> BoundClaimMention:
+    anchors = () if item.relation_cue_anchor is None else (item.relation_cue_anchor,)
+    try:
+        mentions = bind_source_mentions(
+            canonical_span=item.relation_cue_span,
+            source_span=item.exact_span,
+            anchors=anchors,
+            source_start_offset=source_start,
+        )
+    except MentionBindingError as exc:
+        raise ClaimInventoryBindingError(
+            f"claim inventory trigger mention binding failed: {exc}",
+        ) from exc
+    return mentions[0]
+
+
+def _semantic_argument(argument: ClaimInventoryArgument) -> ClaimArgument:
+    return ClaimArgument(
+        role=argument.role,
+        event_role=argument.event_role,
+        exact_span=argument.exact_span,
+        role_rationale=argument.role_rationale,
+    )
+
+
+def _primary_canonical_mention(
+    *,
+    argument: ClaimInventoryArgument,
+    mentions: tuple[BoundClaimMention, ...],
+) -> BoundClaimMention:
+    return next(
+        mention for mention in mentions if mention.exact_span == argument.exact_span
+    )
 
 
 def _canonical_sha256(value: object) -> str:
@@ -288,14 +428,34 @@ def claim_inventory_input_sha256(
     )
 
 
+def claim_inventory_batch_input_sha256(
+    inventory: tuple[BoundClaimInventoryItem, ...],
+) -> str:
+    """Hash ordered semantic identities and complete provider-authored inputs."""
+
+    return _canonical_sha256(
+        [
+            {
+                "inventory_id": claim.inventory_id,
+                "item": claim.item.model_dump(mode="json"),
+            }
+            for claim in inventory
+        ],
+    )
+
+
 __all__ = [
     "CLAIM_INVENTORY_SOURCE_LOCATOR",
+    "BoundClaimArgument",
     "BoundClaimInventoryItem",
     "ClaimInventoryBindingError",
+    "ClaimInventoryArgument",
     "ClaimInventoryItem",
     "ClaimFramingAbstentionReason",
     "ClaimFramingDecision",
     "bind_claim_inventory",
+    "bind_claim_inventory_item_at_source",
+    "claim_inventory_batch_input_sha256",
     "claim_inventory_identity",
     "claim_inventory_input_sha256",
     "merge_bound_claim_inventories",

--- a/services/artana_evidence_api/document_extraction_support/claim_frames/mentions.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_frames/mentions.py
@@ -1,0 +1,143 @@
+"""Deterministic source localization for agent-authored mention anchors."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ClaimMentionAnchor(BaseModel):
+    """Verbatim neighboring text that identifies one source mention."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    mention_span: str = Field(..., min_length=1, max_length=1000)
+    left_context: str = Field(default="", max_length=500)
+    right_context: str = Field(default="", max_length=500)
+
+    @model_validator(mode="after")
+    def require_context(self) -> ClaimMentionAnchor:
+        if not self.left_context and not self.right_context:
+            raise ValueError("mention anchor requires left or right verbatim context")
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class BoundClaimMention:
+    """One mention localized by deterministic code."""
+
+    exact_span: str
+    source_start: int
+    source_end: int
+
+
+class MentionBindingError(ValueError):
+    """Raised when verbatim context does not identify a unique mention."""
+
+
+class MentionAnchorContract(Protocol):
+    mention_span: str
+    left_context: str
+    right_context: str
+
+
+def bind_source_mentions(
+    *,
+    canonical_span: str,
+    source_span: str,
+    anchors: Sequence[MentionAnchorContract] = (),
+    source_start_offset: int = 0,
+) -> tuple[BoundClaimMention, ...]:
+    """Resolve one semantic participant to one or more verbatim mentions."""
+
+    if not anchors:
+        occurrences = _occurrence_starts(source_span, canonical_span)
+        if not occurrences:
+            raise MentionBindingError("mention exact_span is outside the source span")
+        if len(occurrences) != 1:
+            raise MentionBindingError(
+                "repeated mention exact_span requires a verbatim context anchor",
+            )
+        return (_bound_mention(canonical_span, occurrences[0], source_start_offset),)
+
+    if not any(anchor.mention_span == canonical_span for anchor in anchors):
+        raise MentionBindingError(
+            "mention anchors must include the semantic argument's canonical span",
+        )
+
+    selected: list[tuple[str, int]] = []
+    for anchor in anchors:
+        occurrences = _occurrence_starts(source_span, anchor.mention_span)
+        matches = tuple(
+            start
+            for start in occurrences
+            if _anchor_matches(
+                source_span=source_span,
+                exact_span=anchor.mention_span,
+                start=start,
+                anchor=anchor,
+            )
+        )
+        if len(matches) != 1:
+            raise MentionBindingError(
+                "verbatim mention context must identify exactly one occurrence",
+            )
+        mention_identity = (anchor.mention_span, matches[0])
+        if mention_identity in selected:
+            raise MentionBindingError(
+                "multiple mention anchors resolve to the same source occurrence",
+            )
+        selected.append(mention_identity)
+    return tuple(
+        _bound_mention(mention_span, start, source_start_offset)
+        for mention_span, start in sorted(selected, key=lambda item: item[1])
+    )
+
+
+def _occurrence_starts(source_span: str, exact_span: str) -> tuple[int, ...]:
+    starts: list[int] = []
+    search_from = 0
+    while True:
+        start = source_span.find(exact_span, search_from)
+        if start < 0:
+            return tuple(starts)
+        starts.append(start)
+        search_from = start + 1
+
+
+def _anchor_matches(
+    *,
+    source_span: str,
+    exact_span: str,
+    start: int,
+    anchor: MentionAnchorContract,
+) -> bool:
+    left_start = start - len(anchor.left_context)
+    if left_start < 0 or source_span[left_start:start] != anchor.left_context:
+        return False
+    end = start + len(exact_span)
+    return source_span[end : end + len(anchor.right_context)] == anchor.right_context
+
+
+def _bound_mention(
+    exact_span: str,
+    relative_start: int,
+    source_start_offset: int,
+) -> BoundClaimMention:
+    absolute_start = source_start_offset + relative_start
+    return BoundClaimMention(
+        exact_span=exact_span,
+        source_start=absolute_start,
+        source_end=absolute_start + len(exact_span),
+    )
+
+
+__all__ = [
+    "BoundClaimMention",
+    "ClaimMentionAnchor",
+    "MentionBindingError",
+    "bind_source_mentions",
+]

--- a/services/artana_evidence_api/document_extraction_support/llm_extraction/claim_framing.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_extraction/claim_framing.py
@@ -260,7 +260,11 @@ async def _run_claim_framing_step(
                     "framed relation failed qualified claim source validation",
                 )
             frame = candidate.claim_frame.model_copy(
-                update={"assertion_arguments": inventory_claim.item.arguments},
+                update={
+                    "assertion_arguments": tuple(
+                        bound.argument for bound in inventory_claim.bound_arguments
+                    ),
+                },
             )
             try:
                 frame = normalize_claim_frame(

--- a/services/artana_evidence_api/document_extraction_support/llm_extraction/claim_inventory.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_extraction/claim_inventory.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 from dataclasses import dataclass
 from typing import Protocol, cast
@@ -21,6 +20,7 @@ from artana_evidence_api.document_extraction_support.claim_frames import (
     MissingClaimRecoveryResult,
     bind_claim_inventory,
     bind_inventory_completeness_review,
+    claim_inventory_batch_input_sha256,
     require_recovery_matches_review,
 )
 from artana_evidence_api.document_extraction_support.full_text_chunking import (
@@ -287,7 +287,6 @@ async def run_inventory_completeness_review_stage(
         execution_namespace=execution_namespace,
     )
     audit_context = _inventory_review_audit_context(
-        chunk=chunk,
         document_fingerprint=document_fingerprint,
         current_inventory=current_inventory,
         schema_retry=False,
@@ -304,7 +303,6 @@ async def run_inventory_completeness_review_stage(
         execution_namespace=execution_namespace,
     )
     retry_context = _inventory_review_audit_context(
-        chunk=chunk,
         document_fingerprint=document_fingerprint,
         current_inventory=current_inventory,
         schema_retry=True,
@@ -409,7 +407,7 @@ async def run_missing_claim_recovery_stage(
         MISSING_CLAIM_RECOVERY_PROMPT_VERSION,
         model_id,
         document_fingerprint,
-        missing_claim.inventory_id,
+        claim_inventory_batch_input_sha256((missing_claim,)),
         execution_namespace,
     )
     audit_context = ModelAttemptAuditContext(
@@ -417,7 +415,7 @@ async def run_missing_claim_recovery_stage(
         pass_role="claim_inventory_recovery",
         retry_context=None,
         source_sha256=document_fingerprint,
-        input_sha256=_inventory_ids_sha256((missing_claim,)),
+        input_sha256=claim_inventory_batch_input_sha256((missing_claim,)),
         semantic_unit_id=missing_claim.inventory_id,
     )
 
@@ -653,14 +651,13 @@ def _inventory_review_step_key(
         phase,
         model_id,
         chunk.sha256,
-        _inventory_ids_sha256(current_inventory),
+        claim_inventory_batch_input_sha256(current_inventory),
         execution_namespace,
     )
 
 
 def _inventory_review_audit_context(
     *,
-    chunk: RelationExtractionTextChunk,
     document_fingerprint: str,
     current_inventory: tuple[BoundClaimInventoryItem, ...],
     schema_retry: bool,
@@ -672,20 +669,9 @@ def _inventory_review_audit_context(
         pass_role="claim_inventory_completeness",
         retry_context=None,
         source_sha256=document_fingerprint,
-        input_sha256=_inventory_ids_sha256(current_inventory) or chunk.sha256,
+        input_sha256=claim_inventory_batch_input_sha256(current_inventory),
         semantic_unit_id=None,
     )
-
-
-def _inventory_ids_sha256(
-    inventory: tuple[BoundClaimInventoryItem, ...],
-) -> str:
-    payload = json.dumps(
-        [claim.inventory_id for claim in inventory],
-        separators=(",", ":"),
-        ensure_ascii=True,
-    ).encode("utf-8")
-    return hashlib.sha256(payload).hexdigest()
 
 
 def _inventory_audit_context(

--- a/services/artana_evidence_api/document_extraction_support/llm_extraction/prompt_versions.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_extraction/prompt_versions.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import Final
 
-CLAIM_INVENTORY_PROMPT_VERSION: Final = "document_extraction.claim_inventory.v6"
+CLAIM_INVENTORY_PROMPT_VERSION: Final = "document_extraction.claim_inventory.v7"
 CLAIM_INVENTORY_COMPLETENESS_PROMPT_VERSION: Final = (
-    "document_extraction.claim_inventory_completeness.v5"
+    "document_extraction.claim_inventory_completeness.v6"
 )
 MISSING_CLAIM_RECOVERY_PROMPT_VERSION: Final = (
-    "document_extraction.claim_inventory_recovery.v5"
+    "document_extraction.claim_inventory_recovery.v6"
 )
 CLAIM_FRAMING_PROMPT_VERSION: Final = "document_extraction.claim_framing.v6"
 
@@ -20,7 +20,7 @@ CLAIM_FRAME_PIPELINE_COMPONENT_PROMPT_VERSIONS: Final = (
     CLAIM_FRAMING_PROMPT_VERSION,
 )
 CLAIM_FRAME_PIPELINE_PROMPT_VERSION: Final = (
-    "document_extraction.claim_pipeline.v8:"
+    "document_extraction.claim_pipeline.v9:"
     + "+".join(
         version.removeprefix("document_extraction.")
         for version in CLAIM_FRAME_PIPELINE_COMPONENT_PROMPT_VERSIONS

--- a/services/artana_evidence_api/runtime/agent_output_manifest.py
+++ b/services/artana_evidence_api/runtime/agent_output_manifest.py
@@ -475,11 +475,11 @@ _POLICIES = (
     AgentOutputSchemaPolicy(
         schema_id="document_extraction.claim_inventory.v3",
         schema_names=("LLMClaimInventoryResult",),
-        shape_hash="a4d084f26d113cc7a0f4ebf6584b72a431c7e16f0c7fc5265fb28deeac31ff17",
+        shape_hash="5971e1fec819faa32812a0ba5dce46138031eb05df1e55e9c137ef7723b45cda",
         producer_paths=(
             "document_extraction_support/llm_extraction/claim_inventory.py",
         ),
-        prompt_identifiers=("document_extraction.claim_inventory.v6",),
+        prompt_identifiers=("document_extraction.claim_inventory.v7",),
         categorical_fields=(
             _category(
                 "$.claims[].source_locator",
@@ -532,11 +532,11 @@ _POLICIES = (
     AgentOutputSchemaPolicy(
         schema_id="document_extraction.claim_inventory_completeness.v3",
         schema_names=("ClaimInventoryCompletenessReview",),
-        shape_hash="541c7f78ed01e31d66baaf94a5ab2d4bd67c7efda7e6f46546bd9a21fefa8314",
+        shape_hash="c16184f40c2854ff40dfe85c43024e73d9d93e2599de79e9f60fdcfe741e7c23",
         producer_paths=(
             "document_extraction_support/llm_extraction/claim_inventory.py",
         ),
-        prompt_identifiers=("document_extraction.claim_inventory_completeness.v5",),
+        prompt_identifiers=("document_extraction.claim_inventory_completeness.v6",),
         categorical_fields=(
             _category(
                 "$.decision",
@@ -587,11 +587,11 @@ _POLICIES = (
     AgentOutputSchemaPolicy(
         schema_id="document_extraction.claim_inventory_recovery.v3",
         schema_names=("MissingClaimRecoveryResult",),
-        shape_hash="59e9df9996c60ae0b9040287bd85ca94cf0b719fb0e8b616a0906c0e856a3b0f",
+        shape_hash="ffdc56f2350b801840891aa82eef0f4d51abaee21a6900f8b4ba0d83dc932601",
         producer_paths=(
             "document_extraction_support/llm_extraction/claim_inventory.py",
         ),
-        prompt_identifiers=("document_extraction.claim_inventory_recovery.v5",),
+        prompt_identifiers=("document_extraction.claim_inventory_recovery.v6",),
         categorical_fields=(
             _category(
                 "$.claims[].source_locator",

--- a/services/artana_evidence_api/tests/unit/test_claim_inventory_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_claim_inventory_extraction.py
@@ -108,6 +108,14 @@ def test_claim_frame_pipeline_prompt_version_tracks_every_agent_stage() -> None:
     )
 
 
+def test_inventory_prompt_requires_verbatim_context_not_numeric_offsets() -> None:
+    normalized_prompt = CLAIM_INVENTORY_SYSTEM_PROMPT.casefold()
+
+    assert "mention_anchors" in normalized_prompt
+    assert "relation_cue_anchor" in normalized_prompt
+    assert "never return offsets or numeric positions" in normalized_prompt
+
+
 def test_single_claim_prompt_does_not_inherit_multi_relation_ranking() -> None:
     normalized_prompt = SINGLE_CLAIM_FRAMING_SYSTEM_PROMPT.casefold()
 
@@ -118,8 +126,8 @@ def test_single_claim_prompt_does_not_inherit_multi_relation_ranking() -> None:
     assert "up to 10" not in normalized_prompt
     assert "strongest, most specific relationships" not in normalized_prompt
     assert CLAIM_FRAME_PIPELINE_PROMPT_VERSION == (
-        "document_extraction.claim_pipeline.v8:claim_inventory.v6+"
-        "claim_inventory_completeness.v5+claim_inventory_recovery.v5+"
+        "document_extraction.claim_pipeline.v9:claim_inventory.v7+"
+        "claim_inventory_completeness.v6+claim_inventory_recovery.v6+"
         "claim_framing.v6"
     )
 
@@ -1006,8 +1014,10 @@ async def test_alk_assertion_preserves_all_roles_and_multiple_valid_frames(
     assert result.inventory_claim_count == 1
     assert result.raw_relation_count == 2
     assert result.claim_lineage[0].framing_decision == "MULTIPLE_VALID_FRAMES"
-    assert result.claim_lineage[0].inventory_payload["arguments"] == (
-        inventory_claim["arguments"]
+    expected_inventory = ClaimInventoryItem.model_validate(inventory_claim)
+    assert (
+        result.claim_lineage[0].inventory_payload["arguments"]
+        == (expected_inventory.model_dump(mode="json")["arguments"])
     )
     assert [candidate.object_label for candidate in result.candidates] == [
         "ALK G1202R-positive lung adenocarcinoma",
@@ -1716,8 +1726,7 @@ async def test_sibling_clause_qualifier_cannot_leak_into_selected_claim() -> Non
     assert "children" not in str(framing_records[0]["prompt"])
 
 
-@pytest.mark.asyncio
-async def test_inventory_dedupes_changed_rationale_and_argument_order() -> None:
+def test_inventory_rejects_duplicate_semantic_claims() -> None:
     text = "MED13 causes cardiomyopathy."
     first = _inventory_claim(
         exact_span=text,
@@ -1730,33 +1739,16 @@ async def test_inventory_dedupes_changed_rationale_and_argument_order() -> None:
         "arguments": list(reversed(first["arguments"])),
         "inventory_rationale": "Different wording for the same explicit claim.",
     }
-    runner = ScriptedStepRunner(
-        (
-            {"claims": [first, reversed_claim]},
-            _complete_inventory(),
-            _framed_relation(
-                sentence=text,
-                subject="MED13",
-                relation_type="CAUSES",
-                object_="cardiomyopathy",
+    with pytest.raises(ClaimInventoryBindingError, match="cannot repeat"):
+        bind_claim_inventory(
+            tuple(
+                ClaimInventoryItem.model_validate(claim)
+                for claim in (first, reversed_claim)
             ),
-        ),
-    )
-
-    result = await _run_pipeline(text=text, runner=runner)
-
-    assert result.inventory_claim_count == 1
-    assert len(result.claim_lineage) == 1
-    assert (
-        len(
-            [
-                call
-                for call in runner.calls
-                if call["schema_id"] == "document_extraction.claim_framing.v2"
-            ],
+            source_text=text,
+            source_sha256=hashlib.sha256(text.encode()).hexdigest(),
+            chunk_index=0,
         )
-        == 1
-    )
 
 
 @pytest.mark.asyncio

--- a/services/artana_evidence_api/tests/unit/test_claim_mention_binding.py
+++ b/services/artana_evidence_api/tests/unit/test_claim_mention_binding.py
@@ -1,0 +1,442 @@
+"""Regression tests for deterministic source-mention localization."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from artana_evidence_api.document_extraction_support.claim_frames import (
+    ClaimInventoryBindingError,
+    ClaimInventoryItem,
+    ClaimMentionAnchor,
+    bind_claim_inventory,
+    claim_inventory_batch_input_sha256,
+    claim_inventory_identity,
+    claim_inventory_input_sha256,
+    require_recovery_matches_review,
+)
+from pydantic import ValidationError
+
+
+def _inventory_item(
+    *,
+    text: str,
+    cue: str,
+    cue_anchor: dict[str, str] | None = None,
+    first_argument: dict[str, object],
+    second_span: str,
+) -> ClaimInventoryItem:
+    return ClaimInventoryItem.model_validate(
+        {
+            "exact_span": text,
+            "relation_cue_span": cue,
+            "relation_cue_anchor": cue_anchor,
+            "arguments": [
+                first_argument,
+                {
+                    "role": "OTHER_ENTITY",
+                    "event_role": "THEME",
+                    "exact_span": second_span,
+                    "role_rationale": "The source names the second participant.",
+                },
+            ],
+            "source_locator": "normalized_extraction_text",
+            "event_type": "OTHER_EXPLICIT",
+            "polarity": "SUPPORT",
+            "epistemic_status": "ASSERTED",
+            "inventory_rationale": "The source contains one explicit event.",
+        },
+    )
+
+
+def test_mention_anchor_requires_verbatim_context() -> None:
+    with pytest.raises(ValidationError, match="left or right"):
+        ClaimMentionAnchor.model_validate(
+            {"mention_span": "WT1", "left_context": "", "right_context": ""},
+        )
+
+
+def test_repeated_argument_without_anchor_fails_closed() -> None:
+    text = "WT1 in fibroblasts and WT1 in lymphocytes suggests regulation."
+    item = _inventory_item(
+        text=text,
+        cue="suggests",
+        first_argument={
+            "role": "GENE_OR_PROTEIN",
+            "event_role": "THEME",
+            "exact_span": "WT1",
+            "role_rationale": "WT1 is the repeated semantic participant.",
+        },
+        second_span="regulation",
+    )
+
+    with pytest.raises(ClaimInventoryBindingError, match="requires.*context anchor"):
+        bind_claim_inventory(
+            (item,),
+            source_text=text,
+            source_sha256=hashlib.sha256(text.encode()).hexdigest(),
+            chunk_index=0,
+        )
+
+
+def test_one_argument_preserves_multiple_context_anchored_mentions() -> None:
+    text = "WT1 in fibroblasts and WT1 in lymphocytes suggests regulation."
+    item = _inventory_item(
+        text=text,
+        cue="suggests",
+        first_argument={
+            "role": "GENE_OR_PROTEIN",
+            "event_role": "THEME",
+            "exact_span": "WT1",
+            "mention_anchors": [
+                {
+                    "mention_span": "WT1",
+                    "left_context": "",
+                    "right_context": " in fibroblasts",
+                },
+                {
+                    "mention_span": "WT1",
+                    "left_context": " and ",
+                    "right_context": " in lymphocytes",
+                },
+            ],
+            "role_rationale": "Both mentions denote the same participant.",
+        },
+        second_span="regulation",
+    )
+
+    bound = bind_claim_inventory(
+        (item,),
+        source_text=text,
+        source_sha256=hashlib.sha256(text.encode()).hexdigest(),
+        chunk_index=0,
+        source_start_offset=100,
+    )[0]
+    mentions = bound.bound_arguments[0].mentions
+
+    assert [mention.source_start for mention in mentions] == [
+        100 + text.index("WT1"),
+        100 + text.rindex("WT1"),
+    ]
+    assert all(mention.exact_span == "WT1" for mention in mentions)
+
+
+def test_context_anchor_must_select_exactly_one_occurrence() -> None:
+    text = "WT1 in fibroblasts and WT1 in lymphocytes suggests regulation."
+    item = _inventory_item(
+        text=text,
+        cue="suggests",
+        first_argument={
+            "role": "GENE_OR_PROTEIN",
+            "event_role": "THEME",
+            "exact_span": "WT1",
+            "mention_anchors": [
+                {
+                    "mention_span": "WT1",
+                    "left_context": "",
+                    "right_context": " in",
+                },
+            ],
+            "role_rationale": "The anchor is intentionally ambiguous.",
+        },
+        second_span="regulation",
+    )
+
+    with pytest.raises(ClaimInventoryBindingError, match="exactly one occurrence"):
+        bind_claim_inventory(
+            (item,),
+            source_text=text,
+            source_sha256=hashlib.sha256(text.encode()).hexdigest(),
+            chunk_index=0,
+        )
+
+
+def test_repeated_trigger_uses_verbatim_context_instead_of_agent_offset() -> None:
+    text = "AKT1 activates B cells and activates T cells."
+    item = _inventory_item(
+        text=text,
+        cue="activates",
+        cue_anchor={
+            "mention_span": "activates",
+            "left_context": " and ",
+            "right_context": " T cells",
+        },
+        first_argument={
+            "role": "GENE_OR_PROTEIN",
+            "event_role": "AGENT",
+            "exact_span": "AKT1",
+            "role_rationale": "AKT1 is the event agent.",
+        },
+        second_span="T cells",
+    )
+
+    bound = bind_claim_inventory(
+        (item,),
+        source_text=text,
+        source_sha256=hashlib.sha256(text.encode()).hexdigest(),
+        chunk_index=0,
+        source_start_offset=500,
+    )[0]
+
+    assert bound.trigger_mention.source_start == 500 + text.rindex("activates")
+
+
+def test_alias_and_coreference_mentions_preserve_canonical_argument() -> None:
+    text = "WT1 was measured. The gene increased, and it remained elevated."
+    item = _inventory_item(
+        text=text,
+        cue="increased",
+        first_argument={
+            "role": "GENE_OR_PROTEIN",
+            "event_role": "THEME",
+            "exact_span": "WT1",
+            "mention_anchors": [
+                {
+                    "mention_span": "WT1",
+                    "left_context": "",
+                    "right_context": " was measured",
+                },
+                {
+                    "mention_span": "The gene",
+                    "left_context": "WT1 was measured. ",
+                    "right_context": " increased",
+                },
+                {
+                    "mention_span": "it",
+                    "left_context": "increased, and ",
+                    "right_context": " remained elevated",
+                },
+            ],
+            "role_rationale": "The aliases refer to WT1 in this local claim.",
+        },
+        second_span="elevated",
+    )
+
+    bound = bind_claim_inventory(
+        (item,),
+        source_text=text,
+        source_sha256=hashlib.sha256(text.encode()).hexdigest(),
+        chunk_index=0,
+    )[0]
+
+    assert bound.bound_arguments[0].argument.exact_span == "WT1"
+    assert [mention.exact_span for mention in bound.bound_arguments[0].mentions] == [
+        "WT1",
+        "The gene",
+        "it",
+    ]
+    assert "mention_anchors" not in bound.bound_arguments[0].argument.model_dump()
+
+
+def test_legacy_source_start_uses_canonical_mention_when_alias_appears_first() -> None:
+    text = "It remained elevated after WT1 increased regulation."
+    item = _inventory_item(
+        text=text,
+        cue="increased",
+        first_argument={
+            "role": "GENE_OR_PROTEIN",
+            "event_role": "AGENT",
+            "exact_span": "WT1",
+            "mention_anchors": [
+                {
+                    "mention_span": "It",
+                    "left_context": "",
+                    "right_context": " remained elevated",
+                },
+                {
+                    "mention_span": "WT1",
+                    "left_context": "remained elevated after ",
+                    "right_context": " increased",
+                },
+            ],
+            "role_rationale": "The local pronoun and WT1 name the same participant.",
+        },
+        second_span="regulation",
+    )
+
+    bound_argument = bind_claim_inventory(
+        (item,),
+        source_text=text,
+        source_sha256=hashlib.sha256(text.encode()).hexdigest(),
+        chunk_index=0,
+    )[0].bound_arguments[0]
+
+    assert bound_argument.mentions[0].exact_span == "It"
+    assert bound_argument.primary_mention.exact_span == "WT1"
+    assert bound_argument.primary_mention.source_start == text.index("WT1")
+
+
+def test_inventory_identity_excludes_localization_but_input_hash_includes_it() -> None:
+    text = "WT1 in fibroblasts and WT1 in lymphocytes suggests regulation."
+    common = {
+        "role": "GENE_OR_PROTEIN",
+        "event_role": "THEME",
+        "exact_span": "WT1",
+        "role_rationale": "WT1 is the participant.",
+    }
+    first = _inventory_item(
+        text=text,
+        cue="suggests",
+        first_argument={
+            **common,
+            "mention_anchors": [
+                {
+                    "mention_span": "WT1",
+                    "left_context": "",
+                    "right_context": " in fibroblasts",
+                },
+            ],
+        },
+        second_span="regulation",
+    )
+    second = _inventory_item(
+        text=text,
+        cue="suggests",
+        first_argument={
+            **common,
+            "mention_anchors": [
+                {
+                    "mention_span": "WT1",
+                    "left_context": " and ",
+                    "right_context": " in lymphocytes",
+                },
+            ],
+        },
+        second_span="regulation",
+    )
+    source_sha256 = hashlib.sha256(text.encode()).hexdigest()
+    first_id = claim_inventory_identity(
+        item=first,
+        source_sha256=source_sha256,
+        source_start=0,
+    )
+    second_id = claim_inventory_identity(
+        item=second,
+        source_sha256=source_sha256,
+        source_start=0,
+    )
+
+    assert first_id == second_id
+    assert claim_inventory_input_sha256(
+        inventory_id=first_id,
+        item=first,
+    ) != claim_inventory_input_sha256(inventory_id=second_id, item=second)
+    first_bound = bind_claim_inventory(
+        (first,),
+        source_text=text,
+        source_sha256=source_sha256,
+        chunk_index=0,
+    )
+    second_bound = bind_claim_inventory(
+        (second,),
+        source_text=text,
+        source_sha256=source_sha256,
+        chunk_index=0,
+    )
+    assert claim_inventory_batch_input_sha256(
+        first_bound,
+    ) != claim_inventory_batch_input_sha256(second_bound)
+
+
+def test_duplicate_mention_anchors_fail_schema_validation() -> None:
+    anchor = {
+        "mention_span": "WT1",
+        "left_context": "",
+        "right_context": " in fibroblasts",
+    }
+    with pytest.raises(ValidationError, match="mention anchors must be unique"):
+        _inventory_item(
+            text="WT1 in fibroblasts suggests regulation.",
+            cue="suggests",
+            first_argument={
+                "role": "GENE_OR_PROTEIN",
+                "event_role": "THEME",
+                "exact_span": "WT1",
+                "mention_anchors": [anchor, anchor],
+                "role_rationale": "WT1 is the participant.",
+            },
+            second_span="regulation",
+        )
+
+
+def test_duplicate_semantic_claims_cannot_hide_different_mention_payloads() -> None:
+    text = "WT1 in fibroblasts and WT1 in lymphocytes suggests regulation."
+    source_sha256 = hashlib.sha256(text.encode()).hexdigest()
+    items = tuple(
+        _inventory_item(
+            text=text,
+            cue="suggests",
+            first_argument={
+                "role": "GENE_OR_PROTEIN",
+                "event_role": "THEME",
+                "exact_span": "WT1",
+                "mention_anchors": [anchor],
+                "role_rationale": "WT1 is the semantic participant.",
+            },
+            second_span="regulation",
+        )
+        for anchor in (
+            {
+                "mention_span": "WT1",
+                "left_context": "",
+                "right_context": " in fibroblasts",
+            },
+            {
+                "mention_span": "WT1",
+                "left_context": " and ",
+                "right_context": " in lymphocytes",
+            },
+        )
+    )
+
+    with pytest.raises(ClaimInventoryBindingError, match="cannot repeat"):
+        bind_claim_inventory(
+            items,
+            source_text=text,
+            source_sha256=source_sha256,
+            chunk_index=0,
+        )
+
+
+def test_recovery_must_preserve_reviewed_mention_payload() -> None:
+    text = "WT1 in fibroblasts and WT1 in lymphocytes suggests regulation."
+    source_sha256 = hashlib.sha256(text.encode()).hexdigest()
+    reviewed, recovered = (
+        bind_claim_inventory(
+            (
+                _inventory_item(
+                    text=text,
+                    cue="suggests",
+                    first_argument={
+                        "role": "GENE_OR_PROTEIN",
+                        "event_role": "THEME",
+                        "exact_span": "WT1",
+                        "mention_anchors": [anchor],
+                        "role_rationale": "WT1 is the semantic participant.",
+                    },
+                    second_span="regulation",
+                ),
+            ),
+            source_text=text,
+            source_sha256=source_sha256,
+            chunk_index=0,
+        )[0]
+        for anchor in (
+            {
+                "mention_span": "WT1",
+                "left_context": "",
+                "right_context": " in fibroblasts",
+            },
+            {
+                "mention_span": "WT1",
+                "left_context": " and ",
+                "right_context": " in lymphocytes",
+            },
+        )
+    )
+
+    with pytest.raises(ClaimInventoryBindingError, match="exactly match"):
+        require_recovery_matches_review(
+            recovered_claims=(recovered,),
+            reviewed_missing_claims=(reviewed,),
+        )

--- a/tests/unit/test_nary_claim_evaluation.py
+++ b/tests/unit/test_nary_claim_evaluation.py
@@ -12,6 +12,7 @@ from artana_evidence_api.document_extraction_prompting import (
 from artana_evidence_api.document_extraction_support.claim_frames import (
     ClaimInventoryItem,
     bind_claim_inventory,
+    claim_inventory_batch_input_sha256,
     claim_inventory_identity,
 )
 from artana_evidence_api.document_extraction_support.full_text_chunking import (
@@ -177,12 +178,32 @@ def _prediction(case: _Case, *, correct: bool) -> dict[str, object]:
         "events": [
             {
                 **item.model_dump(mode="json"),
-                "arguments": [asdict(argument) for argument in event.arguments],
+                "arguments": [
+                    {
+                        **asdict(argument),
+                        "mention_anchors": [],
+                        "source_mentions": [
+                            {
+                                "exact_span": argument.exact_span,
+                                "source_start": argument.source_start,
+                                "source_end": (
+                                    argument.source_start + len(argument.exact_span)
+                                ),
+                            },
+                        ],
+                    }
+                    for argument in event.arguments
+                ],
                 "inventory_id": inventory_id,
                 "source_start": 0,
                 "source_end": len(case.source_text),
                 "trigger_span": event.trigger_span,
                 "trigger_source_start": event.trigger_source_start,
+                "trigger_source_mention": {
+                    "exact_span": event.trigger_span,
+                    "source_start": event.trigger_source_start,
+                    "source_end": event.trigger_source_start + len(event.trigger_span),
+                },
             },
         ],
         "abstained": False,
@@ -255,7 +276,7 @@ def _report(
                     {
                         key: value
                         for key, value in argument.items()
-                        if key != "source_start"
+                        if key not in {"source_start", "source_mentions"}
                     }
                     for argument in event["arguments"]
                 ],
@@ -273,13 +294,9 @@ def _report(
             f"{completeness_schema.__module__}.{completeness_schema.__qualname__}"
         )
         completeness_invocation = f"completeness-{slug}-{run_index}-{case.case_id}"
-        completeness_input_sha256 = hashlib.sha256(
-            json.dumps(
-                [bound_claim.inventory_id],
-                separators=(",", ":"),
-                ensure_ascii=True,
-            ).encode(),
-        ).hexdigest()
+        completeness_input_sha256 = claim_inventory_batch_input_sha256(
+            (bound_claim,),
+        )
         completeness_prompt = bind_prompt_to_invocation(
             prompt=build_inventory_completeness_prompt(
                 chunk=chunk,
@@ -463,10 +480,7 @@ def test_absolute_gate_selects_sol_when_only_sol_clears_quality() -> None:
     assert result["selected_model"] == "openai:gpt-5.6-sol"
     assert result["decision"] == "QUALIFY_FOR_HELD_OUT_CONFIRMATION"
     assert result["framing_readiness"] == "NOT_EVALUATED_INVENTORY_ONLY"
-    assert (
-        result["persistence_readiness"]
-        == "BLOCKED_UPSTREAM_FRAMING_NOT_VALIDATED"
-    )
+    assert result["persistence_readiness"] == "BLOCKED_UPSTREAM_FRAMING_NOT_VALIDATED"
 
 
 def test_inventory_schema_digest_binds_dynamic_claim_limit() -> None:
@@ -665,7 +679,11 @@ def test_evaluator_rejects_prediction_substitution_after_provider_execution() ->
         }
         | {
             "arguments": [
-                {key: value for key, value in argument.items() if key != "source_start"}
+                {
+                    key: value
+                    for key, value in argument.items()
+                    if key not in {"source_start", "source_mentions"}
+                }
                 for argument in event["arguments"]
             ],
         },

--- a/tests/unit/test_nary_claim_runner.py
+++ b/tests/unit/test_nary_claim_runner.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+import hashlib
 
 import pytest
 from artana_evidence_api.document_extraction_support.claim_frames import (
     ClaimInventoryItem,
+    bind_claim_inventory,
 )
 
 from scripts.validation.claim_events.runner import (
@@ -19,14 +20,12 @@ from scripts.validation.claim_frames.provider_receipts import (
 
 
 def test_nary_adapter_preserves_agent_event_semantics() -> None:
-    lineage = (
-        SimpleNamespace(
-            inventory_id="inventory-1",
-            source_start=0,
-            source_end=31,
-            item=ClaimInventoryItem.model_validate(
+    text = "AKT1 phosphorylation in B cells"
+    lineage = bind_claim_inventory(
+        (
+            ClaimInventoryItem.model_validate(
                 {
-                    "exact_span": "AKT1 phosphorylation in B cells",
+                    "exact_span": text,
                     "relation_cue_span": "phosphorylation",
                     "source_locator": "normalized_extraction_text",
                     "event_type": "PHOSPHORYLATION",
@@ -47,20 +46,29 @@ def test_nary_adapter_preserves_agent_event_semantics() -> None:
                             "role_rationale": "cell population context",
                         },
                     ],
-                }
+                },
             ),
         ),
+        source_text=text,
+        source_sha256=hashlib.sha256(text.encode()).hexdigest(),
+        chunk_index=0,
     )
 
     assert _nary_events(lineage) == [
         {
-            "inventory_id": "inventory-1",
+            "inventory_id": lineage[0].inventory_id,
             "source_start": 0,
             "source_end": 31,
             "exact_span": "AKT1 phosphorylation in B cells",
             "trigger_span": "phosphorylation",
             "trigger_source_start": 5,
+            "trigger_source_mention": {
+                "exact_span": "phosphorylation",
+                "source_start": 5,
+                "source_end": 20,
+            },
             "relation_cue_span": "phosphorylation",
+            "relation_cue_anchor": None,
             "source_locator": "normalized_extraction_text",
             "event_type": "PHOSPHORYLATION",
             "polarity": "SUPPORT",
@@ -70,20 +78,151 @@ def test_nary_adapter_preserves_agent_event_semantics() -> None:
                     "role": "GENE_OR_PROTEIN",
                     "event_role": "THEME",
                     "exact_span": "AKT1",
+                    "mention_anchors": [],
                     "role_rationale": "phosphorylated theme",
                     "source_start": 0,
+                    "source_mentions": [
+                        {"exact_span": "AKT1", "source_start": 0, "source_end": 4}
+                    ],
                 },
                 {
                     "role": "POPULATION",
                     "event_role": "CONTEXT",
                     "exact_span": "B cells",
+                    "mention_anchors": [],
                     "role_rationale": "cell population context",
                     "source_start": 24,
+                    "source_mentions": [
+                        {
+                            "exact_span": "B cells",
+                            "source_start": 24,
+                            "source_end": 31,
+                        }
+                    ],
                 },
             ],
             "inventory_rationale": "explicit source event",
         },
     ]
+
+
+def test_nary_adapter_derives_every_repeated_mention_offset() -> None:
+    text = "WT1 in fibroblasts and WT1 in lymphocytes suggests regulation."
+    item = ClaimInventoryItem.model_validate(
+        {
+            "exact_span": text,
+            "relation_cue_span": "suggests",
+            "source_locator": "normalized_extraction_text",
+            "event_type": "REGULATION",
+            "polarity": "SUPPORT",
+            "epistemic_status": "ASSERTED",
+            "inventory_rationale": "The source states one regulation event.",
+            "arguments": [
+                {
+                    "role": "GENE_OR_PROTEIN",
+                    "event_role": "THEME",
+                    "exact_span": "WT1",
+                    "mention_anchors": [
+                        {
+                            "mention_span": "WT1",
+                            "left_context": "",
+                            "right_context": " in fibroblasts",
+                        },
+                        {
+                            "mention_span": "WT1",
+                            "left_context": " and ",
+                            "right_context": " in lymphocytes",
+                        },
+                    ],
+                    "role_rationale": "Both mentions denote the same participant.",
+                },
+                {
+                    "role": "BIOLOGICAL_PROCESS",
+                    "event_role": "THEME",
+                    "exact_span": "regulation",
+                    "role_rationale": "The source names the regulated process.",
+                },
+            ],
+        },
+    )
+    source_start = 200
+
+    event = _nary_events(
+        bind_claim_inventory(
+            (item,),
+            source_text=text,
+            source_sha256=hashlib.sha256(text.encode()).hexdigest(),
+            chunk_index=0,
+            source_start_offset=source_start,
+        ),
+    )[0]
+
+    repeated_argument = event["arguments"][0]
+    assert repeated_argument["source_start"] == source_start + text.index("WT1")
+    assert [
+        mention["source_start"] for mention in repeated_argument["source_mentions"]
+    ] == [
+        source_start + text.index("WT1"),
+        source_start + text.rindex("WT1"),
+    ]
+    assert event["trigger_source_start"] == source_start + text.index("suggests")
+
+
+def test_nary_adapter_keeps_legacy_offset_on_canonical_span() -> None:
+    text = "It remained elevated after WT1 increased regulation."
+    item = ClaimInventoryItem.model_validate(
+        {
+            "exact_span": text,
+            "relation_cue_span": "increased",
+            "source_locator": "normalized_extraction_text",
+            "event_type": "INCREASE",
+            "polarity": "SUPPORT",
+            "epistemic_status": "ASSERTED",
+            "inventory_rationale": "The source states one increase event.",
+            "arguments": [
+                {
+                    "role": "GENE_OR_PROTEIN",
+                    "event_role": "AGENT",
+                    "exact_span": "WT1",
+                    "mention_anchors": [
+                        {
+                            "mention_span": "It",
+                            "left_context": "",
+                            "right_context": " remained elevated",
+                        },
+                        {
+                            "mention_span": "WT1",
+                            "left_context": "remained elevated after ",
+                            "right_context": " increased",
+                        },
+                    ],
+                    "role_rationale": "The pronoun and WT1 identify one participant.",
+                },
+                {
+                    "role": "BIOLOGICAL_PROCESS",
+                    "event_role": "EFFECT",
+                    "exact_span": "regulation",
+                    "role_rationale": "Regulation is the affected process.",
+                },
+            ],
+        },
+    )
+
+    event = _nary_events(
+        bind_claim_inventory(
+            (item,),
+            source_text=text,
+            source_sha256=hashlib.sha256(text.encode()).hexdigest(),
+            chunk_index=0,
+        ),
+    )[0]
+    argument = event["arguments"][0]
+
+    assert argument["source_mentions"][0]["exact_span"] == "It"
+    assert argument["source_start"] == text.index("WT1")
+    assert (
+        text[argument["source_start"] : argument["source_start"] + len("WT1")] == "WT1"
+    )
 
 
 def test_runner_rejects_unregistered_or_substituted_models() -> None:


### PR DESCRIPTION
## Summary\n\n- add inventory-only verbatim mention anchors for repeated, aliased, and coreferential claim participants and repeated relation cues\n- derive every source offset deterministically and preserve all mentions while keeping the legacy offset on the canonical argument span\n- keep mention localization out of shared ClaimArgument, ClaimFrame persistence, semantic claim identity, graph persistence, and scientific scoring\n- fail closed on duplicate semantic claims and bind completeness/recovery custody to full anchor-bearing provider payloads\n- update governed prompt/schema versions, manifest hashes, TG-04 evidence validation, and focused regressions\n\n## Safety boundary\n\nThis PR repairs representability and evidence custody only. It does not change graph persistence, auto-promotion, scientific score calculations, model thresholds, benchmark gates, or the explicit stop before trusted-graph promotion. It does not claim scientific-quality improvement; that must be measured by the next controlled Luna/Sol TG-04 run.\n\n## Validation\n\n- make service-checks passed\n- isolated repository suite passed at 100%\n- coverage: 87.47% (required: 86%)\n- focused mention/inventory/framing/evaluation suite: 149 passed\n- two adversarial review passes completed; all three initial findings fixed and final review reported no blockers\n- commit and push hooks passed without bypass