### PR TITLE
Seal TG-04 stress failures with provider-backed outcomes

### DIFF
--- a/docs/validation/reports/2026-07-16-tg04-v2-operational-sealing.md
+++ b/docs/validation/reports/2026-07-16-tg04-v2-operational-sealing.md
@@ -1,0 +1,77 @@
+# TG-04 v2 Operational Sealing
+
+## Purpose
+
+This change makes the frozen 40-case TG-04 run observable when a
+representability-stress case cannot be source-bound after the production
+inventory schema retry. It does not change scientific scoring, qualification
+thresholds, model selection, graph projection, or persistence readiness.
+
+## Categorical Outcomes
+
+Each case has one deterministically checked outcome:
+
+- `BOUND_OUTPUT`: the complete accepted inventory is nonempty and exactly
+  matches the scored prediction.
+- `NO_OUTPUT`: the complete accepted inventory is empty and exactly matches an
+  abstaining prediction.
+- `UNBINDABLE_OUTPUT`: a representability-stress case ends in one of the
+  allowlisted provider-backed inventory failure prefixes below.
+
+The evaluator derives `BOUND_OUTPUT` and `NO_OUTPUT` from accepted raw
+inventory. It does not trust the report label.
+
+## Sealable Failure Prefixes
+
+Only these one-chunk inventory prefixes can continue as descriptive
+`UNBINDABLE_OUTPUT`:
+
+1. Primary inventory is schema- or semantic-invalid, followed by a failed
+   schema retry of the same kind.
+2. Primary inventory returns an accepted empty list, its schema retry is
+   explicitly skipped, and the zero-candidate retry plus its schema retry are
+   both schema- or semantic-invalid.
+
+Every executed attempt must retain a canonical OpenAI response ID, provider
+output hash, raw payload and payload hash, prompt hash, kernel run ID, source
+hash, input hash, evidence-unit hash, and output-schema identity. The evaluator
+reconstructs canonical production prompts and live-verifies all receipts.
+
+Invocation, authentication, provider-identity, repository-drift, malformed
+custody, completeness-stage, recovery-stage, and unexpected-topology failures
+still abort without a sealed report.
+
+## Qualification Boundary
+
+`UNBINDABLE_OUTPUT` is accepted only for frozen
+`REPRESENTABILITY_STRESS` cases. It is excluded from scientific quality and
+repeatability metrics. An unbindable qualification case is rejected.
+
+The existing qualification invariant remains strict: even a repaired
+qualification output fails the operational gate when it contains a schema- or
+semantic-invalid attempt. Fallback, unidentified provider attempts, incomplete
+case coverage, duplicate case coverage, and unverified receipts also fail the
+gate.
+
+## Validation
+
+- Focused n-ary runner, operational, evaluator, and production inventory tests:
+  passed.
+- Evidence API strict MyPy gate: passed.
+- Validation-module MyPy with service source resolution: passed.
+- `make service-checks`: passed.
+- Independent adversarial design review: qualification-invalid preservation,
+  outcome derivation, provider custody, and canonical-prefix requirements were
+  incorporated before final validation.
+
+## Next Stop/Go Step
+
+After this change is reviewed and merged, run one separately identified Luna
+operational pass over all 40 frozen cases. Continue to the three-Luna plus
+three-Sol scientific matrix only if the operational artifact covers all 40
+cases, has zero qualification invalid/unbindable outcomes, zero fallback,
+zero unidentified provider attempts, and live-verified provider receipts.
+
+Persistence remains blocked regardless of operational success. It can be
+reconsidered only after the unchanged scientific gates qualify a model and the
+held-out confirmation stage succeeds.

--- a/scripts/validation/claim_events/evaluation.py
+++ b/scripts/validation/claim_events/evaluation.py
@@ -8,8 +8,15 @@ import re
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Final, cast
 
-from scripts.validation.claim_events.evidence_binding import bind_case_evidence
+from scripts.validation.claim_events.evidence_binding import (
+    bind_case_evidence,
+    bind_unbindable_case_evidence,
+)
 from scripts.validation.claim_events.fixture import require_frozen_development_fixture
