### PR TITLE
Adjudicate missing scientific claims without rewriting evidence

### DIFF
--- a/docs/validation/reports/2026-07-11-pr-semantic-pr3-agent-output-registry.json
+++ b/docs/validation/reports/2026-07-11-pr-semantic-pr3-agent-output-registry.json
@@ -310,7 +310,7 @@
         "document_extraction_support/llm_extraction/claim_inventory.py"
       ],
       "prompt_identifiers": [
-        "document_extraction.claim_inventory.v7"
+        "document_extraction.claim_inventory.v8"
       ],
       "schema_id": "document_extraction.claim_inventory.v3",
       "schema_names": [

--- a/docs/validation/reports/2026-07-11-pr-semantic-pr3-agent-output-registry.json
+++ b/docs/validation/reports/2026-07-11-pr-semantic-pr3-agent-output-registry.json
@@ -3,7 +3,7 @@
   "debt_manifest": [],
   "debt_numeric_field_count": 0,
   "origin_governed_numeric_field_count": 3,
-  "registered_category_field_count": 116,
+  "registered_category_field_count": 111,
   "registered_numeric_field_count": 3,
   "registered_schema_count": 19,
   "registered_schemas": [
@@ -432,7 +432,7 @@
         "document_extraction_support/llm_extraction/claim_inventory.py"
       ],
       "prompt_identifiers": [
-        "document_extraction.claim_inventory_completeness.v6"
+        "document_extraction.claim_inventory_completeness.v7"
       ],
       "schema_id": "document_extraction.claim_inventory_completeness.v3",
       "schema_names": [
@@ -445,98 +445,12 @@
         {
           "allow_schema_subset": false,
           "debt_id": null,
-          "path": "$.claims[].source_locator",
+          "path": "$.decision",
           "values": [
-            "normalized_extraction_text"
-          ]
-        },
-        {
-          "allow_schema_subset": false,
-          "debt_id": null,
-          "path": "$.claims[].arguments[].role",
-          "values": [
-            "INTERVENTION",
-            "CONDITION",
-            "POPULATION",
-            "VARIANT",
-            "OUTCOME",
-            "COMPARATOR",
-            "TIMEFRAME",
-            "STUDY_DESIGN",
-            "TREATMENT_SETTING",
-            "GENE_OR_PROTEIN",
-            "CHEMICAL_OR_DRUG",
-            "BIOMARKER",
-            "EXPOSURE",
-            "BIOLOGICAL_PROCESS",
-            "ANATOMY",
-            "MEASUREMENT",
-            "OTHER_ENTITY"
-          ]
-        },
-        {
-          "allow_schema_subset": false,
-          "debt_id": null,
-          "path": "$.claims[].arguments[].event_role",
-          "values": [
-            "AGENT",
-            "THEME",
-            "TARGET",
-            "CAUSE",
-            "EFFECT",
-            "CONTEXT",
-            "SITE",
-            "CSITE",
-            "ATLOC",
-            "TOLOC",
-            "FROMLOC",
-            "MEASURE"
-          ]
-        },
-        {
-          "allow_schema_subset": false,
-          "debt_id": null,
-          "path": "$.claims[].event_type",
-          "values": [
-            "EXPRESSION",
-            "TRANSCRIPTION",
-            "DEGRADATION",
-            "PHOSPHORYLATION",
-            "LOCALIZATION",
-            "BINDING",
-            "REGULATION",
-            "POSITIVE_REGULATION",
-            "NEGATIVE_REGULATION",
-            "INCREASE",
-            "DECREASE",
-            "ASSOCIATION",
-            "TREATMENT_RESPONSE",
-            "NO_EFFECT",
-            "OTHER_EXPLICIT"
-          ]
-        },
-        {
-          "allow_schema_subset": false,
-          "debt_id": null,
-          "path": "$.claims[].polarity",
-          "values": [
-            "SUPPORT",
-            "REFUTE",
-            "UNCERTAIN",
-            "HYPOTHESIS",
-            "NULL_RESULT"
-          ]
-        },
-        {
-          "allow_schema_subset": false,
-          "debt_id": null,
-          "path": "$.claims[].epistemic_status",
-          "values": [
-            "ASSERTED",
-            "PROVISIONAL",
-            "UNCERTAIN",
-            "HYPOTHESIS",
-            "NULL_RESULT"
+            "RECOVER_EXPLICIT_CLAIM",
+            "EXCLUDE_PROCEDURAL_METHOD",
+            "EXCLUDE_NOT_EXPLICIT",
+            "ABSTAIN"
           ]
         }
       ],
@@ -545,13 +459,13 @@
         "document_extraction_support/llm_extraction/claim_inventory.py"
       ],
       "prompt_identifiers": [
-        "document_extraction.claim_inventory_recovery.v6"
+        "document_extraction.claim_inventory_recovery.v7"
       ],
-      "schema_id": "document_extraction.claim_inventory_recovery.v3",
+      "schema_id": "document_extraction.claim_inventory_recovery.v4",
       "schema_names": [
-        "MissingClaimRecoveryResult"
+        "MissingClaimRecoveryDecision"
       ],
-      "shape_hash": "ffdc56f2350b801840891aa82eef0f4d51abaee21a6900f8b4ba0d83dc932601"
+      "shape_hash": "a97e2bcfe7ac51a317407f5e59f5ba66bbd575546fe491ebc4dbf51cd220d33f"
     },
     {
       "categorical_fields": [

--- a/services/artana_evidence_api/document_extraction_prompting.py
+++ b/services/artana_evidence_api/document_extraction_prompting.py
@@ -22,7 +22,7 @@ from artana_evidence_api.document_extraction_support.claim_frames import (
     ClaimQualifier,
     ClaimSourceMeasurement,
     EpistemicStatus,
-    MissingClaimRecoveryResult,
+    MissingClaimRecoveryDecision,
     Polarity,
 )
 from pydantic import (
@@ -94,9 +94,9 @@ def build_claim_inventory_completeness_output_schema() -> type[BaseModel]:
 
 
 def build_missing_claim_recovery_output_schema() -> type[BaseModel]:
-    """Return the missing-only inventory recovery schema."""
+    """Return the categorical missing-claim adjudication schema."""
 
-    return MissingClaimRecoveryResult
+    return MissingClaimRecoveryDecision
 
 
 class _SingleClaimFramingEnvelope(BaseModel):
@@ -576,12 +576,20 @@ Inventory sibling predicates as separate claims even when they occur in one sent
 
 CLAIM_INVENTORY_COMPLETENESS_SYSTEM_PROMPT = """You independently review whether a supplied claim inventory completely covers one frozen source chunk.
 
-Return one categorical decision only: COMPLETE when every explicit biomedical event and every material typed argument is represented, or INCOMPLETE when at least one event or argument is absent. For INCOMPLETE, return a source-bound descriptor for every missing claim using its complete exact span, typed arguments, event roles, relation cue, event_type, polarity, and epistemic status. When an argument is repeated, aliased, or coreferential, copy each intended verbatim mention_span plus adjacent verbatim context, including the canonical exact_span; when a relation cue repeats, do the same for the intended cue; never return numeric offsets. event_type is exactly one of EXPRESSION, TRANSCRIPTION, DEGRADATION, PHOSPHORYLATION, LOCALIZATION, BINDING, REGULATION, POSITIVE_REGULATION, NEGATIVE_REGULATION, INCREASE, DECREASE, ASSOCIATION, TREATMENT_RESPONSE, NO_EFFECT, or OTHER_EXPLICIT. For COMPLETE, return no missing descriptors. Include negative, null, uncertain, provisional, hypothesis, and sibling claims. Do not frame final graph endpoints or relation types, rank claims, use outside knowledge, or return confidence, probability, quality, importance, or any other numeric score."""
+Return one categorical decision only: COMPLETE when every explicit biomedical event and every material typed argument is represented, or INCOMPLETE when at least one event or argument is absent. A qualifying event states a biological relationship, experimental finding, treatment effect, measured outcome, explicit hypothesis, or null result between at least two material biomedical participants. A sentence that only identifies primers, probes, reagents, catalog numbers, vendors, instruments, software, assay setup, sample handling, or another procedural method is not a biomedical claim. Do not report such procedural metadata as missing. A methods sentence can still qualify when it explicitly states a biological intervention, mechanism, comparison, or result; classify the source meaning, not its section label or vocabulary alone.
+
+For INCOMPLETE, return a source-bound descriptor for every missing claim using its complete exact span, typed arguments, event roles, relation cue, event_type, polarity, and epistemic status. When an argument is repeated, aliased, or coreferential, copy each intended verbatim mention_span plus adjacent verbatim context, including the canonical exact_span; when a relation cue repeats, do the same for the intended cue; never return numeric offsets. event_type is exactly one of EXPRESSION, TRANSCRIPTION, DEGRADATION, PHOSPHORYLATION, LOCALIZATION, BINDING, REGULATION, POSITIVE_REGULATION, NEGATIVE_REGULATION, INCREASE, DECREASE, ASSOCIATION, TREATMENT_RESPONSE, NO_EFFECT, or OTHER_EXPLICIT. For COMPLETE, return no missing descriptors. Include negative, null, uncertain, provisional, hypothesis, and sibling claims. Descriptors listed under EXCLUDED REVIEWED ITEMS have already received an independent categorical decision; do not report them again. Do not frame final graph endpoints or relation types, rank claims, use outside knowledge, or return confidence, probability, quality, importance, or any other numeric score."""
 
 
-MISSING_CLAIM_RECOVERY_SYSTEM_PROMPT = """You recover only claims identified as missing by an independent inventory-completeness review.
+MISSING_CLAIM_RECOVERY_SYSTEM_PROMPT = """You independently adjudicate one source-bound descriptor identified as missing by an inventory-completeness review.
 
-Return every reviewed missing claim and no existing or additional claim. Copy every reviewed field exactly, including the complete event span, relation cue, typed arguments, event roles, mention anchors, and rationales; preserve event_type, polarity, and epistemic status; and use source_locator=normalized_extraction_text. For repeated, aliased, or coreferential argument mentions, copy the reviewed verbatim mention_span and adjacent context, including the canonical exact_span; for repeated relation cues, copy the reviewed cue mention_span and context; never return numeric offsets. event_type is exactly one of EXPRESSION, TRANSCRIPTION, DEGRADATION, PHOSPHORYLATION, LOCALIZATION, BINDING, REGULATION, POSITIVE_REGULATION, NEGATIVE_REGULATION, INCREASE, DECREASE, ASSOCIATION, TREATMENT_RESPONSE, NO_EFFECT, or OTHER_EXPLICIT. Do not frame final graph endpoints or relations, rank claims, use outside knowledge, or return confidence, probability, quality, importance, or any other numeric score. If a reviewed descriptor cannot be recovered exactly, return schema-invalid output rather than inventing content."""
+Return exactly one categorical decision and a source-only rationale:
+- RECOVER_EXPLICIT_CLAIM when the frozen source explicitly states a biological relationship, experimental finding, treatment effect, measured outcome, hypothesis, refutation, or null result with at least two material biomedical participants;
+- EXCLUDE_PROCEDURAL_METHOD when the span only documents primers, probes, reagents, catalog numbers, vendors, instruments, software, assay setup, sample handling, or another procedure without stating a biological relationship or result;
+- EXCLUDE_NOT_EXPLICIT when the reviewed descriptor adds a relation, participant, direction, or meaning that the frozen source does not state;
+- ABSTAIN when the source does not support a safe categorical decision.
+
+A methods sentence can still be an explicit scientific claim when it states a biological intervention, mechanism, comparison, or result. Decide from the frozen source and reviewed descriptor, not from section labels, keywords, outside knowledge, or perceived importance. Do not rewrite the descriptor, spans, arguments, anchors, event type, polarity, or epistemic status. Deterministic code preserves the already-bound descriptor unchanged only after RECOVER_EXPLICIT_CLAIM. Do not return confidence, probability, quality, importance, or any numeric score."""
 
 
 SINGLE_CLAIM_FRAMING_SYSTEM_PROMPT = f"""You frame exactly one source-bound, role-typed biomedical assertion. This is not a search or ranking task.

--- a/services/artana_evidence_api/document_extraction_prompting.py
+++ b/services/artana_evidence_api/document_extraction_prompting.py
@@ -555,6 +555,8 @@ CLAIM_INVENTORY_SYSTEM_PROMPT = """You inventory explicit biomedical claims in o
 
 Return every source-local biomedical event or assertion with a relation cue, one closed event_type, and at least two typed arguments. Do not choose graph endpoints in this step. Do not rank claims and do not return confidence, probability, quality, importance, or any other numeric score.
 
+A qualifying event states a biological relationship, experimental finding, treatment effect, measured biological outcome, explicit hypothesis, refutation, or null result between at least two material biomedical participants. Do not inventory a sentence that only identifies primers, probes, reagents, catalog numbers, vendors, instruments, software, assay setup, sample handling, or another procedural method without stating a biological relationship or result. A methods sentence can still qualify when it explicitly states a biological intervention, mechanism, comparison, or result; classify the source meaning, not its section label or vocabulary alone.
+
 For each claim:
 - exact_span is the smallest complete verbatim source span that contains the event, every material argument, and the context needed to interpret it; when the same text repeats in the chunk, include enough adjacent verbatim context to make exact_span occur once;
 - arguments contains every material source-native span with one closed participant role: INTERVENTION, CONDITION, POPULATION, VARIANT, OUTCOME, COMPARATOR, TIMEFRAME, STUDY_DESIGN, TREATMENT_SETTING, GENE_OR_PROTEIN, CHEMICAL_OR_DRUG, BIOMARKER, EXPOSURE, BIOLOGICAL_PROCESS, ANATOMY, MEASUREMENT, or OTHER_ENTITY;

--- a/services/artana_evidence_api/document_extraction_support/claim_frames/__init__.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_frames/__init__.py
@@ -8,9 +8,9 @@ from artana_evidence_api.document_extraction_support.claim_frames.completeness i
     BoundInventoryCompletenessReview,
     ClaimInventoryCompletenessReview,
     InventoryCompletenessDecision,
-    MissingClaimRecoveryResult,
+    MissingClaimRecoveryDecision,
+    MissingClaimRecoveryDisposition,
     bind_inventory_completeness_review,
-    require_recovery_matches_review,
 )
 from artana_evidence_api.document_extraction_support.claim_frames.contracts import (
     ClaimFrame,
@@ -94,7 +94,8 @@ __all__ = [
     "EpistemicStatus",
     "InventoryCompletenessDecision",
     "MeasurementFieldRole",
-    "MissingClaimRecoveryResult",
+    "MissingClaimRecoveryDecision",
+    "MissingClaimRecoveryDisposition",
     "Polarity",
     "Qualifier",
     "QualifierState",
@@ -117,5 +118,4 @@ __all__ = [
     "replace_claim_frame_projection",
     "require_canonical_claim_promotion",
     "require_claim_frame_promotion_preflight",
-    "require_recovery_matches_review",
 ]

--- a/services/artana_evidence_api/document_extraction_support/claim_frames/completeness.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_frames/completeness.py
@@ -10,7 +10,6 @@ from artana_evidence_api.document_extraction_support.claim_frames.inventory impo
     ClaimInventoryBindingError,
     ClaimInventoryItem,
     bind_claim_inventory,
-    claim_inventory_input_sha256,
 )
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -53,19 +52,22 @@ class ClaimInventoryCompletenessReview(BaseModel):
         return self
 
 
-class MissingClaimRecoveryResult(BaseModel):
-    """One missing-only recovery inventory returned by the agent."""
+class MissingClaimRecoveryDisposition(str, Enum):
+    """Closed source-only decision for one reviewed missing descriptor."""
+
+    RECOVER_EXPLICIT_CLAIM = "RECOVER_EXPLICIT_CLAIM"
+    EXCLUDE_PROCEDURAL_METHOD = "EXCLUDE_PROCEDURAL_METHOD"
+    EXCLUDE_NOT_EXPLICIT = "EXCLUDE_NOT_EXPLICIT"
+    ABSTAIN = "ABSTAIN"
+
+
+class MissingClaimRecoveryDecision(BaseModel):
+    """Categorical adjudication of one already source-bound descriptor."""
 
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
-    claims: tuple[ClaimInventoryItem, ...] = Field(..., min_length=1, max_length=64)
-
-    @field_validator("claims", mode="before")
-    @classmethod
-    def restore_claim_tuple(cls, value: object) -> object:
-        """Freeze the JSON array after schema validation."""
-
-        return tuple(value) if isinstance(value, list) else value
+    decision: MissingClaimRecoveryDisposition = Field(..., strict=False)
+    decision_rationale: str = Field(..., min_length=1, max_length=2000)
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,8 +87,9 @@ def bind_inventory_completeness_review(
     chunk_index: int,
     source_start_offset: int,
     current_inventory: tuple[BoundClaimInventoryItem, ...],
+    excluded_inventory: tuple[BoundClaimInventoryItem, ...] = (),
 ) -> BoundInventoryCompletenessReview:
-    """Bind missing descriptors and reject claims already in the inventory."""
+    """Bind missing descriptors and reject already adjudicated identities."""
 
     missing_claims = bind_claim_inventory(
         review.missing_claims,
@@ -95,13 +98,15 @@ def bind_inventory_completeness_review(
         chunk_index=chunk_index,
         source_start_offset=source_start_offset,
     )
-    current_ids = {claim.inventory_id for claim in current_inventory}
-    duplicated_ids = current_ids.intersection(
+    adjudicated_ids = {
+        claim.inventory_id for claim in (*current_inventory, *excluded_inventory)
+    }
+    duplicated_ids = adjudicated_ids.intersection(
         claim.inventory_id for claim in missing_claims
     )
     if duplicated_ids:
         raise ClaimInventoryBindingError(
-            "inventory completeness review marked an existing claim as missing",
+            "inventory completeness review repeated an adjudicated claim",
         )
     return BoundInventoryCompletenessReview(
         decision=review.decision,
@@ -110,38 +115,11 @@ def bind_inventory_completeness_review(
     )
 
 
-def require_recovery_matches_review(
-    *,
-    recovered_claims: tuple[BoundClaimInventoryItem, ...],
-    reviewed_missing_claims: tuple[BoundClaimInventoryItem, ...],
-) -> None:
-    """Require recovery to return exactly the claims named by the review agent."""
-
-    recovered_inputs = {
-        claim.inventory_id: claim_inventory_input_sha256(
-            inventory_id=claim.inventory_id,
-            item=claim.item,
-        )
-        for claim in recovered_claims
-    }
-    reviewed_inputs = {
-        claim.inventory_id: claim_inventory_input_sha256(
-            inventory_id=claim.inventory_id,
-            item=claim.item,
-        )
-        for claim in reviewed_missing_claims
-    }
-    if recovered_inputs != reviewed_inputs:
-        raise ClaimInventoryBindingError(
-            "missing-claim recovery did not exactly match the completeness review",
-        )
-
-
 __all__ = [
     "BoundInventoryCompletenessReview",
     "ClaimInventoryCompletenessReview",
     "InventoryCompletenessDecision",
-    "MissingClaimRecoveryResult",
+    "MissingClaimRecoveryDecision",
+    "MissingClaimRecoveryDisposition",
     "bind_inventory_completeness_review",
-    "require_recovery_matches_review",
 ]

--- a/services/artana_evidence_api/document_extraction_support/llm_extraction/claim_inventory.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_extraction/claim_inventory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from typing import Protocol, cast
@@ -17,11 +18,11 @@ from artana_evidence_api.document_extraction_support.claim_frames import (
     ClaimInventoryBindingError,
     ClaimInventoryCompletenessReview,
     ClaimInventoryItem,
-    MissingClaimRecoveryResult,
+    MissingClaimRecoveryDecision,
+    MissingClaimRecoveryDisposition,
     bind_claim_inventory,
     bind_inventory_completeness_review,
     claim_inventory_batch_input_sha256,
-    require_recovery_matches_review,
 )
 from artana_evidence_api.document_extraction_support.full_text_chunking import (
     RelationExtractionTextChunk,
@@ -87,6 +88,15 @@ class InventoryCompletenessStageResult:
     """Source-bound categorical review plus its immutable agent output."""
 
     review: BoundInventoryCompletenessReview
+    raw_agent_outputs: tuple[dict[str, object], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MissingClaimRecoveryStageResult:
+    """Categorical recovery decision bound to one immutable reviewed claim."""
+
+    decision: MissingClaimRecoveryDisposition
+    reviewed_claim: BoundClaimInventoryItem
     raw_agent_outputs: tuple[dict[str, object], ...]
 
 
@@ -230,6 +240,7 @@ def build_inventory_completeness_prompt(
     document_fingerprint: str,
     current_inventory: tuple[BoundClaimInventoryItem, ...],
     confirmation: bool,
+    excluded_inventory: tuple[BoundClaimInventoryItem, ...] = (),
     schema_retry: bool = False,
 ) -> str:
     """Build an independent source-only completeness review prompt."""
@@ -247,6 +258,18 @@ def build_inventory_completeness_prompt(
         separators=(",", ":"),
         ensure_ascii=True,
     )
+    excluded_json = json.dumps(
+        [
+            {
+                "inventory_id": claim.inventory_id,
+                "claim": claim.item.model_dump(mode="json"),
+            }
+            for claim in excluded_inventory
+        ],
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
     phase = "post_recovery_confirmation" if confirmation else "initial_review"
     return (
         f"{CLAIM_INVENTORY_COMPLETENESS_SYSTEM_PROMPT}\n\n"
@@ -259,6 +282,8 @@ def build_inventory_completeness_prompt(
         "- source_locator: normalized_extraction_text\n\n"
         "---\nCOMPLETE RETURNED INVENTORY\n---\n"
         f"{inventory_json}\n"
+        "---\nEXCLUDED REVIEWED ITEMS\n---\n"
+        f"{excluded_json}\n"
         "---\nFROZEN SOURCE CHUNK\n---\n"
         f"{chunk.text}\n"
         "---\n"
@@ -279,6 +304,7 @@ async def run_inventory_completeness_review_stage(
     step_runner: ModelStepRunner,
     execution_namespace: str,
     confirmation: bool = False,
+    excluded_inventory: tuple[BoundClaimInventoryItem, ...] = (),
 ) -> InventoryCompletenessStageResult:
     """Review completeness with one audited schema-repair opportunity."""
 
@@ -287,6 +313,7 @@ async def run_inventory_completeness_review_stage(
         total_chunks=total_chunks,
         document_fingerprint=document_fingerprint,
         current_inventory=current_inventory,
+        excluded_inventory=excluded_inventory,
         confirmation=confirmation,
     )
     phase = "confirmation" if confirmation else "initial"
@@ -295,12 +322,14 @@ async def run_inventory_completeness_review_stage(
         phase=phase,
         chunk=chunk,
         current_inventory=current_inventory,
+        excluded_inventory=excluded_inventory,
         model_id=model_id,
         execution_namespace=execution_namespace,
     )
     audit_context = _inventory_review_audit_context(
         document_fingerprint=document_fingerprint,
         current_inventory=current_inventory,
+        excluded_inventory=excluded_inventory,
         schema_retry=False,
     )
     retry_prompt = build_inventory_completeness_prompt(
@@ -308,6 +337,7 @@ async def run_inventory_completeness_review_stage(
         total_chunks=total_chunks,
         document_fingerprint=document_fingerprint,
         current_inventory=current_inventory,
+        excluded_inventory=excluded_inventory,
         confirmation=confirmation,
         schema_retry=True,
     )
@@ -318,12 +348,14 @@ async def run_inventory_completeness_review_stage(
         phase=phase,
         chunk=chunk,
         current_inventory=current_inventory,
+        excluded_inventory=excluded_inventory,
         model_id=model_id,
         execution_namespace=execution_namespace,
     )
     retry_context = _inventory_review_audit_context(
         document_fingerprint=document_fingerprint,
         current_inventory=current_inventory,
+        excluded_inventory=excluded_inventory,
         schema_retry=True,
     )
     try:
@@ -331,6 +363,7 @@ async def run_inventory_completeness_review_stage(
             chunk=chunk,
             document_fingerprint=document_fingerprint,
             current_inventory=current_inventory,
+            excluded_inventory=excluded_inventory,
             output_schema=output_schema,
             client=client,
             tenant=tenant,
@@ -345,6 +378,7 @@ async def run_inventory_completeness_review_stage(
             chunk=chunk,
             document_fingerprint=document_fingerprint,
             current_inventory=current_inventory,
+            excluded_inventory=excluded_inventory,
             output_schema=output_schema,
             client=client,
             tenant=tenant,
@@ -413,8 +447,8 @@ async def run_missing_claim_recovery_stage(
     model_id: str,
     step_runner: ModelStepRunner,
     execution_namespace: str,
-) -> ClaimInventoryStageResult:
-    """Run exactly one audited recovery call for one reviewed missing claim."""
+) -> MissingClaimRecoveryStageResult:
+    """Adjudicate one reviewed descriptor without allowing span rewrites."""
 
     prompt = build_missing_claim_recovery_prompt(
         chunk=chunk,
@@ -422,7 +456,7 @@ async def run_missing_claim_recovery_stage(
         missing_claim=missing_claim,
     )
     step_key = fingerprinted_step_key(
-        "research_init.claim_inventory_recovery.v3",
+        "research_init.claim_inventory_recovery.v4",
         MISSING_CLAIM_RECOVERY_PROMPT_VERSION,
         model_id,
         document_fingerprint,
@@ -438,23 +472,9 @@ async def run_missing_claim_recovery_stage(
         semantic_unit_id=missing_claim.inventory_id,
     )
 
-    def _bind_recovery(parsed: BaseModel) -> tuple[BoundClaimInventoryItem, ...]:
-        output = cast("MissingClaimRecoveryResult", parsed)
-        try:
-            recovered = bind_claim_inventory(
-                output.claims,
-                source_text=chunk.text,
-                source_sha256=document_fingerprint,
-                chunk_index=chunk.index,
-                source_start_offset=chunk.start_char,
-            )
-            require_recovery_matches_review(
-                recovered_claims=recovered,
-                reviewed_missing_claims=(missing_claim,),
-            )
-        except ClaimInventoryBindingError as exc:
-            raise StructuredModelSemanticError(str(exc)) from exc
-        return recovered
+    def _bind_recovery(parsed: BaseModel) -> MissingClaimRecoveryDisposition:
+        output = cast("MissingClaimRecoveryDecision", parsed)
+        return output.decision
 
     async def _invoke_model(
         invocation_id: str,
@@ -467,7 +487,7 @@ async def run_missing_claim_recovery_stage(
             model=model_id,
             prompt=provider_prompt,
             output_schema=output_schema,
-            schema_id="document_extraction.claim_inventory_recovery.v3",
+            schema_id="document_extraction.claim_inventory_recovery.v4",
             step_key=step_key,
             replay_policy="fork_on_drift",
         )
@@ -481,8 +501,9 @@ async def run_missing_claim_recovery_stage(
         audit_context=audit_context,
         validate_semantics=_bind_recovery,
     )
-    return ClaimInventoryStageResult(
-        claims=result.value,
+    return MissingClaimRecoveryStageResult(
+        decision=result.value,
+        reviewed_claim=missing_claim,
         raw_agent_outputs=(result.raw_output,),
     )
 
@@ -584,6 +605,7 @@ async def _run_inventory_completeness_step(
     chunk: RelationExtractionTextChunk,
     document_fingerprint: str,
     current_inventory: tuple[BoundClaimInventoryItem, ...],
+    excluded_inventory: tuple[BoundClaimInventoryItem, ...],
     output_schema: type[BaseModel],
     client: object,
     tenant: object,
@@ -603,6 +625,7 @@ async def _run_inventory_completeness_step(
                 chunk_index=chunk.index,
                 source_start_offset=chunk.start_char,
                 current_inventory=current_inventory,
+                excluded_inventory=excluded_inventory,
             )
         except ClaimInventoryBindingError as exc:
             raise StructuredModelSemanticError(str(exc)) from exc
@@ -661,6 +684,7 @@ def _inventory_review_step_key(
     phase: str,
     chunk: RelationExtractionTextChunk,
     current_inventory: tuple[BoundClaimInventoryItem, ...],
+    excluded_inventory: tuple[BoundClaimInventoryItem, ...],
     model_id: str,
     execution_namespace: str,
 ) -> str:
@@ -670,7 +694,7 @@ def _inventory_review_step_key(
         phase,
         model_id,
         chunk.sha256,
-        claim_inventory_batch_input_sha256(current_inventory),
+        _inventory_review_input_sha256(current_inventory, excluded_inventory),
         execution_namespace,
     )
 
@@ -679,6 +703,7 @@ def _inventory_review_audit_context(
     *,
     document_fingerprint: str,
     current_inventory: tuple[BoundClaimInventoryItem, ...],
+    excluded_inventory: tuple[BoundClaimInventoryItem, ...],
     schema_retry: bool,
 ) -> ModelAttemptAuditContext:
     return ModelAttemptAuditContext(
@@ -688,9 +713,35 @@ def _inventory_review_audit_context(
         pass_role="claim_inventory_completeness",
         retry_context=None,
         source_sha256=document_fingerprint,
-        input_sha256=claim_inventory_batch_input_sha256(current_inventory),
+        input_sha256=_inventory_review_input_sha256(
+            current_inventory,
+            excluded_inventory,
+        ),
         semantic_unit_id=None,
     )
+
+
+def _inventory_review_input_sha256(
+    current_inventory: tuple[BoundClaimInventoryItem, ...],
+    excluded_inventory: tuple[BoundClaimInventoryItem, ...],
+) -> str:
+    if not excluded_inventory:
+        return claim_inventory_batch_input_sha256(current_inventory)
+    payload = {
+        "current_inventory_ids": [
+            claim.inventory_id for claim in current_inventory
+        ],
+        "excluded_inventory_ids": [
+            claim.inventory_id for claim in excluded_inventory
+        ],
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _inventory_audit_context(
@@ -721,6 +772,7 @@ __all__ = [
     "MISSING_CLAIM_RECOVERY_PROMPT_VERSION",
     "ClaimInventoryStageResult",
     "InventoryCompletenessStageResult",
+    "MissingClaimRecoveryStageResult",
     "build_inventory_completeness_prompt",
     "build_missing_claim_recovery_prompt",
     "build_claim_inventory_prompt",

--- a/services/artana_evidence_api/document_extraction_support/llm_extraction/prompt_versions.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_extraction/prompt_versions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Final
 
-CLAIM_INVENTORY_PROMPT_VERSION: Final = "document_extraction.claim_inventory.v7"
+CLAIM_INVENTORY_PROMPT_VERSION: Final = "document_extraction.claim_inventory.v8"
 CLAIM_INVENTORY_COMPLETENESS_PROMPT_VERSION: Final = (
     "document_extraction.claim_inventory_completeness.v7"
 )
@@ -20,7 +20,7 @@ CLAIM_FRAME_PIPELINE_COMPONENT_PROMPT_VERSIONS: Final = (
     CLAIM_FRAMING_PROMPT_VERSION,
 )
 CLAIM_FRAME_PIPELINE_PROMPT_VERSION: Final = (
-    "document_extraction.claim_pipeline.v10:"
+    "document_extraction.claim_pipeline.v11:"
     + "+".join(
         version.removeprefix("document_extraction.")
         for version in CLAIM_FRAME_PIPELINE_COMPONENT_PROMPT_VERSIONS

--- a/services/artana_evidence_api/document_extraction_support/llm_extraction/prompt_versions.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_extraction/prompt_versions.py
@@ -6,10 +6,10 @@ from typing import Final
 
 CLAIM_INVENTORY_PROMPT_VERSION: Final = "document_extraction.claim_inventory.v7"
 CLAIM_INVENTORY_COMPLETENESS_PROMPT_VERSION: Final = (
-    "document_extraction.claim_inventory_completeness.v6"
+    "document_extraction.claim_inventory_completeness.v7"
 )
 MISSING_CLAIM_RECOVERY_PROMPT_VERSION: Final = (
-    "document_extraction.claim_inventory_recovery.v6"
+    "document_extraction.claim_inventory_recovery.v7"
 )
 CLAIM_FRAMING_PROMPT_VERSION: Final = "document_extraction.claim_framing.v6"
 
@@ -20,7 +20,7 @@ CLAIM_FRAME_PIPELINE_COMPONENT_PROMPT_VERSIONS: Final = (
     CLAIM_FRAMING_PROMPT_VERSION,
 )
 CLAIM_FRAME_PIPELINE_PROMPT_VERSION: Final = (
-    "document_extraction.claim_pipeline.v9:"
+    "document_extraction.claim_pipeline.v10:"
     + "+".join(
         version.removeprefix("document_extraction.")
         for version in CLAIM_FRAME_PIPELINE_COMPONENT_PROMPT_VERSIONS

--- a/services/artana_evidence_api/document_extraction_support/llm_extraction/runner.py
+++ b/services/artana_evidence_api/document_extraction_support/llm_extraction/runner.py
@@ -17,6 +17,7 @@ from artana_evidence_api.document_extraction_prompting import (
 from artana_evidence_api.document_extraction_support.claim_frames import (
     BoundClaimInventoryItem,
     InventoryCompletenessDecision,
+    MissingClaimRecoveryDisposition,
     coalesce_long_sentence_chunks,
     merge_bound_claim_inventories,
 )
@@ -359,6 +360,8 @@ async def _inventory_chunk_with_recovery(
         )
 
     recovered_claims: tuple[BoundClaimInventoryItem, ...] = ()
+    excluded_claims: tuple[BoundClaimInventoryItem, ...] = ()
+    unresolved_recovery_claims: tuple[BoundClaimInventoryItem, ...] = ()
     for missing_claim in review_result.review.missing_claims:
         recovery_result = await run_missing_claim_recovery_stage(
             chunk=chunk,
@@ -371,11 +374,28 @@ async def _inventory_chunk_with_recovery(
             step_runner=step_runner,
             execution_namespace=execution_namespace,
         )
-        recovered_claims = merge_bound_claim_inventories(
-            recovered_claims,
-            recovery_result.claims,
-        )
         raw_outputs.extend(recovery_result.raw_agent_outputs)
+        if (
+            recovery_result.decision
+            is MissingClaimRecoveryDisposition.RECOVER_EXPLICIT_CLAIM
+        ):
+            recovered_claims = merge_bound_claim_inventories(
+                recovered_claims,
+                (recovery_result.reviewed_claim,),
+            )
+        elif recovery_result.decision in {
+            MissingClaimRecoveryDisposition.EXCLUDE_PROCEDURAL_METHOD,
+            MissingClaimRecoveryDisposition.EXCLUDE_NOT_EXPLICIT,
+        }:
+            excluded_claims = merge_bound_claim_inventories(
+                excluded_claims,
+                (recovery_result.reviewed_claim,),
+            )
+        else:
+            unresolved_recovery_claims = merge_bound_claim_inventories(
+                unresolved_recovery_claims,
+                (recovery_result.reviewed_claim,),
+            )
 
     combined_inventory = merge_bound_claim_inventories(
         inventory_claims,
@@ -393,12 +413,17 @@ async def _inventory_chunk_with_recovery(
         step_runner=step_runner,
         execution_namespace=execution_namespace,
         confirmation=True,
+        excluded_inventory=excluded_claims,
     )
     raw_outputs.extend(confirmation.raw_agent_outputs)
-    unresolved = (
+    confirmation_missing = (
         ()
         if confirmation.review.decision is InventoryCompletenessDecision.COMPLETE
         else confirmation.review.missing_claims
+    )
+    unresolved = merge_bound_claim_inventories(
+        unresolved_recovery_claims,
+        confirmation_missing,
     )
     return _ChunkInventoryOutcome(
         claims=combined_inventory,

--- a/services/artana_evidence_api/runtime/agent_output_manifest.py
+++ b/services/artana_evidence_api/runtime/agent_output_manifest.py
@@ -536,7 +536,7 @@ _POLICIES = (
         producer_paths=(
             "document_extraction_support/llm_extraction/claim_inventory.py",
         ),
-        prompt_identifiers=("document_extraction.claim_inventory_completeness.v6",),
+        prompt_identifiers=("document_extraction.claim_inventory_completeness.v7",),
         categorical_fields=(
             _category(
                 "$.decision",
@@ -585,49 +585,25 @@ _POLICIES = (
         ),
     ),
     AgentOutputSchemaPolicy(
-        schema_id="document_extraction.claim_inventory_recovery.v3",
-        schema_names=("MissingClaimRecoveryResult",),
-        shape_hash="ffdc56f2350b801840891aa82eef0f4d51abaee21a6900f8b4ba0d83dc932601",
+        schema_id="document_extraction.claim_inventory_recovery.v4",
+        schema_names=("MissingClaimRecoveryDecision",),
+        shape_hash="a97e2bcfe7ac51a317407f5e59f5ba66bbd575546fe491ebc4dbf51cd220d33f",
         producer_paths=(
             "document_extraction_support/llm_extraction/claim_inventory.py",
         ),
-        prompt_identifiers=("document_extraction.claim_inventory_recovery.v6",),
+        prompt_identifiers=("document_extraction.claim_inventory_recovery.v7",),
         categorical_fields=(
             _category(
-                "$.claims[].source_locator",
+                "$.decision",
                 {
-                    "normalized_extraction_text": (
-                        "the recovered missing claim binds to the frozen normalized source chunk."
-                    ),
+                    "RECOVER_EXPLICIT_CLAIM": "the reviewed descriptor is an explicit source-supported biomedical claim.",
+                    "EXCLUDE_PROCEDURAL_METHOD": "the reviewed descriptor is procedural metadata without a biomedical relationship or result.",
+                    "EXCLUDE_NOT_EXPLICIT": "the reviewed descriptor adds meaning not explicit in the frozen source.",
+                    "ABSTAIN": "the source does not support a safe categorical adjudication.",
                 },
                 evidence_requirement=(
-                    "Every recovered span must exactly match the reviewed missing descriptor."
+                    "The decision must use only the frozen source and the reviewed source-bound descriptor."
                 ),
-            ),
-            _category(
-                "$.claims[].arguments[].role",
-                _CLAIM_ARGUMENT_ROLE,
-                evidence_requirement="The recovered claim must preserve every reviewed argument role.",
-            ),
-            _category(
-                "$.claims[].arguments[].event_role",
-                _CLAIM_EVENT_ROLE,
-                evidence_requirement="The recovered claim must preserve every reviewed event role.",
-            ),
-            _category(
-                "$.claims[].event_type",
-                _CLAIM_EVENT_TYPE,
-                evidence_requirement="The recovered claim must preserve reviewed event semantics.",
-            ),
-            _category(
-                "$.claims[].polarity",
-                _CLAIM_POLARITY,
-                evidence_requirement="The recovered claim must preserve reviewed direction.",
-            ),
-            _category(
-                "$.claims[].epistemic_status",
-                _CLAIM_EPISTEMIC_STATUS,
-                evidence_requirement="The recovered claim must preserve reviewed status.",
             ),
         ),
     ),

--- a/services/artana_evidence_api/runtime/agent_output_manifest.py
+++ b/services/artana_evidence_api/runtime/agent_output_manifest.py
@@ -479,7 +479,7 @@ _POLICIES = (
         producer_paths=(
             "document_extraction_support/llm_extraction/claim_inventory.py",
         ),
-        prompt_identifiers=("document_extraction.claim_inventory.v7",),
+        prompt_identifiers=("document_extraction.claim_inventory.v8",),
         categorical_fields=(
             _category(
                 "$.claims[].source_locator",

--- a/services/artana_evidence_api/tests/unit/test_agent_output_schema_registry.py
+++ b/services/artana_evidence_api/tests/unit/test_agent_output_schema_registry.py
@@ -365,7 +365,7 @@ def test_production_manifest_covers_current_model_output_schemas() -> None:
         "document_extraction.claim_inventory_completeness.v3": (
             build_claim_inventory_completeness_output_schema()
         ),
-        "document_extraction.claim_inventory_recovery.v3": (
+        "document_extraction.claim_inventory_recovery.v4": (
             build_missing_claim_recovery_output_schema()
         ),
         "document_extraction.claim_framing.v2": (
@@ -412,7 +412,6 @@ def test_inventory_schema_registry_governs_closed_event_type() -> None:
     from artana_evidence_api.document_extraction_prompting import (
         build_claim_inventory_completeness_output_schema,
         build_claim_inventory_output_schema,
-        build_missing_claim_recovery_output_schema,
     )
     from artana_evidence_api.document_extraction_support.claim_frames import (
         ClaimEventType,
@@ -428,11 +427,6 @@ def test_inventory_schema_registry_governs_closed_event_type() -> None:
             "document_extraction.claim_inventory_completeness.v3",
             build_claim_inventory_completeness_output_schema(),
             "$.missing_claims[].event_type",
-        ),
-        (
-            "document_extraction.claim_inventory_recovery.v3",
-            build_missing_claim_recovery_output_schema(),
-            "$.claims[].event_type",
         ),
     )
     expected_values = {event_type.value for event_type in ClaimEventType}
@@ -452,7 +446,6 @@ def test_inventory_schema_registry_governs_closed_event_role() -> None:
     from artana_evidence_api.document_extraction_prompting import (
         build_claim_inventory_completeness_output_schema,
         build_claim_inventory_output_schema,
-        build_missing_claim_recovery_output_schema,
     )
     from artana_evidence_api.document_extraction_support.claim_frames import (
         ClaimEventRole,
@@ -469,11 +462,6 @@ def test_inventory_schema_registry_governs_closed_event_role() -> None:
             build_claim_inventory_completeness_output_schema(),
             "$.missing_claims[].arguments[].event_role",
         ),
-        (
-            "document_extraction.claim_inventory_recovery.v3",
-            build_missing_claim_recovery_output_schema(),
-            "$.claims[].arguments[].event_role",
-        ),
     )
     expected_values = {role.value for role in ClaimEventRole}
 
@@ -486,6 +474,27 @@ def test_inventory_schema_registry_governs_closed_event_role() -> None:
             field for field in policy.categorical_fields if field.path == event_path
         )
         assert {value.value for value in event_policy.values} == expected_values
+
+
+def test_recovery_schema_registry_governs_categorical_adjudication() -> None:
+    from artana_evidence_api.document_extraction_prompting import (
+        build_missing_claim_recovery_output_schema,
+    )
+
+    policy = AGENT_OUTPUT_SCHEMA_REGISTRY.validate(
+        schema_id="document_extraction.claim_inventory_recovery.v4",
+        output_schema=build_missing_claim_recovery_output_schema(),
+    )
+    decision_policy = next(
+        field for field in policy.categorical_fields if field.path == "$.decision"
+    )
+
+    assert {value.value for value in decision_policy.values} == {
+        "RECOVER_EXPLICIT_CLAIM",
+        "EXCLUDE_PROCEDURAL_METHOD",
+        "EXCLUDE_NOT_EXPLICIT",
+        "ABSTAIN",
+    }
 
 
 def test_registry_report_exposes_merge_gate_counts() -> None:

--- a/services/artana_evidence_api/tests/unit/test_claim_inventory_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_claim_inventory_extraction.py
@@ -124,6 +124,15 @@ def test_inventory_prompt_requires_verbatim_context_not_numeric_offsets() -> Non
     assert "never return offsets or numeric positions" in normalized_prompt
 
 
+def test_inventory_prompt_excludes_procedural_metadata_without_keyword_filtering() -> None:
+    normalized_prompt = CLAIM_INVENTORY_SYSTEM_PROMPT.casefold()
+
+    assert "only identifies primers, probes, reagents" in normalized_prompt
+    assert "without stating a biological relationship or result" in normalized_prompt
+    assert "methods sentence can still qualify" in normalized_prompt
+    assert "classify the source meaning" in normalized_prompt
+
+
 def test_single_claim_prompt_does_not_inherit_multi_relation_ranking() -> None:
     normalized_prompt = SINGLE_CLAIM_FRAMING_SYSTEM_PROMPT.casefold()
 
@@ -134,7 +143,7 @@ def test_single_claim_prompt_does_not_inherit_multi_relation_ranking() -> None:
     assert "up to 10" not in normalized_prompt
     assert "strongest, most specific relationships" not in normalized_prompt
     assert CLAIM_FRAME_PIPELINE_PROMPT_VERSION == (
-        "document_extraction.claim_pipeline.v10:claim_inventory.v7+"
+        "document_extraction.claim_pipeline.v11:claim_inventory.v8+"
         "claim_inventory_completeness.v7+claim_inventory_recovery.v7+"
         "claim_framing.v6"
     )

--- a/services/artana_evidence_api/tests/unit/test_claim_inventory_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_claim_inventory_extraction.py
@@ -25,6 +25,7 @@ from artana_evidence_api.document_extraction_prompting import (
     CLAIM_INVENTORY_SYSTEM_PROMPT,
     MISSING_CLAIM_RECOVERY_SYSTEM_PROMPT,
     SINGLE_CLAIM_FRAMING_SYSTEM_PROMPT,
+    build_missing_claim_recovery_output_schema,
     build_single_claim_framing_output_schema,
 )
 from artana_evidence_api.document_extraction_support.claim_frames import (
@@ -133,8 +134,8 @@ def test_single_claim_prompt_does_not_inherit_multi_relation_ranking() -> None:
     assert "up to 10" not in normalized_prompt
     assert "strongest, most specific relationships" not in normalized_prompt
     assert CLAIM_FRAME_PIPELINE_PROMPT_VERSION == (
-        "document_extraction.claim_pipeline.v9:claim_inventory.v7+"
-        "claim_inventory_completeness.v6+claim_inventory_recovery.v6+"
+        "document_extraction.claim_pipeline.v10:claim_inventory.v7+"
+        "claim_inventory_completeness.v7+claim_inventory_recovery.v7+"
         "claim_framing.v6"
     )
 
@@ -162,11 +163,31 @@ def test_claim_event_type_is_closed_and_required_across_inventory_prompts() -> N
     for prompt in (
         CLAIM_INVENTORY_SYSTEM_PROMPT,
         CLAIM_INVENTORY_COMPLETENESS_SYSTEM_PROMPT,
-        MISSING_CLAIM_RECOVERY_SYSTEM_PROMPT,
     ):
         assert "event_type" in prompt
         assert "event_role" in prompt or "event roles" in prompt
         assert all(value in prompt for value in expected_values)
+
+
+def test_missing_claim_recovery_is_categorical_and_score_free() -> None:
+    schema = build_missing_claim_recovery_output_schema()
+    prompt = MISSING_CLAIM_RECOVERY_SYSTEM_PROMPT
+
+    assert {
+        "RECOVER_EXPLICIT_CLAIM",
+        "EXCLUDE_PROCEDURAL_METHOD",
+        "EXCLUDE_NOT_EXPLICIT",
+        "ABSTAIN",
+    }.issubset(prompt.split())
+    assert "do not rewrite the descriptor" in prompt.casefold()
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        schema.model_validate(
+            {
+                "decision": "RECOVER_EXPLICIT_CLAIM",
+                "decision_rationale": "The source states a treatment effect.",
+                "confidence": 0.99,
+            },
+        )
 
 
 def test_multi_frame_decision_requires_multiple_candidate_relations() -> None:
@@ -205,6 +226,13 @@ def _incomplete_inventory(
         "decision": "INCOMPLETE",
         "missing_claims": list(missing_claims),
         "review_rationale": "The returned inventory omitted an explicit claim.",
+    }
+
+
+def _recovery_decision(decision: str) -> dict[str, object]:
+    return {
+        "decision": decision,
+        "decision_rationale": "The frozen source supports this category.",
     }
 
 
@@ -1430,7 +1458,7 @@ async def test_missing_claim_recovery_is_single_attempt_and_fails_closed() -> No
     )
     audit_session = start_model_attempt_audit()
     try:
-        with pytest.raises(StructuredModelSemanticError):
+        with pytest.raises(ValidationError):
             await _run_pipeline(text=text, runner=runner)
     finally:
         stop_model_attempt_audit(audit_session)
@@ -1438,10 +1466,10 @@ async def test_missing_claim_recovery_is_single_attempt_and_fails_closed() -> No
     recovery_records = [
         record
         for record in audit_session.records
-        if "MissingClaimRecoveryResult" in record.output_schema_identity
+        if "MissingClaimRecoveryDecision" in record.output_schema_identity
     ]
     assert len(recovery_records) == 1
-    assert recovery_records[0].validation_outcome == "semantic_invalid"
+    assert recovery_records[0].validation_outcome == "schema_invalid"
     assert recovery_records[0].semantic_unit_id is not None
     assert not any(
         record.pass_role == "claim_framing" for record in audit_session.records
@@ -1469,7 +1497,7 @@ async def test_partial_inventory_gets_reviewed_missing_only_recovery() -> None:
         (
             {"claims": [first_claim]},
             _incomplete_inventory(second_claim),
-            {"claims": [second_claim]},
+            _recovery_decision("RECOVER_EXPLICIT_CLAIM"),
             _complete_inventory(),
             _framed_relation(
                 sentence=first_span,
@@ -1496,7 +1524,7 @@ async def test_partial_inventory_gets_reviewed_missing_only_recovery() -> None:
     recovery_record = next(
         record
         for record in result.model_attempt_records
-        if "MissingClaimRecoveryResult" in record.output_schema_identity
+        if "MissingClaimRecoveryDecision" in record.output_schema_identity
     )
     recovered_lineage = next(
         lineage
@@ -1509,6 +1537,120 @@ async def test_partial_inventory_gets_reviewed_missing_only_recovery() -> None:
     assert not any(
         record.attempt_role in {"primary", "weak_review"}
         for record in result.model_attempt_records
+    )
+
+
+@pytest.mark.asyncio
+async def test_procedural_method_is_categorically_excluded_from_recovery() -> None:
+    text = "Primers and probes were provided by Assay-on-Demand (Applied Biosystems)."
+    procedural_descriptor = _inventory_claim(
+        exact_span=text,
+        endpoint_a_span="Primers and probes",
+        relation_cue_span="provided by",
+        endpoint_b_span="Assay-on-Demand (Applied Biosystems)",
+        event_type="OTHER_EXPLICIT",
+    )
+    runner = ScriptedStepRunner(
+        (
+            {"claims": []},
+            {"claims": []},
+            _incomplete_inventory(procedural_descriptor),
+            _recovery_decision("EXCLUDE_PROCEDURAL_METHOD"),
+            _complete_inventory(),
+        ),
+    )
+
+    result = await _run_inventory(text=text, runner=runner)
+
+    assert result.claims == ()
+    assert result.semantic_inventory_complete is True
+    assert result.inventory_incompleteness == ()
+    recovery_record = next(
+        record
+        for record in result.model_attempt_records
+        if "MissingClaimRecoveryDecision" in record.output_schema_identity
+    )
+    assert recovery_record.validation_outcome == "accepted"
+    assert recovery_record.raw_model_payload == _recovery_decision(
+        "EXCLUDE_PROCEDURAL_METHOD",
+    )
+    confirmation_prompt = cast("str", runner.calls[-1]["prompt"])
+    assert "EXCLUDED REVIEWED ITEMS" in confirmation_prompt
+    assert "Primers and probes" in confirmation_prompt
+
+
+@pytest.mark.asyncio
+async def test_recovery_reuses_reviewed_claim_without_rewriting_anchors() -> None:
+    text = "WT1 in fibroblasts and WT1 in lymphocytes suggests regulation."
+    reviewed_descriptor = _inventory_claim(
+        exact_span=text,
+        endpoint_a_span="WT1",
+        relation_cue_span="suggests",
+        endpoint_b_span="regulation",
+    )
+    first_argument = cast("list[dict[str, object]]", reviewed_descriptor["arguments"])[
+        0
+    ]
+    first_argument["mention_anchors"] = [
+        {
+            "mention_span": "WT1",
+            "left_context": "",
+            "right_context": " in fibroblasts",
+        },
+        {
+            "mention_span": "WT1",
+            "left_context": " and ",
+            "right_context": " in lymphocytes",
+        },
+    ]
+    runner = ScriptedStepRunner(
+        (
+            {"claims": []},
+            {"claims": []},
+            _incomplete_inventory(reviewed_descriptor),
+            _recovery_decision("RECOVER_EXPLICIT_CLAIM"),
+            _complete_inventory(),
+        ),
+    )
+
+    result = await _run_inventory(text=text, runner=runner)
+
+    assert len(result.claims) == 1
+    assert result.claims[0].item == ClaimInventoryItem.model_validate(
+        reviewed_descriptor,
+    )
+    assert len(result.claims[0].item.arguments[0].mention_anchors) == 2
+    assert result.semantic_inventory_complete is True
+
+
+@pytest.mark.asyncio
+async def test_recovery_abstention_remains_semantically_incomplete() -> None:
+    text = "MED13 may affect a cardiac phenotype."
+    descriptor = _inventory_claim(
+        exact_span=text,
+        endpoint_a_span="MED13",
+        relation_cue_span="may affect",
+        endpoint_b_span="cardiac phenotype",
+        polarity="UNCERTAIN",
+        epistemic_status="UNCERTAIN",
+    )
+    runner = ScriptedStepRunner(
+        (
+            {"claims": []},
+            {"claims": []},
+            _incomplete_inventory(descriptor),
+            _recovery_decision("ABSTAIN"),
+            _complete_inventory(),
+        ),
+    )
+
+    result = await _run_inventory(text=text, runner=runner)
+
+    assert result.claims == ()
+    assert result.semantic_inventory_complete is False
+    assert len(result.inventory_incompleteness) == 1
+    assert result.inventory_incompleteness[0].item == ClaimInventoryItem.model_validate(
+        descriptor,
     )
 
 
@@ -1915,7 +2057,7 @@ async def test_post_recovery_incomplete_inventory_fails_closed_with_lineage(
         (
             {"claims": [first]},
             _incomplete_inventory(second),
-            {"claims": [second]},
+            _recovery_decision("RECOVER_EXPLICIT_CLAIM"),
             _incomplete_inventory(third),
             _framed_relation(
                 sentence=first_span,

--- a/services/artana_evidence_api/tests/unit/test_claim_mention_binding.py
+++ b/services/artana_evidence_api/tests/unit/test_claim_mention_binding.py
@@ -13,7 +13,6 @@ from artana_evidence_api.document_extraction_support.claim_frames import (
     claim_inventory_batch_input_sha256,
     claim_inventory_identity,
     claim_inventory_input_sha256,
-    require_recovery_matches_review,
 )
 from pydantic import ValidationError
 
@@ -395,48 +394,4 @@ def test_duplicate_semantic_claims_cannot_hide_different_mention_payloads() -> N
             source_text=text,
             source_sha256=source_sha256,
             chunk_index=0,
-        )
-
-
-def test_recovery_must_preserve_reviewed_mention_payload() -> None:
-    text = "WT1 in fibroblasts and WT1 in lymphocytes suggests regulation."
-    source_sha256 = hashlib.sha256(text.encode()).hexdigest()
-    reviewed, recovered = (
-        bind_claim_inventory(
-            (
-                _inventory_item(
-                    text=text,
-                    cue="suggests",
-                    first_argument={
-                        "role": "GENE_OR_PROTEIN",
-                        "event_role": "THEME",
-                        "exact_span": "WT1",
-                        "mention_anchors": [anchor],
-                        "role_rationale": "WT1 is the semantic participant.",
-                    },
-                    second_span="regulation",
-                ),
-            ),
-            source_text=text,
-            source_sha256=source_sha256,
-            chunk_index=0,
-        )[0]
-        for anchor in (
-            {
-                "mention_span": "WT1",
-                "left_context": "",
-                "right_context": " in fibroblasts",
-            },
-            {
-                "mention_span": "WT1",
-                "left_context": " and ",
-                "right_context": " in lymphocytes",
-            },
-        )
-    )
-
-    with pytest.raises(ClaimInventoryBindingError, match="exactly match"):
-        require_recovery_matches_review(
-            recovered_claims=(recovered,),
-            reviewed_missing_claims=(reviewed,),
         )


### PR DESCRIPTION
## Stack

Stacked on #164. Review and merge after the provider-custody integration lands.

## Root cause

The prior recovery stage asked a second agent to reproduce an already source-bound claim object. In the Luna smoke run, the completeness agent misclassified procedural methods metadata as a missing scientific claim, and the recovery agent then changed an exact mention anchor. Source binding correctly rejected the mutation, but the run could not complete.

## Changes

- replace model-authored recovery payloads with one closed categorical decision: `RECOVER_EXPLICIT_CLAIM`, `EXCLUDE_PROCEDURAL_METHOD`, `EXCLUDE_NOT_EXPLICIT`, or `ABSTAIN`
- require a source-only written rationale and forbid numeric model scores or additional fields
- deterministically reuse the already-bound completeness descriptor after `RECOVER_EXPLICIT_CLAIM`, so recovery cannot rewrite spans, arguments, anchors, event type, polarity, or epistemic status
- keep `ABSTAIN` semantically incomplete and fail closed
- pass categorically excluded descriptors into the independent confirmation review and reject attempts to report an already adjudicated identity again
- explicitly distinguish procedural metadata from biological interventions, mechanisms, comparisons, and results in the agent prompts
- bump prompt/schema identities and regenerate the governed agent-output registry artifact

## Scientific safeguards

This does not add keyword filtering or deterministic biomedical classification. The agent returns a categorical semantic judgment with an explanation; deterministic code applies the category and preserves source provenance. Recovery-dependent output still cannot qualify the frozen TG-04 primary-pass benchmark.

## Validation

- 112 focused inventory, custody, schema-governance, mention-binding, and TG-04 tests passed
- new regressions cover the exact Assay-on-Demand procedural sentence, immutable repeated-mention anchors, categorical abstention, and rejection of the retired model-authored payload shape
- strict Evidence API lint and mypy passed
- agent-output boundary and generated registry checks passed
- full `make artana-evidence-api-service-checks` passed against a freshly migrated ephemeral PostgreSQL database
- all repository pre-commit hooks passed

## Next evidence step

After #164 and this PR are merged, rerun the exact frozen 40-case Luna arm under a new immutable run ID. Report operational completion separately from TG-04 scientific qualification; any recovery-dependent case remains non-qualifying by protocol.

## Live evidence

A preliminary full 40-case Luna smoke on commit `35fc7389` completed and produced immutable local report `tg04-luna-scientific-recovery-smoke-01` (`report_sha256=cee4f538ace6a23189544abf480cb857bf4d91ac6fdc47d96aa4c78cf2a6d1dc`). It receives no qualification credit: 31 cases were unbindable, 68 agent outputs were invalid, whole-event precision/recall were 0, and all 93 provider receipts mismatched because retrieved Responses lacked the expected output-schema metadata. Crucially, that run showed the primary inventory still included the exact procedural sentence, so it exposed an incomplete fix rather than validating this PR.

Commit `4e4c2c85` corrected the primary inventory prompt and bumped its immutable identity. A live Luna rerun of the exact Methods case then completed with `procedural_sentence_present=false`, two accepted claims, four categorical recovery decisions, zero invalid attempts, and complete routing. This targeted diagnostic proves the named regression but is not a provider-receipt-verified benchmark arm and does not establish TG-04 qualification.

Do not launch the six-run matrix yet. The next independent blockers are Luna polarity/epistemic contract discipline and provider receipt reconstruction (`output_schema_missing`).