+from scripts.validation.claim_events.operational import (
+    OperationalSafetyEvidence,
+    build_operational_summary,
+)
 from scripts.validation.claim_events.scoring import (
     CountRate,
     FixtureScore,
@@ -50,6 +57,7 @@ _REPORT_KEYS: Final = frozenset(
         "predictions",
         "metrics",
         "case_scores",
+        "operational_summary",
         "safety",
         "provider_receipts",
         "case_evidence",
@@ -112,7 +120,7 @@ def evaluate_matrix(
             raise ValueError(
                 "TG-04 stored provider receipts differ from live verification"
             )
-        _validate_safety(report, expectations)
+        _validate_safety(fixture, report, expectations)
         grouped.setdefault(_required_text(report, "model_id"), []).append(report)
 
     if len(repository_identities) != 1:
@@ -278,7 +286,7 @@ def _validate_report_identity(report: dict[str, object], fixture_sha256: str) ->
     del unsealed["report_sha256"]
     if _sha256_json(unsealed) != report_sha256:
         raise ValueError("TG-04 live report digest mismatch")
-    if report.get("schema_version") != "tg04_live_arm.v1":
+    if report.get("schema_version") != "tg04_live_arm.v2":
         raise ValueError("unknown TG-04 live report schema")
     if report.get("fixture_sha256") != fixture_sha256:
         raise ValueError("TG-04 report fixture hash mismatch")
@@ -310,6 +318,23 @@ def _validate_derived_report_content(
         raise ValueError("TG-04 report metrics differ from deterministic recomputation")
     if report.get("case_scores") != [asdict(case) for case in score.cases]:
         raise ValueError("TG-04 case scores differ from deterministic recomputation")
+    qualification_invalid, stress_invalid = _invalid_attempt_counts(fixture, report)
+    stored_receipts = _object(report.get("provider_receipts"), "provider_receipts")
+    summary = build_operational_summary(
+        cases=fixture.cases,
+        predictions=[_object(item, "prediction") for item in predictions],
+        safety=OperationalSafetyEvidence(
+            fallback_count=0,
+            unidentified_provider_attempt_count=0,
+            qualification_invalid_agent_output_count=qualification_invalid,
+            representability_stress_invalid_agent_output_count=stress_invalid,
+            provider_receipt_gate_passed=_stored_receipt_gate_passed(stored_receipts),
+        ),
+    )
+    if report.get("operational_summary") != summary:
+        raise ValueError("TG-04 operational summary differs from recomputation")
+    if summary["gate_passed"] is not True:
+        raise ValueError("TG-04 qualification run did not complete operationally")
 
 
 def _receipt_expectations(
@@ -339,14 +364,23 @@ def _receipt_expectations(
         prediction = predictions_by_id.get(case_id)
         if case is None or prediction is None:
             raise ValueError("TG-04 audit evidence references an unknown fixture case")
-        case_expectations, case_topology = bind_case_evidence(
-            case=case,
-            prediction=prediction,
-            case_record=case_record,
-            model_id=model_id,
-        )
+        if prediction.get("execution_outcome") == "UNBINDABLE_OUTPUT":
+            case_expectations, case_topology = bind_unbindable_case_evidence(
+                case=case,
+                prediction=prediction,
+                case_record=case_record,
+                model_id=model_id,
+            )
+        else:
+            case_expectations, case_topology = bind_case_evidence(
+                case=case,
+                prediction=prediction,
+                case_record=case_record,
+                model_id=model_id,
+            )
         expectations.extend(case_expectations)
-        topology[case_id] = case_topology
+        if str(case.control_status) != "REPRESENTABILITY_STRESS":
+            topology[case_id] = case_topology
     if set(evidence_case_ids) != expected_case_ids or len(evidence_case_ids) != len(
         expected_case_ids
     ):
@@ -359,12 +393,16 @@ def _receipt_expectations(
 
 
 def _validate_safety(
+    fixture: NaryClaimFixture,
     report: dict[str, object],
     expectations: tuple[ProviderReceiptExpectation, ...],
 ) -> None:
+    qualification_invalid, stress_invalid = _invalid_attempt_counts(fixture, report)
     expected = {
         "fallback_count": 0,
-        "invalid_agent_output_count": 0,
+        "invalid_agent_output_count": qualification_invalid + stress_invalid,
+        "qualification_invalid_agent_output_count": qualification_invalid,
+        "representability_stress_invalid_agent_output_count": stress_invalid,
         "provider_response_id_count": len(expectations),
         "provider_receipt_status": "verified_live",
         "verified_provider_receipt_count": len(expectations),
@@ -372,6 +410,39 @@ def _validate_safety(
     }
     if _object(report.get("safety"), "safety") != expected:
         raise ValueError("TG-04 safety envelope differs from audited attempts")
+
+
+def _invalid_attempt_counts(
+    fixture: NaryClaimFixture,
+    report: dict[str, object],
+) -> tuple[int, int]:
+    control_by_case = {case.case_id: str(case.control_status) for case in fixture.cases}
+    qualification_invalid = stress_invalid = 0
+    for raw_case in _list(report.get("case_evidence"), "case_evidence"):
+        case_record = _object(raw_case, "case evidence")
+        case_id = _required_text(case_record, "case_id")
+        invalid = sum(
+            _object(raw_attempt, "attempt").get("validation_outcome")
+            in {"schema_invalid", "semantic_invalid"}
+            for raw_attempt in _list(case_record.get("attempts"), "attempts")
+        )
+        if control_by_case.get(case_id) == "REPRESENTABILITY_STRESS":
+            stress_invalid += invalid
+        else:
+            qualification_invalid += invalid
+    return qualification_invalid, stress_invalid
+
+
+def _stored_receipt_gate_passed(receipts: dict[str, object]) -> bool:
+    expected = receipts.get("expected_count")
+    verified = receipts.get("verified_count")
+    return (
+        receipts.get("status") == "verified_live"
+        and isinstance(expected, int)
+        and not isinstance(expected, bool)
+        and expected > 0
+        and verified == expected
+    )
 
 
 def _three_model_runs(

--- a/scripts/validation/claim_events/evidence_binding.py
+++ b/scripts/validation/claim_events/evidence_binding.py
@@ -15,6 +15,7 @@ from artana_evidence_api.document_extraction_prompting import (
 )
 from artana_evidence_api.document_extraction_support.claim_frames import (
     BoundClaimInventoryItem,
+    ClaimInventoryBindingError,
     ClaimInventoryCompletenessReview,
     ClaimInventoryItem,
     bind_claim_inventory,
@@ -37,7 +38,11 @@ from artana_evidence_api.document_extraction_support.llm_extraction.invocation_b
 from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
     llm_extraction_document_fingerprint,
 )
+from pydantic import ValidationError
 
+from scripts.validation.claim_events.operational import (
+    require_sealable_unbindable_attempts,
+)
 from scripts.validation.claim_events.runner import receipt_expectation_from_attempt
 
 if TYPE_CHECKING:
@@ -54,6 +59,9 @@ class EvidenceCaseContract(Protocol):
 
     @property
     def source_text(self) -> str: ...
+
+    @property
+    def control_status(self) -> object: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,6 +99,16 @@ class _InventoryWorkflowInput:
 class _PredictionValidationContext:
     normalized_source: str
     source_sha256: str
+
+
+@dataclass(frozen=True, slots=True)
+class _UnbindableAttemptContext:
+    case_id: str
+    model_id: str
+    source_sha256: str
+    evidence_unit_sha256: str
+    chunks_by_sha: Mapping[str, RelationExtractionTextChunk]
+    prompt_context: _PromptContext
 
 
 def bind_case_evidence(
@@ -151,7 +169,200 @@ def bind_case_evidence(
         raise ValueError(
             "TG-04 scored predictions differ from accepted inventory claims"
         )
+    derived_outcome = "BOUND_OUTPUT" if accepted_inventory else "NO_OUTPUT"
+    if prediction.get("execution_outcome") != derived_outcome:
+        raise ValueError("TG-04 execution outcome differs from accepted inventory")
     return tuple(collected.expectations), topology
+
+
+def bind_unbindable_case_evidence(
+    *,
+    case: EvidenceCaseContract,
+    prediction: Mapping[str, object],
+    case_record: Mapping[str, object],
+    model_id: str,
+) -> tuple[tuple[ProviderReceiptExpectation, ...], str]:
+    """Bind a descriptive stress failure to raw provider-backed attempts."""
+
+    if str(case.control_status) != "REPRESENTABILITY_STRESS":
+        raise ValueError("TG-04 qualification cases cannot be unbindable")
+    if prediction.get("execution_outcome") != "UNBINDABLE_OUTPUT":
+        raise ValueError("TG-04 unbindable evidence has the wrong outcome")
+    if _sequence(prediction.get("events"), "prediction events"):
+        raise ValueError("TG-04 unbindable output cannot contain scored events")
+    if prediction.get("abstained") is not True:
+        raise ValueError("TG-04 unbindable output must abstain")
+    if _text(case_record.get("case_id"), "case evidence case_id") != case.case_id:
+        raise ValueError("TG-04 case evidence is bound to the wrong fixture case")
+    diagnostics = _object(case_record.get("diagnostics"), "diagnostics")
+    if diagnostics.get("fallback_output_used") is True:
+        raise ValueError("TG-04 case used fallback output")
+    if diagnostics.get("claim_extraction_routing_status") != "unbound":
+        raise ValueError("TG-04 unbindable evidence must be routed as unbound")
+
+    normalized_source = normalize_text_document(case.source_text)
+    source_sha256 = llm_extraction_document_fingerprint(normalized_source)
+    evidence_unit_sha256 = _sha256_text(case.case_id)
+    chunks = coalesce_long_sentence_chunks(
+        normalized_text=normalized_source,
+        chunks=build_relation_extraction_text_chunks(normalized_source),
+    )
+    chunks_by_sha = {chunk.sha256: chunk for chunk in chunks}
+    schema = build_claim_inventory_output_schema(_MAX_INVENTORY_CLAIMS_PER_CHUNK)
+    context = _PromptContext(
+        total_chunks=len(chunks),
+        source_sha256=source_sha256,
+        evidence_unit_sha256=evidence_unit_sha256,
+        output_schema_identity=f"{schema.__module__}.{schema.__qualname__}",
+        output_schema_sha256=output_schema_json_sha256(schema),
+        completeness_schema_identity="unused",
+        completeness_schema_sha256="unused",
+    )
+    attempts = tuple(
+        _object(item, "attempt")
+        for item in _sequence(case_record.get("attempts"), "attempts")
+    )
+    if not attempts:
+        raise ValueError("TG-04 unbindable output lacks audited attempts")
+    require_sealable_unbindable_attempts(attempts)
+    terminal_error = _text(
+        diagnostics.get("terminal_error_category"),
+        "terminal_error_category",
+    )
+    if attempts[-1].get("error_type") != terminal_error:
+        raise ValueError("TG-04 terminal error category differs from audited attempt")
+    expectations, signatures, invalid_count = _collect_unbindable_attempts(
+        attempts=attempts,
+        context=_UnbindableAttemptContext(
+            case_id=case.case_id,
+            model_id=model_id,
+            source_sha256=source_sha256,
+            evidence_unit_sha256=evidence_unit_sha256,
+            chunks_by_sha=chunks_by_sha,
+            prompt_context=context,
+        ),
+    )
+    if invalid_count == 0:
+        raise ValueError("TG-04 unbindable output lacks a terminal invalid attempt")
+    if not expectations:
+        raise ValueError("TG-04 unbindable output lacks provider-bound attempts")
+    return tuple(expectations), _canonical_sha256(signatures)
+
+
+def _collect_unbindable_attempts(
+    *,
+    attempts: Sequence[Mapping[str, object]],
+    context: _UnbindableAttemptContext,
+) -> tuple[
+    list[ProviderReceiptExpectation],
+    list[dict[str, object]],
+    int,
+]:
+    expectations: list[ProviderReceiptExpectation] = []
+    signatures: list[dict[str, object]] = []
+    invalid_count = 0
+    for attempt in attempts:
+        outcome = attempt.get("validation_outcome")
+        if outcome not in {
+            "accepted",
+            "schema_invalid",
+            "semantic_invalid",
+            "intentionally_skipped",
+        }:
+            raise ValueError("TG-04 unbindable output has a non-semantic failure")
+        if attempt.get("source_sha256") != context.source_sha256:
+            raise ValueError("TG-04 attempt source hash differs from frozen source")
+        if attempt.get("evidence_unit_sha256") != context.evidence_unit_sha256:
+            raise ValueError("TG-04 attempt is bound to the wrong fixture case")
+        _validate_attempt_record(attempt, outcome)
+        if outcome != "intentionally_skipped":
+            expectations.append(
+                receipt_expectation_from_attempt(
+                    case_id=context.case_id,
+                    report_model_id=context.model_id,
+                    record=dict(attempt),
+                ),
+            )
+        invalid_count += int(outcome in {"schema_invalid", "semantic_invalid"})
+        if attempt.get("attempt_role") in {
+            "claim_inventory",
+            "zero_candidate_retry",
+            "schema_retry",
+        }:
+            input_sha256 = _text(attempt.get("input_sha256"), "input_sha256")
+            chunk = context.chunks_by_sha.get(input_sha256)
+            if chunk is None:
+                raise ValueError("TG-04 inventory attempt targets an unknown chunk")
+            _validate_reported_inventory_outcome(
+                attempt=attempt,
+                chunk=chunk,
+                source_sha256=context.source_sha256,
+            )
+            role = attempt.get("attempt_role")
+            _validate_inventory_prompt(
+                attempt=attempt,
+                chunk=chunk,
+                context=context.prompt_context,
+                zero_retry=(
+                    role == "zero_candidate_retry"
+                    or attempt.get("retry_context") == "zero_candidate_retry"
+                ),
+                schema_retry=role == "schema_retry",
+            )
+        signatures.append(
+            {
+                "attempt_role": attempt.get("attempt_role"),
+                "pass_role": attempt.get("pass_role"),
+                "retry_context": attempt.get("retry_context"),
+                "input_sha256": attempt.get("input_sha256"),
+                "prompt_sha256": attempt.get("prompt_sha256"),
+                "output_schema_identity": attempt.get("output_schema_identity"),
+            },
+        )
+    return expectations, signatures, invalid_count
+
+
+def _validate_reported_inventory_outcome(
+    *,
+    attempt: Mapping[str, object],
+    chunk: RelationExtractionTextChunk,
+    source_sha256: str,
+) -> None:
+    reported = attempt.get("validation_outcome")
+    if reported == "intentionally_skipped":
+        return
+    payload = _object(attempt.get("raw_model_payload"), "raw model payload")
+    schema = build_claim_inventory_output_schema(_MAX_INVENTORY_CLAIMS_PER_CHUNK)
+    try:
+        schema.model_validate(payload)
+    except ValidationError:
+        derived = "schema_invalid"
+    else:
+        claims = tuple(
+            ClaimInventoryItem.model_validate(item)
+            for item in _sequence(payload.get("claims"), "raw inventory claims")
+        )
+        try:
+            bind_claim_inventory(
+                claims,
+                source_text=chunk.text,
+                source_sha256=source_sha256,
+                chunk_index=chunk.index,
+                source_start_offset=chunk.start_char,
+            )
+        except ClaimInventoryBindingError:
+            derived = "semantic_invalid"
+        else:
+            derived = "accepted"
+    if reported != derived:
+        raise ValueError("TG-04 reported validation outcome differs from replay")
+    expected_error_type = {
+        "accepted": None,
+        "schema_invalid": "ValidationError",
+        "semantic_invalid": "StructuredModelSemanticError",
+    }[derived]
+    if attempt.get("error_type") != expected_error_type:
+        raise ValueError("TG-04 reported error type differs from validation replay")
 
 
 def _collect_attempts(
@@ -165,7 +376,12 @@ def _collect_attempts(
     collected = _CollectedAttempts([], [], [], {}, {})
     for attempt in attempts:
         outcome = attempt.get("validation_outcome")
-        if outcome not in {"accepted", "intentionally_skipped"}:
+        if outcome not in {
+            "accepted",
+            "schema_invalid",
+            "semantic_invalid",
+            "intentionally_skipped",
+        }:
             raise ValueError("TG-04 report contains invalid agent output")
         if attempt.get("source_sha256") != source_sha256:
             raise ValueError(
@@ -174,7 +390,7 @@ def _collect_attempts(
         if attempt.get("evidence_unit_sha256") != evidence_unit_sha256:
             raise ValueError("TG-04 attempt is bound to the wrong fixture case")
         _validate_attempt_record(attempt, outcome)
-        if outcome == "accepted":
+        if outcome != "intentionally_skipped":
             collected.expectations.append(
                 receipt_expectation_from_attempt(
                     case_id=case_id,
@@ -196,6 +412,24 @@ def _collect_attempt_by_role(
         _insert_unique_attempt(collected.initial_by_input, attempt)
     elif role == "zero_candidate_retry":
         _insert_unique_attempt(collected.zero_by_input, attempt)
+    elif role == "schema_retry":
+        if outcome == "intentionally_skipped":
+            return
+        if attempt.get("pass_role") == "claim_inventory":
+            target = (
+                collected.zero_by_input
+                if attempt.get("retry_context") == "zero_candidate_retry"
+                else collected.initial_by_input
+            )
+            _replace_invalid_attempt(target, attempt)
+        elif outcome == "accepted" and attempt.get("pass_role") == (
+            "claim_inventory_completeness"
+        ):
+            collected.completeness_attempts.append(attempt)
+        elif outcome == "accepted" and attempt.get("pass_role") == (
+            "claim_inventory_recovery"
+        ):
+            collected.recovery_attempts.append(attempt)
     elif outcome == "accepted" and role == "claim_inventory_completeness":
         collected.completeness_attempts.append(attempt)
     elif outcome == "accepted" and role == "claim_inventory_recovery":
@@ -244,6 +478,7 @@ def _validate_inventory_workflow(
             chunk=chunk,
             context=context,
             zero_retry=False,
+            schema_retry=initial.get("attempt_role") == "schema_retry",
         )
         zero = workflow.zero_by_input[input_sha256]
         initial_claims = _raw_claim_payloads(initial)
@@ -259,6 +494,7 @@ def _validate_inventory_workflow(
             chunk=chunk,
             context=context,
             zero_retry=True,
+            schema_retry=zero.get("attempt_role") == "schema_retry",
         )
         inventory_attempt = initial if initial_claims else zero
         inventory = bind_claim_inventory(
@@ -342,6 +578,7 @@ def _take_complete_review_attempt(
             document_fingerprint=context.source_sha256,
             current_inventory=inventory,
             confirmation=False,
+            schema_retry=attempt.get("attempt_role") == "schema_retry",
         )
         provider_prompt = bind_prompt_to_invocation(
             prompt=prompt,
@@ -373,6 +610,7 @@ def _validate_inventory_prompt(
     chunk: RelationExtractionTextChunk,
     context: _PromptContext,
     zero_retry: bool,
+    schema_retry: bool = False,
 ) -> None:
     if attempt.get("output_schema_identity") != context.output_schema_identity:
         raise ValueError("TG-04 inventory output schema differs from production schema")
@@ -382,6 +620,7 @@ def _validate_inventory_prompt(
         total_chunks=context.total_chunks,
         document_fingerprint=context.source_sha256,
         zero_retry=zero_retry,
+        schema_retry=schema_retry,
     )
     provider_prompt = bind_prompt_to_invocation(
         prompt=prompt,
@@ -492,23 +731,33 @@ def _validate_attempt_record(attempt: Mapping[str, object], outcome: object) -> 
         "claim_inventory_completeness": ("claim_inventory_completeness", None),
         "claim_inventory_recovery": ("claim_inventory_recovery", None),
     }
-    if role not in expected_topology:
-        raise ValueError("TG-04 report contains an unexpected attempt role")
-    expected_pass_role, expected_retry = expected_topology[role]
-    if (
-        attempt.get("pass_role") != expected_pass_role
-        or attempt.get("retry_context") != expected_retry
-    ):
-        raise ValueError("TG-04 attempt role topology is invalid")
+    if role == "schema_retry":
+        _validate_schema_retry_topology(attempt)
+    else:
+        if role not in expected_topology:
+            raise ValueError("TG-04 report contains an unexpected attempt role")
+        expected_pass_role, expected_retry = expected_topology[role]
+        if (
+            attempt.get("pass_role") != expected_pass_role
+            or attempt.get("retry_context") != expected_retry
+        ):
+            raise ValueError("TG-04 attempt role topology is invalid")
     raw_payload = attempt.get("raw_model_payload")
     payload_sha256 = attempt.get("payload_sha256")
-    if outcome == "accepted":
+    if outcome in {"accepted", "schema_invalid", "semantic_invalid"}:
         if not isinstance(raw_payload, Mapping):
-            raise ValueError("TG-04 accepted attempt lacks a raw payload")
+            raise ValueError("TG-04 executed attempt lacks a raw payload")
         if payload_sha256 != _sha256_text(_canonical_json(raw_payload)):
             raise ValueError(
                 "TG-04 raw payload hash differs from provider-bound payload"
             )
+        for field in (
+            "provider_response_id",
+            "provider_output_sha256",
+            "kernel_run_id",
+        ):
+            if not isinstance(attempt.get(field), str) or not attempt.get(field):
+                raise ValueError("TG-04 executed attempt lacks provider custody")
         return
     if raw_payload is not None or payload_sha256 is not None:
         raise ValueError("TG-04 skipped attempt must not contain a payload")
@@ -521,6 +770,17 @@ def _validate_attempt_record(attempt: Mapping[str, object], outcome: object) -> 
             raise ValueError(
                 "TG-04 skipped attempt contains provider execution evidence"
             )
+
+
+def _validate_schema_retry_topology(attempt: Mapping[str, object]) -> None:
+    pass_role = attempt.get("pass_role")
+    retry_context = attempt.get("retry_context")
+    valid = (
+        pass_role == "claim_inventory"
+        and retry_context in {None, "zero_candidate_retry"}
+    ) or (pass_role == "claim_inventory_completeness" and retry_context is None)
+    if not valid:
+        raise ValueError("TG-04 schema retry topology is invalid")
 
 
 def _raw_claim_payloads(attempt: Mapping[str, object]) -> set[str]:
@@ -560,6 +820,20 @@ def _insert_unique_attempt(
     attempts[input_sha256] = attempt
 
 
+def _replace_invalid_attempt(
+    attempts: dict[str, Mapping[str, object]],
+    retry: Mapping[str, object],
+) -> None:
+    input_sha256 = _text(retry.get("input_sha256"), "inventory input_sha256")
+    original = attempts.get(input_sha256)
+    if original is None or original.get("validation_outcome") not in {
+        "schema_invalid",
+        "semantic_invalid",
+    }:
+        raise ValueError("TG-04 schema retry does not follow one invalid attempt")
+    attempts[input_sha256] = retry
+
+
 def _sequence(value: object, label: str) -> Sequence[object]:
     if not isinstance(value, Sequence) or isinstance(value, str | bytes):
         raise TypeError(f"{label} must be a sequence")
@@ -596,4 +870,8 @@ def _sha256_text(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-__all__ = ["EvidenceCaseContract", "bind_case_evidence"]
+__all__ = [
+    "EvidenceCaseContract",
+    "bind_case_evidence",
+    "bind_unbindable_case_evidence",
+]

--- a/scripts/validation/claim_events/operational.py
+++ b/scripts/validation/claim_events/operational.py
@@ -1,0 +1,213 @@
+"""Deterministic operational outcomes for TG-04 live claim runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+from artana_evidence_api.document_extraction_support.llm_extraction.attempt_audit import (
+    canonical_openai_response_id,
+)
+
+
+class CaseExecutionOutcome(StrEnum):
+    """Categorical result of one production-path benchmark case."""
+
+    BOUND_OUTPUT = "BOUND_OUTPUT"
+    NO_OUTPUT = "NO_OUTPUT"
+    UNBINDABLE_OUTPUT = "UNBINDABLE_OUTPUT"
+
+
+_ZERO_RETRY_FAILURE_ATTEMPT_COUNT = 4
+
+
+class OperationalCaseContract(Protocol):
+    @property
+    def case_id(self) -> str: ...
+
+    @property
+    def control_status(self) -> object: ...
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalSafetyEvidence:
+    fallback_count: int
+    unidentified_provider_attempt_count: int
+    qualification_invalid_agent_output_count: int
+    representability_stress_invalid_agent_output_count: int
+    provider_receipt_gate_passed: bool
+
+
+def build_operational_summary(
+    *,
+    cases: Sequence[OperationalCaseContract],
+    predictions: Sequence[Mapping[str, object]],
+    safety: OperationalSafetyEvidence,
+) -> dict[str, object]:
+    """Build the fail-closed run-completion gate from categorical outcomes."""
+
+    expected_ids = {case.case_id for case in cases}
+    case_status = {case.case_id: str(case.control_status) for case in cases}
+    stress_case_count = sum(
+        status == "REPRESENTABILITY_STRESS" for status in case_status.values()
+    )
+    outcomes: Counter[str] = Counter()
+    predicted_ids: list[str] = []
+    qualification_unbindable = stress_unbindable = 0
+    for prediction in predictions:
+        case_id = _text(prediction.get("case_id"), "prediction case_id")
+        outcome = CaseExecutionOutcome(
+            _text(prediction.get("execution_outcome"), "execution_outcome"),
+        )
+        predicted_ids.append(case_id)
+        outcomes[outcome.value] += 1
+        if outcome is CaseExecutionOutcome.UNBINDABLE_OUTPUT:
+            if case_status.get(case_id) == "REPRESENTABILITY_STRESS":
+                stress_unbindable += 1
+            else:
+                qualification_unbindable += 1
+
+    coverage_complete = set(predicted_ids) == expected_ids and len(
+        predicted_ids
+    ) == len(expected_ids)
+    gate_passed = (
+        coverage_complete
+        and qualification_unbindable == 0
+        and safety.fallback_count == 0
+        and safety.unidentified_provider_attempt_count == 0
+        and safety.qualification_invalid_agent_output_count == 0
+        and safety.provider_receipt_gate_passed
+    )
+    return {
+        "case_count": len(cases),
+        "qualification_case_count": len(cases) - stress_case_count,
+        "representability_stress_case_count": stress_case_count,
+        "covered_case_count": len(set(predicted_ids) & expected_ids),
+        "coverage_complete": coverage_complete,
+        "outcome_counts": {
+            outcome.value: outcomes[outcome.value] for outcome in CaseExecutionOutcome
+        },
+        "qualification_unbindable_count": qualification_unbindable,
+        "qualification_invalid_agent_output_count": (
+            safety.qualification_invalid_agent_output_count
+        ),
+        "representability_stress_invalid_agent_output_count": (
+            safety.representability_stress_invalid_agent_output_count
+        ),
+        "total_invalid_agent_output_count": (
+            safety.qualification_invalid_agent_output_count
+            + safety.representability_stress_invalid_agent_output_count
+        ),
+        "provider_receipt_gate_passed": safety.provider_receipt_gate_passed,
+        "representability_stress_unbindable_count": stress_unbindable,
+        "gate_passed": gate_passed,
+    }
+
+
+def require_sealable_unbindable_attempts(
+    attempts: Sequence[Mapping[str, object]],
+) -> None:
+    """Require one complete provider-backed inventory failure prefix."""
+
+    topology = tuple(
+        (
+            attempt.get("attempt_role"),
+            attempt.get("validation_outcome"),
+            attempt.get("retry_context"),
+        )
+        for attempt in attempts
+    )
+    invalid_outcomes = ("schema_invalid", "semantic_invalid")
+    allowed_topologies = {
+        (
+            ("claim_inventory", initial_outcome, None),
+            ("schema_retry", retry_outcome, None),
+        )
+        for initial_outcome in invalid_outcomes
+        for retry_outcome in invalid_outcomes
+    } | {
+        (
+            ("claim_inventory", "accepted", None),
+            ("schema_retry", "intentionally_skipped", None),
+            (
+                "zero_candidate_retry",
+                initial_outcome,
+                "zero_candidate_retry",
+            ),
+            ("schema_retry", retry_outcome, "zero_candidate_retry"),
+        )
+        for initial_outcome in invalid_outcomes
+        for retry_outcome in invalid_outcomes
+    }
+    if topology not in allowed_topologies:
+        raise ValueError("TG-04 unbindable attempt topology is not sealable")
+
+    terminal_input = attempts[-1].get("input_sha256")
+    terminal_retry = attempts[-1].get("retry_context")
+    for attempt in attempts:
+        if (
+            attempt.get("input_sha256") != terminal_input
+            or attempt.get("pass_role") != "claim_inventory"
+        ):
+            raise ValueError("TG-04 unbindable attempts cross workflow boundaries")
+        if attempt.get("validation_outcome") == "intentionally_skipped":
+            _require_skipped_attempt(attempt)
+        else:
+            _require_provider_custody(attempt)
+    if attempts[-2].get("retry_context") != terminal_retry:
+        raise ValueError("TG-04 terminal retry is detached from its failed attempt")
+    if len(attempts) == _ZERO_RETRY_FAILURE_ATTEMPT_COUNT:
+        payload = attempts[0].get("raw_model_payload")
+        if not isinstance(payload, Mapping) or payload.get("claims") != []:
+            raise ValueError("TG-04 zero retry did not follow an accepted empty output")
+
+
+def _require_provider_custody(attempt: Mapping[str, object]) -> None:
+    response_id = _text(attempt.get("provider_response_id"), "provider_response_id")
+    canonical_openai_response_id(response_id)
+    for field in ("provider_output_sha256", "kernel_run_id", "prompt_sha256"):
+        _text(attempt.get(field), field)
+    payload = attempt.get("raw_model_payload")
+    if not isinstance(payload, Mapping):
+        raise TypeError("TG-04 executed attempt lacks a raw payload")
+    expected_hash = hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8"),
+    ).hexdigest()
+    if attempt.get("payload_sha256") != expected_hash:
+        raise ValueError("TG-04 executed attempt payload hash differs")
+
+
+def _require_skipped_attempt(attempt: Mapping[str, object]) -> None:
+    for field in (
+        "provider_response_id",
+        "provider_output_sha256",
+        "kernel_run_id",
+        "raw_model_payload",
+        "payload_sha256",
+    ):
+        if attempt.get(field) is not None:
+            raise ValueError("TG-04 skipped attempt contains provider evidence")
+
+
+def _text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be nonempty text")
+    return value
+
+
+__all__ = [
+    "CaseExecutionOutcome",
+    "OperationalSafetyEvidence",
+    "build_operational_summary",
+    "require_sealable_unbindable_attempts",
+]

--- a/scripts/validation/claim_events/runner.py
+++ b/scripts/validation/claim_events/runner.py
@@ -6,7 +6,7 @@ import asyncio
 import hashlib
 import json
 from contextlib import suppress
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Final, Protocol, cast
@@ -22,6 +22,12 @@ from artana_evidence_api.document_extraction_support.llm_extraction.invocation_b
 )
 
 from scripts.validation.claim_events.fixture import require_frozen_development_fixture
+from scripts.validation.claim_events.operational import (
+    CaseExecutionOutcome,
+    OperationalSafetyEvidence,
+    build_operational_summary,
+    require_sealable_unbindable_attempts,
+)
 from scripts.validation.claim_events.scoring import score_fixture
 from scripts.validation.claim_frames.evidence import collect_repository_evidence
 from scripts.validation.claim_frames.provider_receipts import (
@@ -39,7 +45,10 @@ if TYPE_CHECKING:
         ModelAttemptAuditRecord,
     )
 
-    from scripts.validation.claim_events.contracts import NaryClaimFixture
+    from scripts.validation.claim_events.contracts import (
+        NaryClaimCase,
+        NaryClaimFixture,
+    )
     from scripts.validation.claim_events.scoring import BenchmarkFixtureContract
 
 _ALLOWED_MODELS: Final = frozenset(
@@ -51,6 +60,13 @@ _TASK_ID: Final = "nary_event_inventory"
 
 class _AsyncClosable(Protocol):
     async def close(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _CaseRunResult:
+    prediction: dict[str, object]
+    evidence: dict[str, object]
+    records: tuple[ModelAttemptAuditRecord, ...]
 
 
 def run_live_arm(
@@ -83,22 +99,6 @@ async def _run_live_arm(
     run_id: str,
     repository_evidence: dict[str, object],
 ) -> dict[str, object]:
-    from artana_evidence_api.document_extraction import (
-        normalize_text_document,
-    )
-    from artana_evidence_api.document_extraction_support.full_text_chunking import (
-        build_relation_extraction_text_chunks,
-    )
-    from artana_evidence_api.document_extraction_support.llm_extraction.runner import (
-        run_llm_claim_inventory_with_zero_retry,
-    )
-    from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
-        llm_extraction_document_fingerprint,
-        start_model_attempt_audit,
-        stop_model_attempt_audit,
-    )
-    from artana_evidence_api.step_helpers import run_single_step_with_policy
-
     client, tenant, execution_model_id, kernel, store = _build_inventory_runtime(
         model_id,
     )
@@ -108,65 +108,35 @@ async def _run_live_arm(
     provider_ids: set[str] = set()
     receipt_expectations: list[ProviderReceiptExpectation] = []
     fallback_count = invalid_count = unidentified_provider_count = 0
+    qualification_invalid_count = stress_invalid_count = 0
     try:
         for case in fixture.cases:
-            invocation_namespace = f"tg04-{_TASK_ID}-{uuid4().hex}"
-            normalized_text = normalize_text_document(case.source_text)
-            audit = start_model_attempt_audit(evidence_unit_id=case.case_id)
-            try:
-                inventory = await run_llm_claim_inventory_with_zero_retry(
-                    normalized_text=normalized_text,
-                    chunks=build_relation_extraction_text_chunks(normalized_text),
-                    document_fingerprint=llm_extraction_document_fingerprint(
-                        normalized_text,
-                    ),
-                    client=client,
-                    tenant=tenant,
-                    model_id=execution_model_id,
-                    step_runner=run_single_step_with_policy,
-                    execution_namespace=invocation_namespace,
-                )
-                events = _nary_events(inventory.claims)
-            finally:
-                stop_model_attempt_audit(audit)
-
-            attempts = [record.as_json() for record in audit.records]
+            case_result = await _execute_case(
+                case=case,
+                client=client,
+                tenant=tenant,
+                execution_model_id=execution_model_id,
+            )
             case_expectations, case_invalid, case_unidentified = (
                 _case_receipt_expectations(
-                    records=tuple(audit.records),
+                    records=case_result.records,
                     case_id=case.case_id,
                     model_id=model_id,
                 )
             )
             invalid_count += case_invalid
+            if str(case.control_status) == "REPRESENTABILITY_STRESS":
+                stress_invalid_count += case_invalid
+            else:
+                qualification_invalid_count += case_invalid
             unidentified_provider_count += case_unidentified
             for expectation in case_expectations:
                 if expectation.response_id in provider_ids:
                     raise RuntimeError("TG-04 provider response IDs must be unique")
                 provider_ids.add(expectation.response_id)
                 receipt_expectations.append(expectation)
-            predictions.append(
-                {
-                    "case_id": case.case_id,
-                    "events": events,
-                    "abstained": not events,
-                },
-            )
-            case_evidence.append(
-                {
-                    "case_id": case.case_id,
-                    "invocation_namespace": invocation_namespace,
-                    "attempts": attempts,
-                    "diagnostics": {
-                        "fallback_output_used": False,
-                        "claim_extraction_routing_status": (
-                            "complete"
-                            if inventory.semantic_inventory_complete
-                            else "semantic_incomplete"
-                        ),
-                    },
-                },
-            )
+            predictions.append(case_result.prediction)
+            case_evidence.append(case_result.evidence)
     finally:
         with suppress(Exception):
             await kernel.close()
@@ -181,8 +151,19 @@ async def _run_live_arm(
         receipt_expectations,
         OpenAIProviderReceiptVerifier.from_environment(),
     )
+    operational_summary = build_operational_summary(
+        cases=fixture.cases,
+        predictions=predictions,
+        safety=OperationalSafetyEvidence(
+            fallback_count=fallback_count,
+            unidentified_provider_attempt_count=unidentified_provider_count,
+            qualification_invalid_agent_output_count=qualification_invalid_count,
+            representability_stress_invalid_agent_output_count=stress_invalid_count,
+            provider_receipt_gate_passed=provider_receipts.gate_passed,
+        ),
+    )
     report: dict[str, object] = {
-        "schema_version": "tg04_live_arm.v1",
+        "schema_version": "tg04_live_arm.v2",
         "run_id": run_id,
         "generated_at": datetime.now(UTC).isoformat(),
         "fixture_sha256": fixture.sha256,
@@ -192,9 +173,14 @@ async def _run_live_arm(
         "predictions": predictions,
         "metrics": asdict(score.metrics),
         "case_scores": [asdict(case) for case in score.cases],
+        "operational_summary": operational_summary,
         "safety": {
             "fallback_count": fallback_count,
             "invalid_agent_output_count": invalid_count,
+            "qualification_invalid_agent_output_count": (qualification_invalid_count),
+            "representability_stress_invalid_agent_output_count": (
+                stress_invalid_count
+            ),
             "provider_response_id_count": len(provider_ids),
             "provider_receipt_status": provider_receipts.status,
             "verified_provider_receipt_count": provider_receipts.verified_count,
@@ -205,6 +191,106 @@ async def _run_live_arm(
     }
     report["report_sha256"] = _sha256_json(report)
     return report
+
+
+async def _execute_case(
+    *,
+    case: NaryClaimCase,
+    client: object,
+    tenant: object,
+    execution_model_id: str,
+) -> _CaseRunResult:
+    from artana_evidence_api.document_extraction import normalize_text_document
+    from artana_evidence_api.document_extraction_support.full_text_chunking import (
+        build_relation_extraction_text_chunks,
+    )
+    from artana_evidence_api.document_extraction_support.llm_extraction.runner import (
+        run_llm_claim_inventory_with_zero_retry,
+    )
+    from artana_evidence_api.document_extraction_support.llm_extraction.structured_step import (
+        StructuredModelSemanticError,
+    )
+    from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+        llm_extraction_document_fingerprint,
+        start_model_attempt_audit,
+        stop_model_attempt_audit,
+    )
+    from artana_evidence_api.step_helpers import run_single_step_with_policy
+    from pydantic import ValidationError
+
+    invocation_namespace = f"tg04-{_TASK_ID}-{uuid4().hex}"
+    normalized_text = normalize_text_document(case.source_text)
+    audit = start_model_attempt_audit(evidence_unit_id=case.case_id)
+    inventory = None
+    terminal_error: ValidationError | StructuredModelSemanticError | None = None
+    try:
+        try:
+            inventory = await run_llm_claim_inventory_with_zero_retry(
+                normalized_text=normalized_text,
+                chunks=build_relation_extraction_text_chunks(normalized_text),
+                document_fingerprint=llm_extraction_document_fingerprint(
+                    normalized_text,
+                ),
+                client=client,
+                tenant=tenant,
+                model_id=execution_model_id,
+                step_runner=run_single_step_with_policy,
+                execution_namespace=invocation_namespace,
+            )
+        except (ValidationError, StructuredModelSemanticError) as exc:
+            terminal_error = exc
+    finally:
+        stop_model_attempt_audit(audit)
+
+    if terminal_error is not None:
+        require_sealable_unbindable_attempts(
+            tuple(record.as_json() for record in audit.records),
+        )
+        if audit.records[-1].error_type != type(terminal_error).__name__:
+            raise RuntimeError("TG-04 terminal audit error differs from raised error")
+
+    events = [] if inventory is None else _nary_events(inventory.claims)
+    outcome = _execution_outcome(events=events, failed=terminal_error is not None)
+    routing_status = "unbound"
+    if terminal_error is None:
+        routing_status = (
+            "complete"
+            if inventory is not None and inventory.semantic_inventory_complete
+            else "semantic_incomplete"
+        )
+    return _CaseRunResult(
+        prediction={
+            "case_id": case.case_id,
+            "events": events,
+            "abstained": not events,
+            "execution_outcome": outcome.value,
+        },
+        evidence={
+            "case_id": case.case_id,
+            "invocation_namespace": invocation_namespace,
+            "attempts": [record.as_json() for record in audit.records],
+            "diagnostics": {
+                "fallback_output_used": False,
+                "claim_extraction_routing_status": routing_status,
+                "terminal_error_category": (
+                    None if terminal_error is None else type(terminal_error).__name__
+                ),
+            },
+        },
+        records=tuple(audit.records),
+    )
+
+
+def _execution_outcome(
+    *,
+    events: list[dict[str, object]],
+    failed: bool,
+) -> CaseExecutionOutcome:
+    if failed:
+        return CaseExecutionOutcome.UNBINDABLE_OUTPUT
+    return (
+        CaseExecutionOutcome.BOUND_OUTPUT if events else CaseExecutionOutcome.NO_OUTPUT
+    )
 
 
 def _build_inventory_runtime(

--- a/services/artana_evidence_api/document_extraction_support/llm_extraction/claim_inventory.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_extraction/claim_inventory.py
@@ -95,10 +95,12 @@ def build_claim_inventory_prompt(
     total_chunks: int,
     document_fingerprint: str,
     zero_retry: bool = False,
+    schema_retry: bool = False,
 ) -> str:
     """Build one source-only inventory prompt for a frozen chunk."""
 
     retry_instruction = _ZERO_RETRY_INSTRUCTION if zero_retry else ""
+    schema_retry_instruction = _SCHEMA_RETRY_INSTRUCTION if schema_retry else ""
     return (
         f"{CLAIM_INVENTORY_SYSTEM_PROMPT}\n\n"
         "MODEL CONTRACT\n"
@@ -112,6 +114,7 @@ def build_claim_inventory_prompt(
         f"{chunk.text}\n"
         "---\n"
         f"{retry_instruction}"
+        f"{schema_retry_instruction}"
     )
 
 
@@ -153,7 +156,13 @@ async def run_claim_inventory_stage(
         zero_retry=zero_retry,
         schema_retry=False,
     )
-    schema_retry_prompt = f"{prompt}{_SCHEMA_RETRY_INSTRUCTION}"
+    schema_retry_prompt = build_claim_inventory_prompt(
+        chunk=chunk,
+        total_chunks=total_chunks,
+        document_fingerprint=document_fingerprint,
+        zero_retry=zero_retry,
+        schema_retry=True,
+    )
     schema_retry_step_key = _inventory_step_key(
         prompt_version=f"{prompt_version}.{_SCHEMA_RETRY_SUFFIX}",
         chunk=chunk,
@@ -220,6 +229,7 @@ def build_inventory_completeness_prompt(
     document_fingerprint: str,
     current_inventory: tuple[BoundClaimInventoryItem, ...],
     confirmation: bool,
+    schema_retry: bool = False,
 ) -> str:
     """Build an independent source-only completeness review prompt."""
 
@@ -251,6 +261,7 @@ def build_inventory_completeness_prompt(
         "---\nFROZEN SOURCE CHUNK\n---\n"
         f"{chunk.text}\n"
         "---\n"
+        f"{_SCHEMA_RETRY_INSTRUCTION if schema_retry else ''}"
     )
 
 
@@ -291,7 +302,14 @@ async def run_inventory_completeness_review_stage(
         current_inventory=current_inventory,
         schema_retry=False,
     )
-    retry_prompt = f"{prompt}{_SCHEMA_RETRY_INSTRUCTION}"
+    retry_prompt = build_inventory_completeness_prompt(
+        chunk=chunk,
+        total_chunks=total_chunks,
+        document_fingerprint=document_fingerprint,
+        current_inventory=current_inventory,
+        confirmation=confirmation,
+        schema_retry=True,
+    )
     retry_step_key = _inventory_review_step_key(
         prompt_version=(
             f"{CLAIM_INVENTORY_COMPLETENESS_PROMPT_VERSION}.{_SCHEMA_RETRY_SUFFIX}"

--- a/tests/unit/test_nary_claim_evaluation.py
+++ b/tests/unit/test_nary_claim_evaluation.py
@@ -32,6 +32,13 @@ from scripts.validation.claim_events.evaluation import (
     _run_passes,
     evaluate_matrix,
 )
+from scripts.validation.claim_events.evidence_binding import (
+    bind_unbindable_case_evidence,
+)
+from scripts.validation.claim_events.operational import (
+    OperationalSafetyEvidence,
+    build_operational_summary,
+)
 from scripts.validation.claim_events.runner import receipt_expectation_from_attempt
 from scripts.validation.claim_events.scoring import score_fixture
 from scripts.validation.claim_frames.provider_receipts import (
@@ -207,6 +214,7 @@ def _prediction(case: _Case, *, correct: bool) -> dict[str, object]:
             },
         ],
         "abstained": False,
+        "execution_outcome": "BOUND_OUTPUT",
     }
 
 
@@ -406,7 +414,7 @@ def _report(
     )
     receipt_verification = verify_provider_receipts(expectations, _LiveVerifier())
     report: dict[str, object] = {
-        "schema_version": "tg04_live_arm.v1",
+        "schema_version": "tg04_live_arm.v2",
         "run_id": f"tg04-{slug}-nary-{run_index:02d}",
         "generated_at": "2026-07-16T00:00:00+00:00",
         "fixture_sha256": fixture.sha256,
@@ -421,9 +429,22 @@ def _report(
         "predictions": predictions,
         "metrics": asdict(score.metrics),
         "case_scores": [asdict(case) for case in score.cases],
+        "operational_summary": build_operational_summary(
+            cases=fixture.cases,
+            predictions=predictions,
+            safety=OperationalSafetyEvidence(
+                fallback_count=0,
+                unidentified_provider_attempt_count=0,
+                qualification_invalid_agent_output_count=0,
+                representability_stress_invalid_agent_output_count=0,
+                provider_receipt_gate_passed=True,
+            ),
+        ),
         "safety": {
             "fallback_count": 0,
             "invalid_agent_output_count": 0,
+            "qualification_invalid_agent_output_count": 0,
+            "representability_stress_invalid_agent_output_count": 0,
             "provider_response_id_count": len(expectations),
             "provider_receipt_status": "verified_live",
             "verified_provider_receipt_count": len(expectations),
@@ -453,6 +474,201 @@ def _sha256_json(value: object) -> str:
     return hashlib.sha256(
         json.dumps(value, sort_keys=True, separators=(",", ":")).encode(),
     ).hexdigest()
+
+
+def _unbindable_stress_artifact(
+    *,
+    control_status: str = "REPRESENTABILITY_STRESS",
+) -> tuple[_Case, dict[str, object], dict[str, object]]:
+    case = _Case(
+        "stress",
+        "WT1 increased expression.",
+        (),
+        control_status=control_status,
+    )
+    source_sha256 = hashlib.sha256(case.source_text.encode()).hexdigest()
+    evidence_unit_sha256 = hashlib.sha256(case.case_id.encode()).hexdigest()
+    chunk = build_relation_extraction_text_chunks(case.source_text)[0]
+    schema = build_claim_inventory_output_schema(64)
+    schema_identity = f"{schema.__module__}.{schema.__qualname__}"
+    raw_payload = {"claims": [{"exact_span": "not copied from source"}]}
+    attempts = []
+    for index, (role, schema_retry) in enumerate(
+        (("claim_inventory", False), ("schema_retry", True)),
+        start=1,
+    ):
+        invocation_id = f"stress-invocation-{index}"
+        provider_prompt = bind_prompt_to_invocation(
+            prompt=build_claim_inventory_prompt(
+                chunk=chunk,
+                total_chunks=1,
+                document_fingerprint=source_sha256,
+                schema_retry=schema_retry,
+            ),
+            invocation_id=invocation_id,
+            source_sha256=source_sha256,
+            input_sha256=chunk.sha256,
+            evidence_unit_sha256=evidence_unit_sha256,
+            output_schema_sha256=output_schema_json_sha256(schema),
+        )
+        attempts.append(
+            {
+                "invocation_id": invocation_id,
+                "attempt_role": role,
+                "model_id": "openai/gpt-5.6-luna",
+                "pass_role": "claim_inventory",
+                "retry_context": None,
+                "validation_outcome": "schema_invalid",
+                "error_type": "ValidationError",
+                "provider_response_id": f"resp_stress_{index}",
+                "provider_output_sha256": str(index) * 64,
+                "payload_sha256": _sha256_json(raw_payload),
+                "prompt_sha256": hashlib.sha256(provider_prompt.encode()).hexdigest(),
+                "kernel_run_id": f"research-init-extraction:{invocation_id}",
+                "source_sha256": source_sha256,
+                "input_sha256": chunk.sha256,
+                "evidence_unit_sha256": evidence_unit_sha256,
+                "output_schema_identity": schema_identity,
+                "semantic_unit_id": None,
+                "raw_model_payload": raw_payload,
+            },
+        )
+    prediction = {
+        "case_id": case.case_id,
+        "events": [],
+        "abstained": True,
+        "execution_outcome": "UNBINDABLE_OUTPUT",
+    }
+    evidence = {
+        "case_id": case.case_id,
+        "invocation_namespace": "stress-run",
+        "diagnostics": {
+            "fallback_output_used": False,
+            "claim_extraction_routing_status": "unbound",
+            "terminal_error_category": "ValidationError",
+        },
+        "attempts": attempts,
+    }
+    return case, prediction, evidence
+
+
+def _semantic_invalid_inventory_payload() -> dict[str, object]:
+    item = ClaimInventoryItem.model_validate(
+        {
+            "exact_span": "TP53 increased expression.",
+            "relation_cue_span": "increased",
+            "event_type": "INCREASE",
+            "polarity": "SUPPORT",
+            "epistemic_status": "ASSERTED",
+            "arguments": [
+                {
+                    "role": "GENE_OR_PROTEIN",
+                    "event_role": "THEME",
+                    "exact_span": "TP53",
+                    "role_rationale": "source theme",
+                },
+                {
+                    "role": "MEASUREMENT",
+                    "event_role": "MEASURE",
+                    "exact_span": "expression",
+                    "role_rationale": "source measure",
+                },
+            ],
+            "source_locator": "normalized_extraction_text",
+            "inventory_rationale": "explicit synthetic claim",
+        },
+    )
+    return {"claims": [item.model_dump(mode="json")]}
+
+
+def test_stress_unbindable_output_retains_provider_custody() -> None:
+    case, prediction, evidence = _unbindable_stress_artifact()
+
+    expectations, topology = bind_unbindable_case_evidence(
+        case=case,
+        prediction=prediction,
+        case_record=evidence,
+        model_id="openai:gpt-5.6-luna",
+    )
+
+    assert len(expectations) == 2
+    assert topology
+
+
+def test_stress_unbindable_allows_schema_to_semantic_retry_failure() -> None:
+    case, prediction, evidence = _unbindable_stress_artifact()
+    semantic_payload = _semantic_invalid_inventory_payload()
+    evidence["attempts"][1]["validation_outcome"] = "semantic_invalid"
+    evidence["attempts"][1]["error_type"] = "StructuredModelSemanticError"
+    evidence["attempts"][1]["raw_model_payload"] = semantic_payload
+    evidence["attempts"][1]["payload_sha256"] = _sha256_json(semantic_payload)
+    evidence["diagnostics"]["terminal_error_category"] = "StructuredModelSemanticError"
+
+    expectations, _ = bind_unbindable_case_evidence(
+        case=case,
+        prediction=prediction,
+        case_record=evidence,
+        model_id="openai:gpt-5.6-luna",
+    )
+
+    assert len(expectations) == 2
+
+
+def test_stress_unbindable_rejects_valid_payload_relabelled_invalid() -> None:
+    case, prediction, evidence = _unbindable_stress_artifact()
+    valid_payload = {"claims": []}
+    for attempt in evidence["attempts"]:
+        attempt["raw_model_payload"] = valid_payload
+        attempt["payload_sha256"] = _sha256_json(valid_payload)
+
+    with pytest.raises(ValueError, match="validation outcome differs from replay"):
+        bind_unbindable_case_evidence(
+            case=case,
+            prediction=prediction,
+            case_record=evidence,
+            model_id="openai:gpt-5.6-luna",
+        )
+
+
+def test_qualification_case_cannot_use_unbindable_stress_exception() -> None:
+    case, prediction, evidence = _unbindable_stress_artifact(
+        control_status="EVENT_GOLD",
+    )
+
+    with pytest.raises(ValueError, match="qualification cases cannot be unbindable"):
+        bind_unbindable_case_evidence(
+            case=case,
+            prediction=prediction,
+            case_record=evidence,
+            model_id="openai:gpt-5.6-luna",
+        )
+
+
+@pytest.mark.parametrize("field", ["payload_sha256", "prompt_sha256"])
+def test_stress_unbindable_output_rejects_custody_tampering(field: str) -> None:
+    case, prediction, evidence = _unbindable_stress_artifact()
+    evidence["attempts"][1][field] = "f" * 64
+
+    with pytest.raises(ValueError, match="payload hash|production prompt"):
+        bind_unbindable_case_evidence(
+            case=case,
+            prediction=prediction,
+            case_record=evidence,
+            model_id="openai:gpt-5.6-luna",
+        )
+
+
+def test_stress_unbindable_rejects_schema_retry_from_another_pass() -> None:
+    case, prediction, evidence = _unbindable_stress_artifact()
+    evidence["attempts"][1]["pass_role"] = "claim_framing"
+
+    with pytest.raises(ValueError, match="workflow boundaries"):
+        bind_unbindable_case_evidence(
+            case=case,
+            prediction=prediction,
+            case_record=evidence,
+            model_id="openai:gpt-5.6-luna",
+        )
 
 
 def _reseal_with_recomputed_score(

--- a/tests/unit/test_nary_claim_operational.py
+++ b/tests/unit/test_nary_claim_operational.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from scripts.validation.claim_events.operational import (
+    OperationalSafetyEvidence,
+    build_operational_summary,
+)
+
+
+@dataclass(frozen=True)
+class _Case:
+    case_id: str
+    control_status: str
+
+
+def _safety(
+    *,
+    qualification_invalid: int = 0,
+    stress_invalid: int = 0,
+) -> OperationalSafetyEvidence:
+    return OperationalSafetyEvidence(
+        fallback_count=0,
+        unidentified_provider_attempt_count=0,
+        qualification_invalid_agent_output_count=qualification_invalid,
+        representability_stress_invalid_agent_output_count=stress_invalid,
+        provider_receipt_gate_passed=True,
+    )
+
+
+def test_operational_gate_allows_only_stress_unbindable_outputs() -> None:
+    cases = (
+        _Case("qualification", "EVENT_GOLD"),
+        _Case("stress", "REPRESENTABILITY_STRESS"),
+    )
+    summary = build_operational_summary(
+        cases=cases,
+        predictions=(
+            {
+                "case_id": "qualification",
+                "execution_outcome": "BOUND_OUTPUT",
+            },
+            {
+                "case_id": "stress",
+                "execution_outcome": "UNBINDABLE_OUTPUT",
+            },
+        ),
+        safety=_safety(stress_invalid=2),
+    )
+
+    assert summary["gate_passed"] is True
+    assert summary["qualification_unbindable_count"] == 0
+    assert summary["representability_stress_unbindable_count"] == 1
+
+
+def test_operational_gate_rejects_qualification_failure_or_invalid_attempt() -> None:
+    cases = (_Case("qualification", "EVENT_GOLD"),)
+    unbindable = build_operational_summary(
+        cases=cases,
+        predictions=(
+            {
+                "case_id": "qualification",
+                "execution_outcome": "UNBINDABLE_OUTPUT",
+            },
+        ),
+        safety=_safety(),
+    )
+    repaired_invalid = build_operational_summary(
+        cases=cases,
+        predictions=(
+            {
+                "case_id": "qualification",
+                "execution_outcome": "BOUND_OUTPUT",
+            },
+        ),
+        safety=_safety(qualification_invalid=1),
+    )
+
+    assert unbindable["gate_passed"] is False
+    assert repaired_invalid["gate_passed"] is False
+
+
+def test_operational_gate_rejects_incomplete_or_duplicate_coverage() -> None:
+    cases = (_Case("one", "EVENT_GOLD"), _Case("two", "EVENT_GOLD"))
+    summary = build_operational_summary(
+        cases=cases,
+        predictions=(
+            {"case_id": "one", "execution_outcome": "NO_OUTPUT"},
+            {"case_id": "one", "execution_outcome": "NO_OUTPUT"},
+        ),
+        safety=_safety(),
+    )
+
+    assert summary["coverage_complete"] is False
+    assert summary["gate_passed"] is False

--- a/tests/unit/test_nary_claim_runner.py
+++ b/tests/unit/test_nary_claim_runner.py
@@ -7,9 +7,17 @@ from artana_evidence_api.document_extraction_support.claim_frames import (
     ClaimInventoryItem,
     bind_claim_inventory,
 )
+from artana_evidence_api.document_extraction_support.full_text_chunking import (
+    build_relation_extraction_text_chunks,
+)
+from artana_evidence_api.document_extraction_support.llm_extraction.claim_inventory import (
+    build_claim_inventory_prompt,
+)
 
+from scripts.validation.claim_events.operational import CaseExecutionOutcome
 from scripts.validation.claim_events.runner import (
     _attempt_output_schema_sha256,
+    _execution_outcome,
     _nary_events,
     _require_attempt_model,
     _require_model,
@@ -242,7 +250,6 @@ def test_zero_candidate_retry_uses_inventory_pass_schema() -> None:
             "pass_role": "claim_inventory",
         },
     )
-
     assert (
         _attempt_output_schema_sha256(
             {
@@ -252,3 +259,33 @@ def test_zero_candidate_retry_uses_inventory_pass_schema() -> None:
         )
         == primary
     )
+
+
+def test_runner_categorizes_bound_empty_and_unbindable_results() -> None:
+    assert (
+        _execution_outcome(events=[{"event_type": "BINDING"}], failed=False)
+        is CaseExecutionOutcome.BOUND_OUTPUT
+    )
+    assert _execution_outcome(events=[], failed=False) is CaseExecutionOutcome.NO_OUTPUT
+    assert (
+        _execution_outcome(events=[], failed=True)
+        is CaseExecutionOutcome.UNBINDABLE_OUTPUT
+    )
+
+
+def test_schema_retry_prompt_is_canonically_reconstructable() -> None:
+    chunk = build_relation_extraction_text_chunks("WT1 increased expression.")[0]
+    base = build_claim_inventory_prompt(
+        chunk=chunk,
+        total_chunks=1,
+        document_fingerprint="a" * 64,
+    )
+    retry = build_claim_inventory_prompt(
+        chunk=chunk,
+        total_chunks=1,
+        document_fingerprint="a" * 64,
+        schema_retry=True,
+    )
+
+    assert retry.startswith(base)
+    assert "SCHEMA AND SOURCE-BINDING RETRY" in retry


### PR DESCRIPTION
## Summary

- seal TG-04 live runs with categorical `BOUND_OUTPUT`, `NO_OUTPUT`, and stress-only `UNBINDABLE_OUTPUT` outcomes
- preserve the zero-invalid qualification gate and keep scientific thresholds, scoring, projection, and persistence unchanged
- require canonical provider custody, replay alleged schema/semantic failures through the production schema and source binder, and live-verify every executed attempt
- reconstruct schema-retry prompts exactly and validate the v2 report/operational summary deterministically

## Safety boundary

Only the two one-chunk inventory failure prefixes needed for the observed representability blocker are sealable. Invocation/authentication/custody/topology failures and completeness/recovery failures still abort fail-closed. Unbindable qualification cases cannot pass.

## Validation

- focused TG-04 and production inventory suite: 74 passed
- evidence API strict MyPy: passed
- validation modules strict MyPy with service source resolution: passed
- `make service-checks`: passed
- pre-commit lint and type hooks: passed
- two independent adversarial agent reviews; the report-authored invalid-label bypass was reproduced and fixed

## Next step after merge

Run one separately identified Luna operational pass across all 40 frozen cases. Start the 3x Luna + 3x Sol scientific matrix only if coverage, qualification validity, fallback, provider identity, and live receipt gates all pass. Persistence remains blocked.