### PR TITLE
feat: preserve and adjudicate non-lossy evidence claims

### DIFF
--- a/docs/validation/reports/2026-07-11-pr-semantic-pr3-agent-output-registry.json
+++ b/docs/validation/reports/2026-07-11-pr-semantic-pr3-agent-output-registry.json
@@ -3,10 +3,60 @@
   "debt_manifest": [],
   "debt_numeric_field_count": 0,
   "origin_governed_numeric_field_count": 3,
-  "registered_category_field_count": 113,
+  "registered_category_field_count": 116,
   "registered_numeric_field_count": 3,
-  "registered_schema_count": 19,
+  "registered_schema_count": 20,
   "registered_schemas": [
+    {
+      "categorical_fields": [
+        {
+          "allow_schema_subset": false,
+          "debt_id": null,
+          "path": "$.decisions[].atomicity",
+          "values": [
+            "ATOMIC",
+            "BUNDLED",
+            "ABSTAIN"
+          ]
+        },
+        {
+          "allow_schema_subset": false,
+          "debt_id": null,
+          "path": "$.decisions[].source_support",
+          "values": [
+            "ENTAILED",
+            "CONTRADICTED",
+            "INSUFFICIENT",
+            "ABSTAIN"
+          ]
+        },
+        {
+          "allow_schema_subset": false,
+          "debt_id": null,
+          "path": "$.decisions[].relationship",
+          "values": [
+            "CANONICAL",
+            "SAME_AS",
+            "REFINES",
+            "GENERALIZES",
+            "CONTRADICTS",
+            "ABSTAIN"
+          ]
+        }
+      ],
+      "numeric_fields": [],
+      "producer_paths": [
+        "document_extraction_support/claim_adjudication/service.py"
+      ],
+      "prompt_identifiers": [
+        "document_extraction.claim_adjudication.v1"
+      ],
+      "schema_id": "document_extraction.claim_adjudication.v1",
+      "schema_names": [
+        "ClaimAdjudicationOutput"
+      ],
+      "shape_hash": "fca1813bd051bf51168f278950c2a2345e740cc01e464838300c12dc4d77da78"
+    },
     {
       "categorical_fields": [
         {

--- a/docs/validation/tg04-nonlossy-claim-normalization-remediation.md
+++ b/docs/validation/tg04-nonlossy-claim-normalization-remediation.md
@@ -1,0 +1,163 @@
+# TG-04 Non-Lossy Claim Normalization Remediation
+
+Created: 2026-07-17
+
+Status: implemented on `alvaro/tg04-nonlossy-claim-normalization`, stacked on
+the bounded-convergence TG-04 work.
+
+## Problem
+
+The frozen TG-04 benchmark and the product answer different questions:
+
+- the benchmark asks whether Artana recovered a finite, predeclared set of
+  complete scientific events;
+- the product asks an agent to discover scientifically meaningful claims and
+  then normalize their entities, relations, and aliases.
+
+The dictionary can normalize two surface forms to the same concept. It cannot
+decide that two claims have the same scientific meaning, that one is more
+specific, or that a novel hypothesis should be discarded. Those decisions
+require semantic adjudication with the source in view.
+
+The previous semantic-incompleteness route returned no visible candidates. It
+correctly blocked benchmark credit, but it also hid source-bound discoveries
+from human review. This confused **not benchmark-qualified** with **not useful**.
+
+## Implemented Flow
+
+```text
+source document
+  -> agent event inventory
+  -> exact-span and typed-role binding
+  -> dictionary/entity resolution and governed concept proposals
+  -> non-lossy candidate drafts
+  -> independent categorical claim adjudication
+  -> deterministic review-only or promotion-eligible routing
+  -> existing relevance review
+  -> proposal persistence
+```
+
+The implementation preserves these independent facts:
+
+1. **Inventory completeness:** did the bounded extraction task converge?
+2. **Source support:** is the individual claim entailed, contradicted,
+   insufficient, or should the adjudicator abstain?
+3. **Claim atomicity:** is the claim atomic, bundled, or unresolved?
+4. **Claim relationship:** is it canonical, the same as an earlier claim, a
+   refinement, a generalization, a contradiction, or unresolved?
+5. **Dictionary identity:** can the entities and aliases be resolved to
+   governed concepts?
+
+No one answer overwrites another.
+
+## Safety Rules
+
+- A semantically incomplete inventory preserves its bound candidates as
+  `review_only`; it never receives scored benchmark credit or automatic trust.
+- Unresolved missing-claim descriptors remain diagnostics. They are not
+  converted into executable graph claims.
+- The adjudication agent returns closed categories, exact source spans,
+  reasoning, and a falsification condition. It does not return numeric scores.
+- Code deterministically computes counts and applies score ceilings.
+- A claim is promotion-eligible only when it is atomic, source-entailed,
+  canonical, independently agent-verified, and already satisfies the existing
+  entity, provenance, variant, and relation-governance gates.
+- Same-as, refinement, generalization, and contradiction findings are stored
+  as review-only relation proposals with stable target lineage.
+- Missing, invalid, incomplete, or unavailable adjudication fails closed and
+  leaves every affected claim review-only.
+- No deterministic semantic fallback is credited as agent evidence.
+
+## Deterministic Measurements
+
+The agent authors categorical artifacts. Code derives:
+
+- total, atomic, and bundled claim counts;
+- source-entailed, contradicted, insufficient, and abstained counts;
+- canonical, same-as, refining, generalizing, and contradicting counts;
+- review-only event count for semantically incomplete TG-04 runs.
+
+No adjudication metric is named or interpreted as promotion eligibility. That
+decision requires the complete deterministic promotion preflight, entity
+resolution, provenance, and graph-governance context.
+
+Scientific precision and recall still require a frozen independent reference
+set. Preserved review-only discoveries are reported separately and are not
+silently counted as false positives or true positives. A future expert or
+source-only adjudication may classify an unmatched discovery as valid outside
+the gold set, invalid, duplicated, or unresolved without changing the frozen
+benchmark labels.
+
+## Code Boundaries
+
+- `document_extraction_support/claim_adjudication/contracts.py`: closed
+  categorical contracts.
+- `document_extraction_support/claim_adjudication/service.py`: independent
+  source-only agent invocation, validation, fail-closed routing, and semantic
+  relation proposals.
+- `document_extraction_support/claim_adjudication/metrics.py`: deterministic
+  counts only.
+- `document_extraction_support/claim_adjudication/candidate_preservation.py`:
+  non-lossy review routing for deterministically pruned candidates.
+- `document_extraction.py`: non-lossy routing for incomplete inventories.
+- `routers/documents.py`: interactive document extraction integration.
+- `research_init_document_extraction_runtime.py`: research-init integration.
+- `promotion_policy.py`: deterministic promotion gate.
+- `scripts/validation/claim_events/runner.py`: separates scored events from
+  review-only events.
+- `scripts/validation/claim_events/evidence_binding.py`: independently replays
+  and verifies review-only event lineage.
+
+## Merge Validation
+
+Required before merge:
+
+- focused unit and regression tests for extraction, adjudication, promotion,
+  API integration, and TG-04 evidence replay;
+- Evidence API lint, strict type check, boundary check, contract check, and
+  full service test suite;
+- repository `make service-checks`;
+- adversarial review that attempts unknown targets, fabricated spans, partial
+  coverage, numeric model judgments, semantic fallback credit, and promotion
+  from incomplete inventories;
+- live GitHub review-thread, approval, conflict, and required-check inspection.
+
+### Local evidence
+
+Validated on 2026-07-17:
+
+- focused extraction, adjudication, promotion, and TG-04 replay suite: green;
+- Evidence API lint and strict mypy over 612 production modules: green;
+- agent-output schema registry and boundary validation: green;
+- OpenAPI, service boundary, architecture-size, and architecture-structure
+  checks: green;
+- repository `make service-checks`: green with `87.47%` measured coverage;
+- fresh ephemeral PostgreSQL migrations and full service tests: green.
+
+Three adversarial review rounds found and closed these gaps:
+
+- deterministic pruning and candidate overflow could hide claims before agent
+  adjudication;
+- evidence spans could come from another claim in the same document;
+- an empty review-only list could bypass preservation comparison;
+- later relevance review could overwrite adjudication score ceilings;
+- a categorical count was misleadingly named as promotion eligibility;
+- research-init discarded document-level adjudication diagnostics;
+- quality-filter many-to-one repair could break source-order reconstruction;
+- an unbounded adjudication prompt could fail all overflow candidates;
+- a batch could target an earlier claim absent from its bounded context.
+
+The final design preserves stable per-input lineage, uses source-order batches of
+at most 12 claims with at most 24 visible prior targets, and rejects relations
+to claims outside the actual adjudication context.
+
+## Stop/Go Decision
+
+This remediation improves information preservation and promotion safety. It
+does not by itself prove scientific accuracy.
+
+Continue to a larger run only when the small frozen sample shows at least one
+exact whole-event recovery and no safety regression. If exact recovery remains
+zero, stop prompt-loop expansion and compare the finite source-unit task with
+an expert-seeded or hybrid candidate workflow. Do not enable trusted graph
+promotion from review-only discoveries.

--- a/scripts/validation/claim_events/evidence_binding.py
+++ b/scripts/validation/claim_events/evidence_binding.py
@@ -190,6 +190,23 @@ def bind_semantically_incomplete_case_evidence(
         require_complete=False,
     )
     _validate_convergence_diagnostics(diagnostics, replay.workflow)
+    review_only_events = _sequence(
+        prediction.get("review_only_events", ()),
+        "review-only prediction events",
+    )
+    review_inventory = _validate_predictions(
+        prediction={"events": review_only_events},
+        context=_PredictionValidationContext(
+            normalized_source=replay.normalized_source,
+            source_sha256=replay.source_sha256,
+        ),
+    )
+    if review_inventory != replay.workflow.accepted_inventory:
+        raise ValueError(
+            "TG-04 review-only events differ from accepted inventory claims"
+        )
+    if diagnostics.get("review_only_event_count") != len(review_only_events):
+        raise ValueError("TG-04 review-only event count is not deterministic")
     return replay.expectations, replay.workflow.topology_sha256
 
 
@@ -223,13 +240,11 @@ def _replay_case_inventory(
         reported_rejection_events
     ):
         raise ValueError("TG-04 binding rejection count differs from evidence")
-    inventory_rejections, completeness_rejections = (
-        _validate_binding_rejection_events(
-            attempts=attempts,
-            reported_events=reported_rejection_events,
-            chunks=chunks,
-            source_sha256=source_sha256,
-        )
+    inventory_rejections, completeness_rejections = _validate_binding_rejection_events(
+        attempts=attempts,
+        reported_events=reported_rejection_events,
+        chunks=chunks,
+        source_sha256=source_sha256,
     )
     collected = _collect_attempts(
         attempts=attempts,
@@ -496,13 +511,11 @@ def _validate_reported_inventory_outcome(
         raise ValueError("TG-04 reported validation outcome differs from replay")
     error_types_by_outcome: dict[str, frozenset[str | None]] = {
         "accepted": frozenset({None}),
-        "schema_invalid": frozenset(
-            {"StructuredModelSchemaError", "ValidationError"}
-        ),
+        "schema_invalid": frozenset({"StructuredModelSchemaError", "ValidationError"}),
         "semantic_invalid": frozenset(
             {
-            "StructuredModelSemanticError",
-            "ClaimInventoryItemsRejectedError",
+                "StructuredModelSemanticError",
+                "ClaimInventoryItemsRejectedError",
             }
         ),
     }

--- a/scripts/validation/claim_events/runner.py
+++ b/scripts/validation/claim_events/runner.py
@@ -282,7 +282,9 @@ async def _execute_case(
         ),
         terminal_error=terminal_error,
     )
-    events = _nary_events(inventory.claims) if executable and inventory else []
+    framed_events = _nary_events(inventory.claims) if inventory is not None else []
+    events = framed_events if executable else []
+    review_only_events = framed_events if inventory is not None and not executable else []
     outcome = _execution_outcome(
         events=events,
         terminal_failure=terminal_error is not None or inventory is None,
@@ -292,6 +294,7 @@ async def _execute_case(
         prediction={
             "case_id": case.case_id,
             "events": events,
+            "review_only_events": review_only_events,
             "abstained": not events,
             "execution_outcome": outcome.value,
         },
@@ -316,6 +319,7 @@ async def _execute_case(
                     if inventory is None
                     else inventory.unresolved_binding_rejection_count
                 ),
+                "review_only_event_count": len(review_only_events),
                 "inventory_recovery_round_count": (
                     0 if inventory is None else inventory.inventory_recovery_round_count
                 ),

--- a/services/artana_evidence_api/document_extraction.py
+++ b/services/artana_evidence_api/document_extraction.py
@@ -63,6 +63,11 @@ from artana_evidence_api.document_extraction_review import (
     review_from_draft_metadata,
     shorten_text,
 )
+from artana_evidence_api.document_extraction_support.claim_adjudication.candidate_preservation import (
+    as_review_only_candidate,
+    preserve_pruned_candidates_for_adjudication,
+    preserve_quality_filtered_candidates_for_adjudication,
+)
 from artana_evidence_api.document_extraction_support.full_text_chunking import (
     build_relation_extraction_text_chunks,
 )
@@ -273,12 +278,21 @@ def _route_agent_extraction_result(
     usable_candidates = tuple(quality_filter_result.candidates)
     routing_status: ClaimExtractionRoutingStatus
     if not extraction_attempt.semantic_inventory_complete:
-        visible_candidates: tuple[ExtractedRelationCandidate, ...] = ()
-        overflow_candidates = usable_candidates
+        visible_candidates = tuple(
+            as_review_only_candidate(candidate, "semantic_inventory_incomplete")
+            for candidate in usable_candidates
+        )
+        overflow_candidates: tuple[ExtractedRelationCandidate, ...] = ()
         routing_status = "semantic_incomplete"
     else:
-        visible_candidates = usable_candidates[:max_relations]
         overflow_candidates = usable_candidates[max_relations:]
+        visible_candidates = (
+            *usable_candidates[:max_relations],
+            *(
+                as_review_only_candidate(candidate, "candidate_overflow")
+                for candidate in overflow_candidates
+            ),
+        )
         routing_status = "candidate_overflow" if overflow_candidates else "complete"
     return SpecificityFilteredCandidateList(
         visible_candidates,
@@ -418,8 +432,16 @@ async def extract_relation_candidates_with_llm(
                 "Suppressed %s generic relation candidates after LLM extraction",
                 pruning_result.pruned_count,
             )
+        candidates_for_adjudication = preserve_pruned_candidates_for_adjudication(
+            candidates=candidates,
+            pruning_result=pruning_result,
+        )
         quality_filter_result = _filter_relation_candidate_quality(
-            pruning_result.candidates,
+            candidates_for_adjudication,
+        )
+        quality_filter_result = preserve_quality_filtered_candidates_for_adjudication(
+            candidates=candidates_for_adjudication,
+            quality_filter_result=quality_filter_result,
         )
         filtered_candidates = _route_agent_extraction_result(
             extraction_attempt=extraction_attempt,
@@ -592,7 +614,12 @@ async def discover_relation_candidates(  # noqa: PLR0911
     if not hasattr(llm_candidates, "claim_extraction_routing_status"):
         llm_pruning = _prune_relation_candidate_specificity(llm_candidates)
         llm_pruned_generic_relation_count += llm_pruning.pruned_count
-        llm_candidates = list(llm_pruning.candidates)
+        llm_candidates = list(
+            preserve_pruned_candidates_for_adjudication(
+                candidates=llm_candidates,
+                pruning_result=llm_pruning,
+            ),
+        )
     routing_status = normalize_claim_extraction_routing_status(
         getattr(llm_candidates, "claim_extraction_routing_status", "not_run"),
     )
@@ -607,15 +634,20 @@ async def discover_relation_candidates(  # noqa: PLR0911
     inventory_binding_rejections = tuple(
         getattr(llm_candidates, "inventory_binding_rejections", ()),
     )
+    inventory_incompleteness = tuple(
+        getattr(llm_candidates, "inventory_incompleteness", ()),
+    )
 
     if routing_status == "semantic_incomplete":
         return (
             llm_candidates,
             candidate_semantic_incomplete(
+                candidate_count=len(llm_candidates),
                 claim_lineage=claim_lineage,
                 raw_agent_outputs=raw_agent_outputs,
                 model_attempt_records=model_attempt_records,
                 inventory_binding_rejections=inventory_binding_rejections,
+                inventory_incompleteness=inventory_incompleteness,
                 llm_extraction_chunk_count=llm_extraction_chunk_count,
                 llm_extraction_text_char_count=llm_extraction_text_char_count,
             ),

--- a/services/artana_evidence_api/document_extraction_contracts.py
+++ b/services/artana_evidence_api/document_extraction_contracts.py
@@ -309,6 +309,7 @@ class DocumentCandidateExtractionDiagnostics:
     raw_agent_outputs: tuple[dict[str, object], ...] = ()
     model_attempt_records: tuple[dict[str, object], ...] = ()
     inventory_binding_rejections: tuple[dict[str, object], ...] = ()
+    inventory_incompleteness: tuple[dict[str, object], ...] = ()
 
     @property
     def agent_extraction_completed(self) -> bool:
@@ -387,6 +388,10 @@ class DocumentCandidateExtractionDiagnostics:
         if self.inventory_binding_rejections:
             payload["inventory_binding_rejections"] = json_value(
                 self.inventory_binding_rejections,
+            )
+        if self.inventory_incompleteness:
+            payload["inventory_incompleteness"] = json_value(
+                self.inventory_incompleteness,
             )
         if self.llm_candidate_error is not None:
             payload["llm_candidate_error"] = self.llm_candidate_error

--- a/services/artana_evidence_api/document_extraction_diagnostics.py
+++ b/services/artana_evidence_api/document_extraction_diagnostics.py
@@ -85,10 +85,12 @@ def candidate_llm_empty(
 
 def candidate_semantic_incomplete(
     *,
+    candidate_count: int,
     claim_lineage: tuple[ClaimExtractionLineage, ...],
     raw_agent_outputs: tuple[dict[str, object], ...],
     model_attempt_records: tuple[dict[str, object], ...],
     inventory_binding_rejections: tuple[dict[str, object], ...],
+    inventory_incompleteness: tuple[dict[str, object], ...],
     llm_extraction_chunk_count: int,
     llm_extraction_text_char_count: int,
 ) -> DocumentCandidateExtractionDiagnostics:
@@ -101,11 +103,13 @@ def candidate_semantic_incomplete(
         ),
         llm_extraction_chunk_count=llm_extraction_chunk_count,
         llm_extraction_text_char_count=llm_extraction_text_char_count,
+        llm_candidate_count=candidate_count,
         claim_extraction_routing_status="semantic_incomplete",
         claim_lineage=claim_lineage,
         raw_agent_outputs=raw_agent_outputs,
         model_attempt_records=model_attempt_records,
         inventory_binding_rejections=inventory_binding_rejections,
+        inventory_incompleteness=inventory_incompleteness,
     )
 
 

--- a/services/artana_evidence_api/document_extraction_review.py
+++ b/services/artana_evidence_api/document_extraction_review.py
@@ -330,10 +330,17 @@ def apply_document_proposal_review(
         }
         for item in draft.evidence_bundle
     ]
+    score_ceiling = _claim_adjudication_score_ceiling(draft)
+    confidence = (
+        factual_score if score_ceiling is None else min(factual_score, score_ceiling)
+    )
+    ranking_score = (
+        ranking.score if score_ceiling is None else min(ranking.score, score_ceiling)
+    )
     return replace(
         draft,
-        confidence=factual_score,
-        ranking_score=ranking.score,
+        confidence=confidence,
+        ranking_score=ranking_score,
         reasoning_path={
             **draft.reasoning_path,
             "proposal_review": {
@@ -350,6 +357,32 @@ def apply_document_proposal_review(
             "proposal_review": proposal_review_metadata,
         },
     )
+
+
+def _claim_adjudication_score_ceiling(
+    draft: HarnessProposalDraft,
+) -> float | None:
+    """Preserve deterministic safety ceilings across later review ranking."""
+
+    adjudication = _metadata_object(
+        draft.metadata.get("claim_semantic_adjudication"),
+    )
+    source_support = adjudication.get("source_support")
+    if source_support == "CONTRADICTED":
+        return 0.05
+    if source_support in {"INSUFFICIENT", "ABSTAIN"}:
+        return 0.25
+    if adjudication and (
+        adjudication.get("atomicity") != "ATOMIC"
+        or adjudication.get("relationship") != "CANONICAL"
+    ):
+        return 0.25
+    reason_codes = draft.metadata.get("review_reason_codes")
+    if isinstance(reason_codes, list) and "claim_adjudication_unavailable" in (
+        reason_codes
+    ):
+        return 0.25
+    return None
 
 
 def _draft_evidence_ranking_inputs(

--- a/services/artana_evidence_api/document_extraction_support/claim_adjudication/__init__.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_adjudication/__init__.py
@@ -1,0 +1,10 @@
+"""Source-bound categorical claim adjudication."""
+
+from artana_evidence_api.document_extraction_support.claim_adjudication.contracts import (
+    ClaimAdjudicationDiagnostics,
+)
+from artana_evidence_api.document_extraction_support.claim_adjudication.service import (
+    adjudicate_document_claims,
+)
+
+__all__ = ["ClaimAdjudicationDiagnostics", "adjudicate_document_claims"]

--- a/services/artana_evidence_api/document_extraction_support/claim_adjudication/candidate_preservation.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_adjudication/candidate_preservation.py
@@ -1,0 +1,94 @@
+"""Preserve deterministic extraction rejections for semantic review."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from artana_evidence_api.document_extraction_contracts import (
+    ExtractedRelationCandidate,
+)
+from artana_evidence_api.document_extraction_support.relation_candidate_quality_filter import (
+    RelationCandidateQualityFilterResult,
+)
+from artana_evidence_api.document_extraction_support.relation_specificity_pruning import (
+    RelationSpecificityPruningResult,
+)
+
+
+def preserve_pruned_candidates_for_adjudication(
+    *,
+    candidates: list[ExtractedRelationCandidate],
+    pruning_result: RelationSpecificityPruningResult,
+) -> tuple[ExtractedRelationCandidate, ...]:
+    """Keep deterministic pruning decisions as review-only semantic inputs."""
+
+    reason_by_index = {
+        item.candidate_index: "generic_relation_shadowed_by_specific_sibling"
+        for item in pruning_result.pruned_candidates
+    }
+    reason_by_index.update(
+        {
+            item.candidate_index: "weak_generic_relation_candidate"
+            for item in pruning_result.weak_generic_candidates
+        },
+    )
+    return tuple(
+        as_review_only_candidate(candidate, reason_by_index[index])
+        if index in reason_by_index
+        else candidate
+        for index, candidate in enumerate(candidates)
+    )
+
+
+def preserve_quality_filtered_candidates_for_adjudication(
+    *,
+    candidates: tuple[ExtractedRelationCandidate, ...],
+    quality_filter_result: RelationCandidateQualityFilterResult,
+) -> RelationCandidateQualityFilterResult:
+    """Convert quality-filter removals into review-only semantic inputs."""
+
+    filtered_by_index = {
+        item.candidate_index: item for item in quality_filter_result.filtered_candidates
+    }
+    kept = iter(
+        quality_filter_result.unmerged_candidates or quality_filter_result.candidates
+    )
+    preserved: list[ExtractedRelationCandidate] = []
+    for index, _candidate in enumerate(candidates):
+        filtered = filtered_by_index.get(index)
+        if filtered is not None:
+            preserved.append(
+                as_review_only_candidate(
+                    filtered.candidate,
+                    f"quality_filter_{filtered.reason}",
+                ),
+            )
+            continue
+        preserved.append(next(kept))
+    return RelationCandidateQualityFilterResult(
+        candidates=tuple(preserved),
+        filtered_candidates=quality_filter_result.filtered_candidates,
+        unmerged_candidates=tuple(preserved),
+    )
+
+
+def as_review_only_candidate(
+    candidate: ExtractedRelationCandidate,
+    reason: str,
+) -> ExtractedRelationCandidate:
+    """Preserve one source-bound claim without making it promotion eligible."""
+
+    return replace(
+        candidate,
+        review_status="review_only",
+        review_reason_codes=tuple(
+            dict.fromkeys((*candidate.review_reason_codes, reason)),
+        ),
+    )
+
+
+__all__ = [
+    "as_review_only_candidate",
+    "preserve_pruned_candidates_for_adjudication",
+    "preserve_quality_filtered_candidates_for_adjudication",
+]

--- a/services/artana_evidence_api/document_extraction_support/claim_adjudication/contracts.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_adjudication/contracts.py
@@ -1,0 +1,111 @@
+"""Categorical contracts for source-bound claim adjudication."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from artana_evidence_api.types.common import JSONObject
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+ClaimAtomicity = Literal["ATOMIC", "BUNDLED", "ABSTAIN"]
+ClaimSourceSupport = Literal[
+    "ENTAILED",
+    "CONTRADICTED",
+    "INSUFFICIENT",
+    "ABSTAIN",
+]
+ClaimSemanticRelationship = Literal[
+    "CANONICAL",
+    "SAME_AS",
+    "REFINES",
+    "GENERALIZES",
+    "CONTRADICTS",
+    "ABSTAIN",
+]
+ClaimAdjudicationStatus = Literal[
+    "not_needed",
+    "completed",
+    "unavailable",
+    "failed",
+]
+
+
+class ClaimAdjudicationDecision(BaseModel):
+    """One model-authored categorical judgment for one extracted claim."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    claim_ref: str = Field(..., min_length=1, max_length=128)
+    atomicity: ClaimAtomicity
+    source_support: ClaimSourceSupport
+    relationship: ClaimSemanticRelationship
+    target_claim_ref: str | None = Field(default=None, max_length=128)
+    evidence_spans: list[str] = Field(default_factory=list, max_length=8)
+    reasoning: str = Field(..., min_length=1, max_length=4000)
+    falsification: str = Field(..., min_length=1, max_length=4000)
+
+    @model_validator(mode="after")
+    def validate_relationship_target(self) -> ClaimAdjudicationDecision:
+        """Require targets only for relationships between two claims."""
+
+        needs_target = self.relationship in {
+            "SAME_AS",
+            "REFINES",
+            "GENERALIZES",
+            "CONTRADICTS",
+        }
+        if needs_target and self.target_claim_ref is None:
+            raise ValueError("relational claim decisions require target_claim_ref")
+        if not needs_target and self.target_claim_ref is not None:
+            raise ValueError("non-relational claim decisions cannot have a target")
+        if self.target_claim_ref == self.claim_ref:
+            raise ValueError("claim adjudication cannot target itself")
+        if self.source_support == "ENTAILED" and not self.evidence_spans:
+            raise ValueError("ENTAILED decisions require exact evidence spans")
+        return self
+
+
+class ClaimAdjudicationOutput(BaseModel):
+    """Closed output envelope for one document-level adjudication pass."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    decisions: list[ClaimAdjudicationDecision] = Field(..., max_length=12)
+
+
+@dataclass(frozen=True, slots=True)
+class ClaimAdjudicationDiagnostics:
+    """Auditable outcome of the independent claim adjudication pass."""
+
+    status: ClaimAdjudicationStatus
+    model_id: str | None = None
+    error: str | None = None
+    decision_count: int = 0
+    metrics: JSONObject | None = None
+
+    def as_metadata(self) -> JSONObject:
+        """Serialize diagnostics without inventing a quality score."""
+
+        payload: JSONObject = {
+            "status": self.status,
+            "decision_count": self.decision_count,
+        }
+        if self.model_id is not None:
+            payload["model_id"] = self.model_id
+        if self.error is not None:
+            payload["error"] = self.error
+        if self.metrics is not None:
+            payload["metrics"] = self.metrics
+        return payload
+
+
+__all__ = [
+    "ClaimAdjudicationDecision",
+    "ClaimAdjudicationDiagnostics",
+    "ClaimAdjudicationOutput",
+    "ClaimAdjudicationStatus",
+    "ClaimAtomicity",
+    "ClaimSemanticRelationship",
+    "ClaimSourceSupport",
+]

--- a/services/artana_evidence_api/document_extraction_support/claim_adjudication/metrics.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_adjudication/metrics.py
@@ -1,0 +1,41 @@
+"""Deterministic metrics derived from categorical claim adjudications."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+
+from artana_evidence_api.document_extraction_support.claim_adjudication.contracts import (
+    ClaimAdjudicationDecision,
+)
+from artana_evidence_api.types.common import JSONObject
+
+
+def claim_adjudication_metrics(
+    decisions: Iterable[ClaimAdjudicationDecision],
+) -> JSONObject:
+    """Calculate counts without treating model-authored numbers as evidence."""
+
+    items = tuple(decisions)
+    atomicity = Counter(item.atomicity for item in items)
+    support = Counter(item.source_support for item in items)
+    relationships = Counter(item.relationship for item in items)
+    return {
+        "total_claims": len(items),
+        "atomic_claims": atomicity["ATOMIC"],
+        "bundled_claims": atomicity["BUNDLED"],
+        "atomicity_abstentions": atomicity["ABSTAIN"],
+        "entailed_claims": support["ENTAILED"],
+        "contradicted_claims": support["CONTRADICTED"],
+        "insufficient_claims": support["INSUFFICIENT"],
+        "support_abstentions": support["ABSTAIN"],
+        "canonical_claims": relationships["CANONICAL"],
+        "same_as_claims": relationships["SAME_AS"],
+        "refining_claims": relationships["REFINES"],
+        "generalizing_claims": relationships["GENERALIZES"],
+        "claim_contradictions": relationships["CONTRADICTS"],
+        "relationship_abstentions": relationships["ABSTAIN"],
+    }
+
+
+__all__ = ["claim_adjudication_metrics"]

--- a/services/artana_evidence_api/document_extraction_support/claim_adjudication/runtime.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_adjudication/runtime.py
@@ -1,0 +1,78 @@
+"""Compose trust, semantic adjudication, and relevance review for document drafts."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from artana_evidence_api import document_extraction
+from artana_evidence_api.document_extraction_contracts import (
+    DocumentCandidateExtractionDiagnostics,
+    DocumentExtractionReviewContext,
+    ExtractedRelationCandidate,
+)
+from artana_evidence_api.document_extraction_support.claim_adjudication.contracts import (
+    ClaimAdjudicationDiagnostics,
+)
+from artana_evidence_api.document_extraction_support.claim_adjudication.service import (
+    adjudicate_document_claims,
+)
+from artana_evidence_api.document_store import HarnessDocumentRecord
+from artana_evidence_api.proposal_store import HarnessProposalDraft
+
+
+async def adjudicate_and_review_document_drafts(
+    *,
+    document: HarnessDocumentRecord,
+    candidates: list[ExtractedRelationCandidate],
+    drafts: tuple[HarnessProposalDraft, ...],
+    candidate_diagnostics: DocumentCandidateExtractionDiagnostics,
+    review_context: DocumentExtractionReviewContext,
+) -> tuple[HarnessProposalDraft, ...]:
+    """Apply trust lineage, independent adjudication, and relevance review."""
+
+    trusted_drafts = document_extraction.with_candidate_extraction_trust_metadata(
+        drafts=drafts,
+        diagnostics=candidate_diagnostics,
+    )
+    adjudicated_drafts, diagnostics = await adjudicate_document_claims(
+        document=document,
+        drafts=trusted_drafts,
+    )
+    adjudicated_drafts = with_claim_adjudication_diagnostics(
+        drafts=adjudicated_drafts,
+        diagnostics=diagnostics,
+    )
+    return await document_extraction.review_document_extraction_drafts(
+        document=document,
+        candidates=candidates,
+        drafts=adjudicated_drafts,
+        review_context=review_context,
+    )
+
+
+def with_claim_adjudication_diagnostics(
+    *,
+    drafts: tuple[HarnessProposalDraft, ...],
+    diagnostics: ClaimAdjudicationDiagnostics,
+) -> tuple[HarnessProposalDraft, ...]:
+    """Persist the document-level adjudication outcome on research-init drafts."""
+
+    serialized = diagnostics.as_metadata()
+    return tuple(
+        replace(
+            draft,
+            metadata={
+                **draft.metadata,
+                "claim_adjudication_diagnostics": serialized,
+            },
+        )
+        if draft.proposal_type == "candidate_claim"
+        else draft
+        for draft in drafts
+    )
+
+
+__all__ = [
+    "adjudicate_and_review_document_drafts",
+    "with_claim_adjudication_diagnostics",
+]

--- a/services/artana_evidence_api/document_extraction_support/claim_adjudication/service.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_adjudication/service.py
@@ -1,0 +1,476 @@
+"""Independent categorical adjudication for canonicalized document claims."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from dataclasses import replace
+from typing import Protocol, cast
+from uuid import uuid4
+
+from artana_evidence_api.document_extraction_support.claim_adjudication.contracts import (
+    ClaimAdjudicationDecision,
+    ClaimAdjudicationDiagnostics,
+    ClaimAdjudicationOutput,
+)
+from artana_evidence_api.document_extraction_support.claim_adjudication.metrics import (
+    claim_adjudication_metrics,
+)
+from artana_evidence_api.document_store import HarnessDocumentRecord
+from artana_evidence_api.proposal_store import HarnessProposalDraft
+from artana_evidence_api.types.common import JSONObject, json_value
+from pydantic import ValidationError
+
+_SCHEMA_ID = "document_extraction.claim_adjudication.v1"
+_PROMPT_ID = "document_extraction.claim_adjudication.v1"
+_RELATIONAL_DECISIONS = frozenset(
+    {"SAME_AS", "REFINES", "GENERALIZES", "CONTRADICTS"},
+)
+_MAX_CLAIMS_PER_ADJUDICATION_BATCH = 12
+_MAX_PRIOR_CLAIMS_IN_PROMPT = 24
+
+CLAIM_ADJUDICATION_SYSTEM_PROMPT = """You independently adjudicate extracted biomedical claims against their frozen source excerpts.
+
+For every claim reference, return exactly one categorical decision. Never return confidence, probability, quality, importance, or any other numeric score.
+
+Atomicity:
+- ATOMIC: one scientific assertion with one predicate and one endpoint pair.
+- BUNDLED: multiple assertions or predicates have been combined.
+- ABSTAIN: atomicity cannot be determined from the supplied source.
+
+Source support:
+- ENTAILED: the exact source explicitly supports the complete claim.
+- CONTRADICTED: the source explicitly conflicts with the claim.
+- INSUFFICIENT: the source does not establish the complete claim.
+- ABSTAIN: support cannot be determined safely.
+
+Relationship:
+- CANONICAL: retain this as the first independent representation.
+- SAME_AS: equivalent to an earlier claim despite wording differences.
+- REFINES: adds source-supported context or specificity to an earlier claim.
+- GENERALIZES: removes material context from an earlier claim.
+- CONTRADICTS: conflicts with an earlier claim.
+- ABSTAIN: no safe relationship decision, including bundled claims.
+
+Only target an earlier claim reference. Preserve negative, null, uncertain, provisional, and hypothesis semantics. A hypothesis is not an asserted finding. Copy exact source evidence spans for ENTAILED claims. Explain what source change would falsify each judgment. Do not use outside knowledge."""
+
+
+class ClaimAdjudicationAgent(Protocol):
+    """Injectable agent boundary used by focused tests and alternate runtimes."""
+
+    model_id: str
+
+    async def adjudicate(self, *, prompt: str) -> ClaimAdjudicationOutput:
+        """Return categorical decisions for the supplied claims."""
+
+
+async def adjudicate_document_claims(
+    *,
+    document: HarnessDocumentRecord,
+    drafts: tuple[HarnessProposalDraft, ...],
+    agent: ClaimAdjudicationAgent | None = None,
+) -> tuple[tuple[HarnessProposalDraft, ...], ClaimAdjudicationDiagnostics]:
+    """Adjudicate claims and apply deterministic review-only safety floors."""
+
+    claim_drafts = tuple(
+        draft for draft in drafts if draft.proposal_type == "candidate_claim"
+    )
+    if not claim_drafts:
+        return drafts, ClaimAdjudicationDiagnostics(status="not_needed")
+
+    claim_refs = _claim_refs(claim_drafts)
+    model_id = agent.model_id if agent is not None else ""
+    collected_decisions: list[ClaimAdjudicationDecision] = []
+    try:
+        for batch_start in range(
+            0,
+            len(claim_drafts),
+            _MAX_CLAIMS_PER_ADJUDICATION_BATCH,
+        ):
+            batch_end = min(
+                batch_start + _MAX_CLAIMS_PER_ADJUDICATION_BATCH,
+                len(claim_drafts),
+            )
+            batch_refs = claim_refs[batch_start:batch_end]
+            batch_drafts = claim_drafts[batch_start:batch_end]
+            prior_start = max(0, batch_start - _MAX_PRIOR_CLAIMS_IN_PROMPT)
+            prompt = _build_prompt(
+                claim_refs=batch_refs,
+                drafts=batch_drafts,
+                prior_claim_refs=claim_refs[prior_start:batch_start],
+                prior_drafts=claim_drafts[prior_start:batch_start],
+            )
+            if agent is not None:
+                output = await agent.adjudicate(prompt=prompt)
+            else:
+                output, model_id = await _run_kernel_agent(
+                    document=document,
+                    prompt=prompt,
+                    output_schema=ClaimAdjudicationOutput,
+                    schema_id="document_extraction.claim_adjudication.v1",
+                )
+            collected_decisions.extend(
+                _validated_decisions(
+                    output=output,
+                    claim_refs=batch_refs,
+                    drafts=batch_drafts,
+                    ordered_document_claim_refs=claim_refs,
+                    visible_claim_refs=(
+                        *claim_refs[prior_start:batch_start],
+                        *batch_refs,
+                    ),
+                    source_text=document.text_content,
+                ),
+            )
+    except (RuntimeError, TimeoutError, ValidationError, ValueError) as exc:
+        return (
+            _mark_adjudication_unavailable(drafts),
+            ClaimAdjudicationDiagnostics(
+                status="unavailable",
+                model_id=getattr(agent, "model_id", None),
+                error=str(exc),
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return (
+            _mark_adjudication_unavailable(drafts),
+            ClaimAdjudicationDiagnostics(
+                status="failed",
+                model_id=getattr(agent, "model_id", None),
+                error=str(exc),
+            ),
+        )
+
+    decisions = tuple(collected_decisions)
+    decisions_by_ref = {decision.claim_ref: decision for decision in decisions}
+    drafts_by_ref = dict(zip(claim_refs, claim_drafts, strict=True))
+    updated_claims: dict[int, HarnessProposalDraft] = {}
+    for claim_ref, draft in zip(claim_refs, claim_drafts, strict=True):
+        decision = decisions_by_ref[claim_ref]
+        target_ref = decision.target_claim_ref
+        updated_claims[id(draft)] = _apply_decision(
+            draft=draft,
+            decision=decision,
+            model_id=model_id,
+            target_draft=(
+                drafts_by_ref.get(target_ref) if target_ref is not None else None
+            ),
+        )
+    return (
+        tuple(updated_claims.get(id(draft), draft) for draft in drafts),
+        ClaimAdjudicationDiagnostics(
+            status="completed",
+            model_id=model_id,
+            decision_count=len(decisions),
+            metrics=claim_adjudication_metrics(decisions),
+        ),
+    )
+
+
+def _claim_refs(drafts: Sequence[HarnessProposalDraft]) -> tuple[str, ...]:
+    return tuple(f"claim-{index:04d}" for index in range(1, len(drafts) + 1))
+
+
+def _build_prompt(
+    *,
+    claim_refs: Sequence[str],
+    drafts: Sequence[HarnessProposalDraft],
+    prior_claim_refs: Sequence[str] = (),
+    prior_drafts: Sequence[HarnessProposalDraft] = (),
+) -> str:
+    blocks = [
+        _claim_prompt_block(claim_ref=claim_ref, draft=draft)
+        for claim_ref, draft in zip(claim_refs, drafts, strict=True)
+    ]
+    prior_blocks = [
+        "\n".join(
+            (
+                f"Prior claim reference: {claim_ref}",
+                f"- subject: {_draft_label(draft, 'subject')}",
+                f"- relation: {draft.payload.get('proposed_claim_type')}",
+                f"- object: {_draft_label(draft, 'object')}",
+                f"- exact source excerpt: {draft.summary}",
+            ),
+        )
+        for claim_ref, draft in zip(prior_claim_refs, prior_drafts, strict=True)
+    ]
+    prior_section = (
+        "PRIOR CLAIMS AVAILABLE ONLY AS RELATION TARGETS\n"
+        f"{'\n\n'.join(prior_blocks)}\n\n"
+        if prior_blocks
+        else ""
+    )
+    return (
+        f"Prompt identity: {_PROMPT_ID}\n\n"
+        f"{CLAIM_ADJUDICATION_SYSTEM_PROMPT}\n\n"
+        f"{prior_section}CLAIMS TO ADJUDICATE IN SOURCE ORDER\n"
+        f"{'\n\n'.join(blocks)}\n\n"
+        "Return one decision for every claim reference exactly once."
+    )
+
+
+def _claim_prompt_block(
+    *,
+    claim_ref: str,
+    draft: HarnessProposalDraft,
+) -> str:
+    frame = draft.payload.get("claim_frame")
+    frame_payload = frame if isinstance(frame, Mapping) else {}
+    return "\n".join(
+        (
+            f"Claim reference: {claim_ref}",
+            f"- subject: {_draft_label(draft, 'subject')}",
+            f"- relation: {draft.payload.get('proposed_claim_type')}",
+            f"- object: {_draft_label(draft, 'object')}",
+            f"- polarity: {frame_payload.get('polarity')}",
+            f"- epistemic_status: {frame_payload.get('epistemic_status')}",
+            f"- exact source excerpt: {draft.summary}",
+        ),
+    )
+
+
+def _draft_label(draft: HarnessProposalDraft, endpoint: str) -> object:
+    return draft.metadata.get(f"resolved_{endpoint}_label") or draft.metadata.get(
+        f"{endpoint}_label",
+    )
+
+
+async def _run_kernel_agent(
+    *,
+    document: HarnessDocumentRecord,
+    prompt: str,
+    output_schema: type[ClaimAdjudicationOutput],
+    schema_id: str,
+) -> tuple[ClaimAdjudicationOutput, str]:
+    from artana.agent import SingleStepModelClient
+    from artana.kernel import ArtanaKernel
+    from artana.models import TenantContext
+    from artana.ports.model import LiteLLMAdapter
+    from artana_evidence_api.runtime import (
+        ModelCapability,
+        create_artana_postgres_store,
+        get_model_registry,
+        has_configured_openai_api_key,
+        normalize_litellm_model_id,
+    )
+    from artana_evidence_api.step_helpers import run_single_step_with_policy
+
+    if not has_configured_openai_api_key():
+        raise RuntimeError("OPENAI_API_KEY not configured")
+    if output_schema is not ClaimAdjudicationOutput or schema_id != _SCHEMA_ID:
+        raise RuntimeError("claim adjudication schema binding is invalid")
+
+    model_spec = get_model_registry().get_default_model(ModelCapability.JUDGE)
+    model_id = normalize_litellm_model_id(model_spec.model_id)
+    step_key = f"{_SCHEMA_ID}:{hashlib.sha256(prompt.encode('utf-8')).hexdigest()}"
+    store = create_artana_postgres_store()
+    kernel = ArtanaKernel(
+        store=store,
+        model_port=LiteLLMAdapter(timeout_seconds=model_spec.timeout_seconds),
+    )
+    try:
+        result = await asyncio.wait_for(
+            run_single_step_with_policy(
+                SingleStepModelClient(kernel=kernel),
+                run_id=f"claim-adjudication:{uuid4()}",
+                tenant=TenantContext(
+                    tenant_id=f"claim-adjudication:{document.space_id}",
+                    capabilities=frozenset(),
+                    budget_usd_limit=1.0,
+                ),
+                model=model_id,
+                prompt=prompt,
+                output_schema=output_schema,
+                schema_id="document_extraction.claim_adjudication.v1",
+                step_key=step_key,
+                replay_policy="fork_on_drift",
+            ),
+            timeout=model_spec.timeout_seconds,
+        )
+        output = (
+            result.output
+            if isinstance(result.output, ClaimAdjudicationOutput)
+            else ClaimAdjudicationOutput.model_validate(result.output)
+        )
+        return output, model_spec.model_id
+    finally:
+        with suppress(Exception):
+            await kernel.close()
+        with suppress(Exception):
+            await store.close()
+
+
+def _validated_decisions(
+    *,
+    output: ClaimAdjudicationOutput,
+    claim_refs: Sequence[str],
+    drafts: Sequence[HarnessProposalDraft],
+    ordered_document_claim_refs: Sequence[str],
+    visible_claim_refs: Sequence[str],
+    source_text: str,
+) -> tuple[ClaimAdjudicationDecision, ...]:
+    expected = tuple(claim_refs)
+    actual = tuple(decision.claim_ref for decision in output.decisions)
+    if len(set(actual)) != len(actual):
+        raise ValueError("claim adjudication returned duplicate claim references")
+    if set(actual) != set(expected):
+        raise ValueError("claim adjudication must cover every claim exactly once")
+
+    index_by_ref = {
+        claim_ref: index for index, claim_ref in enumerate(ordered_document_claim_refs)
+    }
+    visible_refs = frozenset(visible_claim_refs)
+    draft_by_ref = dict(zip(expected, drafts, strict=True))
+    decisions_by_ref = {decision.claim_ref: decision for decision in output.decisions}
+    ordered = tuple(decisions_by_ref[claim_ref] for claim_ref in expected)
+    for decision in ordered:
+        if decision.target_claim_ref is not None:
+            target_index = index_by_ref.get(decision.target_claim_ref)
+            if target_index is None:
+                raise ValueError("claim relationship target is not in this document")
+            if decision.target_claim_ref not in visible_refs:
+                raise ValueError(
+                    "claim relationship target is outside the adjudication context",
+                )
+            if target_index >= index_by_ref[decision.claim_ref]:
+                raise ValueError("claim relationships must target an earlier claim")
+        for span in decision.evidence_spans:
+            if span.strip() == "" or span not in source_text:
+                raise ValueError("claim evidence span is not exact frozen source text")
+            if span not in draft_by_ref[decision.claim_ref].summary:
+                raise ValueError(
+                    "claim evidence span is outside the adjudicated claim excerpt",
+                )
+    return ordered
+
+
+def _apply_decision(
+    *,
+    draft: HarnessProposalDraft,
+    decision: ClaimAdjudicationDecision,
+    model_id: str,
+    target_draft: HarnessProposalDraft | None,
+) -> HarnessProposalDraft:
+    support = {
+        "ENTAILED": "ENTAILS",
+        "CONTRADICTED": "CONTRADICTS",
+        "INSUFFICIENT": "NEUTRAL",
+        "ABSTAIN": "NEUTRAL",
+    }[decision.source_support]
+    adjudication: JSONObject = cast(
+        "JSONObject",
+        json_value(decision.model_dump(mode="json")),
+    )
+    metadata: JSONObject = {
+        **draft.metadata,
+        "claim_semantic_adjudication": adjudication,
+        "support_verification": {
+            "support": support,
+            "rationale": decision.reasoning,
+            "model_id": model_id,
+            "verification_method": "agent",
+            "evidence_spans": list(decision.evidence_spans),
+            "falsification": decision.falsification,
+        },
+    }
+    if decision.relationship in _RELATIONAL_DECISIONS and target_draft is not None:
+        metadata["claim_relation_proposal"] = {
+            "relation_type": decision.relationship,
+            "target_source_key": target_draft.source_key,
+            "target_claim_fingerprint": target_draft.claim_fingerprint,
+            "evidence_summary": decision.reasoning,
+            "review_status": "PROPOSED",
+        }
+    reason = _review_only_reason(decision)
+    if reason is not None:
+        metadata = _with_review_only_reason(metadata=metadata, reason=reason)
+    confidence, ranking_score = _deterministic_score_floors(
+        draft=draft,
+        source_support=decision.source_support,
+    )
+    return replace(
+        draft,
+        metadata=metadata,
+        confidence=confidence,
+        ranking_score=ranking_score,
+    )
+
+
+def _review_only_reason(decision: ClaimAdjudicationDecision) -> str | None:
+    if decision.atomicity != "ATOMIC":
+        return f"claim_atomicity_{decision.atomicity.casefold()}"
+    if decision.source_support != "ENTAILED":
+        return f"claim_support_{decision.source_support.casefold()}"
+    if decision.relationship != "CANONICAL":
+        return f"claim_relationship_{decision.relationship.casefold()}"
+    return None
+
+
+def _with_review_only_reason(*, metadata: JSONObject, reason: str) -> JSONObject:
+    existing = metadata.get("review_reason_codes")
+    reason_codes = (
+        [item for item in existing if isinstance(item, str)]
+        if isinstance(
+            existing,
+            list,
+        )
+        else []
+    )
+    return {
+        **metadata,
+        "review_status": "review_only",
+        "review_reason_codes": list(dict.fromkeys((*reason_codes, reason))),
+    }
+
+
+def _deterministic_score_floors(
+    *,
+    draft: HarnessProposalDraft,
+    source_support: str,
+) -> tuple[float, float]:
+    if source_support == "ENTAILED":
+        return draft.confidence, draft.ranking_score
+    ceiling = 0.05 if source_support == "CONTRADICTED" else 0.25
+    return min(draft.confidence, ceiling), min(draft.ranking_score, ceiling)
+
+
+def _mark_adjudication_unavailable(
+    drafts: tuple[HarnessProposalDraft, ...],
+) -> tuple[HarnessProposalDraft, ...]:
+    updated: list[HarnessProposalDraft] = []
+    for draft in drafts:
+        if draft.proposal_type != "candidate_claim":
+            updated.append(draft)
+            continue
+        metadata = _with_review_only_reason(
+            metadata={
+                **draft.metadata,
+                "support_verification": {
+                    "support": "NEUTRAL",
+                    "rationale": "Independent agent adjudication was unavailable.",
+                    "model_id": None,
+                    "verification_method": "unavailable",
+                    "evidence_spans": [],
+                    "falsification": "Agent adjudication must complete.",
+                },
+            },
+            reason="claim_adjudication_unavailable",
+        )
+        updated.append(
+            replace(
+                draft,
+                metadata=metadata,
+                confidence=min(draft.confidence, 0.25),
+                ranking_score=min(draft.ranking_score, 0.25),
+            ),
+        )
+    return tuple(updated)
+
+
+__all__ = [
+    "CLAIM_ADJUDICATION_SYSTEM_PROMPT",
+    "ClaimAdjudicationAgent",
+    "adjudicate_document_claims",
+]

--- a/services/artana_evidence_api/document_extraction_support/claim_frames/promotion_policy.py
+++ b/services/artana_evidence_api/document_extraction_support/claim_frames/promotion_policy.py
@@ -6,6 +6,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Never
 
+from artana_evidence_api.document_extraction_support.claim_adjudication.contracts import (
+    ClaimAdjudicationDecision,
+)
 from artana_evidence_api.document_extraction_support.claim_frames.contracts import (
     ClaimFrame,
 )
@@ -41,7 +44,7 @@ def require_canonical_claim_promotion(
         metadata=metadata,
     )
     try:
-        return bind_claim_frame(
+        bound_frame = bind_claim_frame(
             frame,
             source_text,
             chunk_locator=frame.source_locator,
@@ -52,6 +55,16 @@ def require_canonical_claim_promotion(
             "claim_frame_source_binding_failed",
             "Canonical promotion requires the complete ClaimFrame to bind to the stored source.",
         ) from exc
+    adjudication = _require_promotable_claim_adjudication(metadata)
+    if any(
+        span not in bound_frame.source_evidence.exact_span
+        for span in adjudication.evidence_spans
+    ):
+        _reject(
+            "claim_adjudication_evidence_mismatch",
+            "Canonical promotion requires adjudication evidence from the claim's exact source region.",
+        )
+    return bound_frame
 
 
 def require_claim_frame_promotion_preflight(
@@ -103,6 +116,7 @@ def require_claim_frame_promotion_preflight(
             "review_only_claim_frame",
             "Review-only claims cannot become canonical relations.",
         )
+    _require_promotable_claim_adjudication(metadata)
     grounding = _mapping(metadata.get("evidence_grounding"))
     if not all(
         grounding.get(field) is True
@@ -116,12 +130,41 @@ def require_claim_frame_promotion_preflight(
     if (
         support.get("support") != "ENTAILS"
         or support.get("verification_method") != "agent"
+        or not isinstance(support.get("model_id"), str)
+        or not str(support["model_id"]).strip()
     ):
         _reject(
             "agent_support_not_verified",
             "Canonical promotion requires an agent entailment verification.",
         )
     return frame
+
+
+def _require_promotable_claim_adjudication(
+    metadata: Mapping[str, object],
+) -> ClaimAdjudicationDecision:
+    """Validate the complete categorical adjudication artifact."""
+
+    raw_adjudication = metadata.get("claim_semantic_adjudication")
+    try:
+        adjudication = ClaimAdjudicationDecision.model_validate(raw_adjudication)
+    except ValidationError as exc:
+        raise ClaimFramePromotionError(
+            "invalid_claim_semantic_adjudication",
+            "Canonical promotion requires a complete valid claim adjudication artifact.",
+        ) from exc
+    if any(
+        (
+            adjudication.atomicity != "ATOMIC",
+            adjudication.source_support != "ENTAILED",
+            adjudication.relationship != "CANONICAL",
+        ),
+    ):
+        _reject(
+            "claim_semantic_adjudication_not_promotable",
+            "Canonical promotion requires atomic, entailed, canonical adjudication.",
+        )
+    return adjudication
 
 
 def _require_resolved_framing_decision(

--- a/services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py
+++ b/services/artana_evidence_api/document_extraction_support/relation_candidate_quality_filter.py
@@ -177,6 +177,7 @@ class RelationCandidateQualityFilterResult:
 
     candidates: tuple[ExtractedRelationCandidate, ...]
     filtered_candidates: tuple[QualityFilteredRelationCandidate, ...]
+    unmerged_candidates: tuple[ExtractedRelationCandidate, ...] = ()
 
     @property
     def filtered_count(self) -> int:
@@ -263,6 +264,7 @@ def filter_low_value_relation_candidates(
     return RelationCandidateQualityFilterResult(
         candidates=_merge_duplicate_kept_candidates(kept_candidates),
         filtered_candidates=tuple(filtered_candidates),
+        unmerged_candidates=tuple(kept_candidates),
     )
 
 
@@ -316,8 +318,7 @@ def _merge_duplicate_kept_candidates(
             ),
             review_status=(
                 "review_only"
-                if "review_only"
-                in {existing.review_status, candidate.review_status}
+                if "review_only" in {existing.review_status, candidate.review_status}
                 or bool(review_reason_codes)
                 else "candidate"
             ),
@@ -838,10 +839,13 @@ def _is_specific_molecular_target_object(label: str) -> bool:
 
 
 def _is_specific_biomarker_response_object(label: str) -> bool:
-    return re.search(
-        r"\b(response|sensitivity|benefit)\b",
-        _normalize_entity_label(label),
-    ) is not None
+    return (
+        re.search(
+            r"\b(response|sensitivity|benefit)\b",
+            _normalize_entity_label(label),
+        )
+        is not None
+    )
 
 
 def _candidate_relation_cue_present(candidate: ExtractedRelationCandidate) -> bool:

--- a/services/artana_evidence_api/document_extraction_support/strict_relation_discovery.py
+++ b/services/artana_evidence_api/document_extraction_support/strict_relation_discovery.py
@@ -76,13 +76,18 @@ async def discover_relation_candidates_strict(
     inventory_binding_rejections = tuple(
         getattr(llm_candidates, "inventory_binding_rejections", ()),
     )
+    inventory_incompleteness = tuple(
+        getattr(llm_candidates, "inventory_incompleteness", ()),
+    )
 
     if routing_status == "semantic_incomplete":
         return candidates, candidate_semantic_incomplete(
+            candidate_count=len(candidates),
             claim_lineage=claim_lineage,
             raw_agent_outputs=raw_agent_outputs,
             model_attempt_records=model_attempt_records,
             inventory_binding_rejections=inventory_binding_rejections,
+            inventory_incompleteness=inventory_incompleteness,
             llm_extraction_chunk_count=llm_extraction_chunk_count,
             llm_extraction_text_char_count=llm_extraction_text_char_count,
         )

--- a/services/artana_evidence_api/research_init_document_extraction_runtime.py
+++ b/services/artana_evidence_api/research_init_document_extraction_runtime.py
@@ -11,6 +11,9 @@ from artana_evidence_api import document_extraction as _document_extraction
 from artana_evidence_api.document_extraction import (
     build_document_review_context,
 )
+from artana_evidence_api.document_extraction_support.claim_adjudication.runtime import (
+    adjudicate_and_review_document_drafts,
+)
 from artana_evidence_api.document_extraction_support.variant_aware_trust_metadata import (
     with_variant_aware_trust_metadata,
 )
@@ -214,9 +217,7 @@ async def run_research_init_document_extraction(
         text_observations_created = upload_result.text_observations_created
         pdf_observations_created = upload_result.pdf_observations_created
 
-        source_results["pubmed"][
-            "observations_created"
-        ] = pubmed_observations_created
+        source_results["pubmed"]["observations_created"] = pubmed_observations_created
         source_results["text"]["observations_created"] = text_observations_created
         source_results["pdf"]["observations_created"] = pdf_observations_created
 
@@ -515,9 +516,7 @@ async def _run_pubmed_observation_bridge_batches(
                 "pubmed_observation_bridge_batch_count": len(pubmed_bridge_batches),
                 "pubmed_observation_bridge_batch_index": batch_index,
                 "pubmed_documents_to_bridge_count": len(pubmed_documents_to_bridge),
-                "pubmed_documents_bridged_count": len(
-                    aggregated_pubmed_bridge_results
-                ),
+                "pubmed_documents_bridged_count": len(aggregated_pubmed_bridge_results),
                 "source_results": source_results,
             },
             progress_observer=progress_observer,
@@ -743,11 +742,13 @@ async def _prepare_document_extractions(
                             ),
                         )
 
-                    ai_resolved_entities = await _document_extraction.pre_resolve_entities_with_ai(
-                        space_id=space_id,
-                        candidates=candidates,
-                        graph_api_gateway=doc_gateway,
-                        space_context=objective,
+                    ai_resolved_entities = (
+                        await _document_extraction.pre_resolve_entities_with_ai(
+                            space_id=space_id,
+                            candidates=candidates,
+                            graph_api_gateway=doc_gateway,
+                            space_context=objective,
+                        )
                     )
                     drafts, _skipped = await asyncio.to_thread(
                         _document_extraction.build_document_extraction_drafts,
@@ -758,15 +759,11 @@ async def _prepare_document_extractions(
                         review_context=review_context,
                         ai_resolved_entities=ai_resolved_entities,
                     )
-                    reviewed_drafts = await _document_extraction.review_document_extraction_drafts(
+                    reviewed_drafts = await adjudicate_and_review_document_drafts(
                         document=current_document,
                         candidates=candidates,
-                        drafts=(
-                            _document_extraction.with_candidate_extraction_trust_metadata(
-                                drafts=drafts,
-                                diagnostics=candidate_diagnostics,
-                            )
-                        ),
+                        drafts=drafts,
+                        candidate_diagnostics=candidate_diagnostics,
                         review_context=review_context,
                     )
                     return _PreparedDocumentExtraction(
@@ -845,7 +842,10 @@ async def _prepare_document_extractions(
             progress_percent=min(
                 0.72,
                 0.6
-                + (extraction_progress_span * (completed_count / extraction_total_count)),
+                + (
+                    extraction_progress_span
+                    * (completed_count / extraction_total_count)
+                ),
             ),
             completed_steps=3,
             metadata={
@@ -925,11 +925,13 @@ async def _sync_upload_observation_documents(
         progress_observer=progress_observer,
     )
     try:
-        batch_result = await _sync_file_upload_documents_into_shared_observation_ingestion(
-            space_id=space_id,
-            owner_id=_SYSTEM_OWNER_ID,
-            documents=upload_documents_to_bridge,
-            pipeline_run_id=run.id,
+        batch_result = (
+            await _sync_file_upload_documents_into_shared_observation_ingestion(
+                space_id=space_id,
+                owner_id=_SYSTEM_OWNER_ID,
+                documents=upload_documents_to_bridge,
+                pipeline_run_id=run.id,
+            )
         )
         errors.extend(batch_result.errors)
         _append_unique_entity_ids(

--- a/services/artana_evidence_api/routers/documents.py
+++ b/services/artana_evidence_api/routers/documents.py
@@ -36,9 +36,14 @@ from artana_evidence_api.document_extraction import (
     extract_relation_candidates,
     extract_relation_candidates_with_diagnostics,
     normalize_text_document,
+    pre_resolve_entities_with_ai,
     review_document_extraction_drafts_with_diagnostics,
     sha256_hex,
     with_candidate_extraction_trust_metadata,
+)
+from artana_evidence_api.document_extraction_support.claim_adjudication import (
+    ClaimAdjudicationDiagnostics,
+    adjudicate_document_claims,
 )
 from artana_evidence_api.document_extraction_support.dismech_structured import (
     build_dismech_structured_extraction_drafts,
@@ -143,10 +148,12 @@ def _extraction_diagnostics_metadata(
     *,
     candidate_diagnostics: DocumentCandidateExtractionDiagnostics,
     review_diagnostics: DocumentProposalReviewDiagnostics,
+    claim_adjudication_diagnostics: ClaimAdjudicationDiagnostics,
 ) -> JSONObject:
     return {
         **candidate_diagnostics.as_metadata(),
         **review_diagnostics.as_metadata(),
+        "claim_adjudication": claim_adjudication_diagnostics.as_metadata(),
     }
 
 
@@ -1000,16 +1007,27 @@ async def extract_document(  # noqa: PLR0913, PLR0915
                     regex_candidate_count=0,
                     llm_diagnostics=candidate_diagnostics.as_metadata(),
                 )
+        ai_resolved_entities = await pre_resolve_entities_with_ai(
+            space_id=space_id,
+            candidates=candidates,
+            graph_api_gateway=graph_api_gateway,
+            space_context=review_context.objective or "",
+        )
         drafts, skipped_candidates = build_document_extraction_drafts(
             space_id=space_id,
             document=document,
             candidates=candidates,
             graph_api_gateway=graph_api_gateway,
             review_context=review_context,
+            ai_resolved_entities=ai_resolved_entities,
         )
         drafts = with_candidate_extraction_trust_metadata(
             drafts=drafts,
             diagnostics=candidate_diagnostics,
+        )
+        drafts, claim_adjudication_diagnostics = await adjudicate_document_claims(
+            document=document,
+            drafts=drafts,
         )
         (
             drafts,
@@ -1023,6 +1041,7 @@ async def extract_document(  # noqa: PLR0913, PLR0915
         extraction_diagnostics = _extraction_diagnostics_metadata(
             candidate_diagnostics=candidate_diagnostics,
             review_diagnostics=review_diagnostics,
+            claim_adjudication_diagnostics=claim_adjudication_diagnostics,
         )
         if not candidates:
             skipped_candidates.append(

--- a/services/artana_evidence_api/runtime/agent_output_manifest.py
+++ b/services/artana_evidence_api/runtime/agent_output_manifest.py
@@ -830,6 +830,46 @@ _POLICIES = (
         ),
     ),
     AgentOutputSchemaPolicy(
+        schema_id="document_extraction.claim_adjudication.v1",
+        schema_names=("ClaimAdjudicationOutput",),
+        shape_hash="fca1813bd051bf51168f278950c2a2345e740cc01e464838300c12dc4d77da78",
+        producer_paths=("document_extraction_support/claim_adjudication/service.py",),
+        prompt_identifiers=("document_extraction.claim_adjudication.v1",),
+        categorical_fields=(
+            _category(
+                "$.decisions[].atomicity",
+                {
+                    "ATOMIC": "the item contains one scientific assertion with one predicate and endpoint pair.",
+                    "BUNDLED": "the item combines multiple scientific assertions or predicates.",
+                    "ABSTAIN": "the supplied source cannot resolve whether the item is atomic.",
+                },
+                evidence_requirement="The exact source excerpt and reasoning must establish claim atomicity.",
+            ),
+            _category(
+                "$.decisions[].source_support",
+                {
+                    "ENTAILED": "exact cited source spans explicitly support the complete claim.",
+                    "CONTRADICTED": "the cited source explicitly conflicts with the complete claim.",
+                    "INSUFFICIENT": "the cited source does not establish the complete claim.",
+                    "ABSTAIN": "source support cannot be resolved safely from the supplied text.",
+                },
+                evidence_requirement="ENTAILED requires exact source spans; every value requires reasoning and a falsification condition.",
+            ),
+            _category(
+                "$.decisions[].relationship",
+                {
+                    "CANONICAL": "the claim is the first independent representation of its source-local meaning.",
+                    "SAME_AS": "the claim is semantically equivalent to an earlier claim.",
+                    "REFINES": "the claim adds source-supported material context to an earlier claim.",
+                    "GENERALIZES": "the claim removes material context from an earlier claim.",
+                    "CONTRADICTS": "the claim conflicts with an earlier claim.",
+                    "ABSTAIN": "the relationship cannot be resolved safely.",
+                },
+                evidence_requirement="Relational values require an earlier target claim and source-grounded reasoning.",
+            ),
+        ),
+    ),
+    AgentOutputSchemaPolicy(
         schema_id="document_extraction.proposal_review.v1",
         schema_names=("ProposalReviewResult",),
         shape_hash="172c1f2ab7a2a8d6f3b47dfab1fe2a50a185aac1460b30adb27a4fea22058247",

--- a/services/artana_evidence_api/tests/integration/test_runtime_paths.py
+++ b/services/artana_evidence_api/tests/integration/test_runtime_paths.py
@@ -872,6 +872,16 @@ def _qualified_agent_claim_metadata(
             "model_id": "test-agent-entailment-verifier",
             "verification_method": "agent",
         },
+        "claim_semantic_adjudication": {
+            "claim_ref": "claim-0001",
+            "atomicity": "ATOMIC",
+            "source_support": "ENTAILED",
+            "relationship": "CANONICAL",
+            "target_claim_ref": None,
+            "evidence_spans": [frame.source_evidence.exact_span],
+            "reasoning": "The exact source supports one atomic canonical claim.",
+            "falsification": "An explicit source conflict would falsify the claim.",
+        },
     }
 
 

--- a/services/artana_evidence_api/tests/unit/test_agent_output_schema_registry.py
+++ b/services/artana_evidence_api/tests/unit/test_agent_output_schema_registry.py
@@ -543,7 +543,7 @@ def test_recovery_schema_registry_governs_categorical_adjudication() -> None:
 def test_registry_report_exposes_merge_gate_counts() -> None:
     report = build_agent_output_registry_report()
 
-    assert report["registered_schema_count"] == 19
+    assert report["registered_schema_count"] == 20
     assert report["registered_numeric_field_count"] == 3
     assert report["origin_governed_numeric_field_count"] == 3
     assert report["debt_numeric_field_count"] == 0

--- a/services/artana_evidence_api/tests/unit/test_app.py
+++ b/services/artana_evidence_api/tests/unit/test_app.py
@@ -459,6 +459,17 @@ def _with_qualified_agent_claim(
             "support_verification": {
                 "support": "ENTAILS",
                 "verification_method": "agent",
+                "model_id": "test:claim-adjudicator",
+            },
+            "claim_semantic_adjudication": {
+                "claim_ref": "claim-0001",
+                "atomicity": "ATOMIC",
+                "source_support": "ENTAILED",
+                "relationship": "CANONICAL",
+                "target_claim_ref": None,
+                "evidence_spans": [exact_evidence],
+                "reasoning": "The source supports one atomic canonical claim.",
+                "falsification": "An explicit source conflict would falsify it.",
             },
         },
     )

--- a/services/artana_evidence_api/tests/unit/test_claim_inventory_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_claim_inventory_extraction.py
@@ -515,9 +515,7 @@ def _replay_inventory_attempt(
     chunk = _chunk(text)
     attempts = tuple(record.as_json() for record in result.model_attempt_records)
     initial = next(
-        attempt
-        for attempt in attempts
-        if attempt["attempt_role"] == "claim_inventory"
+        attempt for attempt in attempts if attempt["attempt_role"] == "claim_inventory"
     )
     zero = next(
         attempt
@@ -1969,24 +1967,28 @@ async def test_inventory_converges_after_two_bounded_recovery_rounds() -> None:
     assert result.semantic_inventory_complete is True
     assert len(result.claims) == 3
     assert result.inventory_recovery_round_count == 2
-    assert result.inventory_convergence_stop_reasons == (
-        "CONFIRMED_COMPLETE",
+    assert result.inventory_convergence_stop_reasons == ("CONFIRMED_COMPLETE",)
+    assert (
+        len(
+            [
+                record
+                for record in result.model_attempt_records
+                if record.pass_role == "claim_inventory_completeness"
+                and record.validation_outcome == "accepted"
+            ]
+        )
+        == 3
     )
-    assert len(
-        [
-            record
-            for record in result.model_attempt_records
-            if record.pass_role == "claim_inventory_completeness"
-            and record.validation_outcome == "accepted"
-        ]
-    ) == 3
-    assert len(
-        [
-            record
-            for record in result.model_attempt_records
-            if record.pass_role == "claim_inventory_recovery"
-        ]
-    ) == 2
+    assert (
+        len(
+            [
+                record
+                for record in result.model_attempt_records
+                if record.pass_role == "claim_inventory_recovery"
+            ]
+        )
+        == 2
+    )
     replay = _replay_inventory_attempt(
         text=text,
         result=result,
@@ -2043,13 +2045,16 @@ async def test_recovery_adjudicates_every_descriptor_before_abstaining() -> None
         reversed_result.inventory_convergence_round_traces
     )
     assert forward.inventory_convergence_stop_reasons == ("RECOVERY_ABSTAINED",)
-    assert len(
-        [
-            record
-            for record in forward.model_attempt_records
-            if record.pass_role == "claim_inventory_recovery"
-        ]
-    ) == 2
+    assert (
+        len(
+            [
+                record
+                for record in forward.model_attempt_records
+                if record.pass_role == "claim_inventory_recovery"
+            ]
+        )
+        == 2
+    )
 
 
 def test_inventory_batch_hash_is_independent_of_agent_output_order() -> None:
@@ -2133,9 +2138,7 @@ async def test_inventory_stops_incomplete_after_two_recovery_rounds() -> None:
         ClaimInventoryItem.model_validate(fourth),
     ]
     assert result.inventory_recovery_round_count == 2
-    assert result.inventory_convergence_stop_reasons == (
-        "MAX_RECOVERY_ROUNDS",
-    )
+    assert result.inventory_convergence_stop_reasons == ("MAX_RECOVERY_ROUNDS",)
     assert len(runner.calls) == 6
 
 
@@ -2216,9 +2219,7 @@ async def test_duplicate_only_completeness_review_stops_without_another_agent_ca
     assert result.inventory_incompleteness == ()
     assert result.unresolved_binding_rejection_count == 1
     assert result.inventory_recovery_round_count == 0
-    assert result.inventory_convergence_stop_reasons == (
-        "NO_NEW_IDENTITIES",
-    )
+    assert result.inventory_convergence_stop_reasons == ("NO_NEW_IDENTITIES",)
     assert len(runner.calls) == 2
 
 
@@ -2341,9 +2342,7 @@ async def test_recovery_abstention_remains_semantically_incomplete() -> None:
         descriptor,
     )
     assert result.inventory_recovery_round_count == 1
-    assert result.inventory_convergence_stop_reasons == (
-        "RECOVERY_ABSTAINED",
-    )
+    assert result.inventory_convergence_stop_reasons == ("RECOVERY_ABSTAINED",)
     assert len(runner.calls) == 4
 
 
@@ -2714,9 +2713,11 @@ async def test_non_positive_claims_over_limit_are_routed_without_loss() -> None:
 
     assert len(result.candidates) == 2
     assert len(result.claim_lineage) == 2
-    assert len(routed) == 1
+    assert len(routed) == 2
     assert routed.claim_extraction_routing_status == "candidate_overflow"
     assert routed.candidate_overflow_count == 1
+    assert routed[1].review_status == "review_only"
+    assert "candidate_overflow" in routed[1].review_reason_codes
     assert routed.overflow_candidates[0].claim_frame is not None
     assert routed.overflow_candidates[0].claim_frame.polarity.value == "SUPPORT"
     assert (
@@ -2725,7 +2726,7 @@ async def test_non_positive_claims_over_limit_are_routed_without_loss() -> None:
 
 
 @pytest.mark.asyncio
-async def test_post_recovery_incomplete_inventory_fails_closed_with_lineage(
+async def test_post_recovery_incomplete_inventory_preserves_review_only_lineage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     first_span = "MED13 causes cardiomyopathy."
@@ -2792,9 +2793,15 @@ async def test_post_recovery_incomplete_inventory_fails_closed_with_lineage(
     assert result.semantic_inventory_complete is False
     assert len(result.inventory_incompleteness) == 1
     assert len(result.claim_lineage) == 2
-    assert routed == []
+    assert len(routed) == 2
+    assert all(candidate.review_status == "review_only" for candidate in routed)
+    assert all(
+        "semantic_inventory_incomplete" in candidate.review_reason_codes
+        for candidate in routed
+    )
+    assert all(not candidate.trusted_evidence_eligible for candidate in routed)
     assert routed.claim_extraction_routing_status == "semantic_incomplete"
-    assert tuple(routed.overflow_candidates) == tuple(result.candidates)
+    assert routed.overflow_candidates == ()
 
     async def _incomplete_agent_result(
         _text: str,
@@ -2820,9 +2827,24 @@ async def test_post_recovery_incomplete_inventory_fails_closed_with_lineage(
 
     assert discovered is routed
     assert diagnostics.llm_candidate_status == "semantic_incomplete"
+    assert diagnostics.llm_candidate_count == 2
     assert diagnostics.fallback_output_used is False
     assert diagnostics.trusted_evidence_eligible is False
     assert diagnostics.claim_lineage == result.claim_lineage
+    assert len(diagnostics.inventory_incompleteness) == 1
+    assert diagnostics.inventory_incompleteness[0]["claim"]["exact_span"] == third_span
+
+    drafts = _build_pipeline_drafts(
+        monkeypatch=monkeypatch,
+        text=text,
+        candidates=list(discovered),
+    )
+    assert len(drafts) == 2
+    assert all(draft.metadata["review_status"] == "review_only" for draft in drafts)
+    assert all(
+        "semantic_inventory_incomplete" in draft.metadata["review_reason_codes"]
+        for draft in drafts
+    )
 
 
 @pytest.mark.asyncio

--- a/services/artana_evidence_api/tests/unit/test_document_claim_adjudication.py
+++ b/services/artana_evidence_api/tests/unit/test_document_claim_adjudication.py
@@ -1,0 +1,505 @@
+"""Regression tests for categorical document-claim adjudication."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from artana_evidence_api.document_extraction_support.claim_adjudication.contracts import (
+    ClaimAdjudicationDecision,
+    ClaimAdjudicationDiagnostics,
+    ClaimAdjudicationOutput,
+)
+from artana_evidence_api.document_extraction_support.claim_adjudication.runtime import (
+    with_claim_adjudication_diagnostics,
+)
+from artana_evidence_api.document_extraction_support.claim_adjudication.service import (
+    adjudicate_document_claims,
+)
+from artana_evidence_api.document_store import HarnessDocumentRecord
+from artana_evidence_api.proposal_store import HarnessProposalDraft
+
+
+@dataclass
+class _Agent:
+    output: ClaimAdjudicationOutput
+    model_id: str = "test:categorical-reviewer"
+
+    async def adjudicate(self, *, prompt: str) -> ClaimAdjudicationOutput:
+        assert "Never return confidence" in prompt
+        return self.output
+
+
+@dataclass
+class _BatchAgent:
+    spans_by_ref: dict[str, str]
+    relationship_target_by_ref: dict[str, str] | None = None
+    model_id: str = "test:batched-categorical-reviewer"
+    call_count: int = 0
+
+    async def adjudicate(self, *, prompt: str) -> ClaimAdjudicationOutput:
+        self.call_count += 1
+        claim_refs = [
+            line.removeprefix("Claim reference: ")
+            for line in prompt.splitlines()
+            if line.startswith("Claim reference: ")
+        ]
+        return ClaimAdjudicationOutput(
+            decisions=[
+                _decision(
+                    claim_ref=claim_ref,
+                    span=self.spans_by_ref[claim_ref],
+                    relationship=(
+                        "SAME_AS"
+                        if self.relationship_target_by_ref
+                        and claim_ref in self.relationship_target_by_ref
+                        else "CANONICAL"
+                    ),
+                    target=(
+                        self.relationship_target_by_ref.get(claim_ref)
+                        if self.relationship_target_by_ref
+                        else None
+                    ),
+                )
+                for claim_ref in claim_refs
+            ],
+        )
+
+
+def _document(text: str) -> HarnessDocumentRecord:
+    now = datetime.now(UTC)
+    return HarnessDocumentRecord(
+        id="document-1",
+        space_id=str(uuid4()),
+        created_by=str(uuid4()),
+        title="Claim adjudication source",
+        source_type="text",
+        filename=None,
+        media_type="text/plain",
+        sha256="source-sha",
+        byte_size=len(text.encode()),
+        page_count=None,
+        text_content=text,
+        text_excerpt=text,
+        raw_storage_key=None,
+        enriched_storage_key=None,
+        ingestion_run_id=str(uuid4()),
+        last_enrichment_run_id=None,
+        last_extraction_run_id=None,
+        enrichment_status="completed",
+        extraction_status="completed",
+        metadata={},
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _draft(
+    *,
+    subject: str,
+    relation: str,
+    object_: str,
+    sentence: str,
+    review_status: str = "candidate",
+) -> HarnessProposalDraft:
+    return HarnessProposalDraft(
+        proposal_type="candidate_claim",
+        source_kind="document_extraction",
+        source_key=f"document-1:{subject}:{relation}:{object_}",
+        title=f"{subject} {relation} {object_}",
+        summary=sentence,
+        confidence=0.8,
+        ranking_score=0.7,
+        reasoning_path={},
+        evidence_bundle=[],
+        payload={
+            "proposed_subject_label": subject,
+            "proposed_claim_type": relation,
+            "proposed_object_label": object_,
+        },
+        metadata={
+            "subject_label": subject,
+            "resolved_subject_label": subject,
+            "object_label": object_,
+            "resolved_object_label": object_,
+            "review_status": review_status,
+            "review_reason_codes": (
+                ["semantic_inventory_incomplete"]
+                if review_status == "review_only"
+                else []
+            ),
+        },
+    )
+
+
+def _decision(
+    *,
+    claim_ref: str,
+    span: str,
+    atomicity: str = "ATOMIC",
+    support: str = "ENTAILED",
+    relationship: str = "CANONICAL",
+    target: str | None = None,
+) -> ClaimAdjudicationDecision:
+    return ClaimAdjudicationDecision.model_validate(
+        {
+            "claim_ref": claim_ref,
+            "atomicity": atomicity,
+            "source_support": support,
+            "relationship": relationship,
+            "target_claim_ref": target,
+            "evidence_spans": [span] if support == "ENTAILED" else [],
+            "reasoning": "The exact source supports this categorical decision.",
+            "falsification": "A source statement with the opposite relation would falsify it.",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_entailed_atomic_claim_gets_agent_support_without_numeric_judgment() -> (
+    None
+):
+    sentence = "GATA3 represses FOXP3."
+    draft = _draft(
+        subject="GATA3",
+        relation="INHIBITS",
+        object_="FOXP3",
+        sentence=sentence,
+    )
+
+    (updated,), diagnostics = await adjudicate_document_claims(
+        document=_document(sentence),
+        drafts=(draft,),
+        agent=_Agent(
+            ClaimAdjudicationOutput(
+                decisions=[_decision(claim_ref="claim-0001", span=sentence)],
+            ),
+        ),
+    )
+
+    assert diagnostics.status == "completed"
+    assert diagnostics.metrics == {
+        "total_claims": 1,
+        "atomic_claims": 1,
+        "bundled_claims": 0,
+        "atomicity_abstentions": 0,
+        "entailed_claims": 1,
+        "contradicted_claims": 0,
+        "insufficient_claims": 0,
+        "support_abstentions": 0,
+        "canonical_claims": 1,
+        "same_as_claims": 0,
+        "refining_claims": 0,
+        "generalizing_claims": 0,
+        "claim_contradictions": 0,
+        "relationship_abstentions": 0,
+    }
+    assert updated.metadata["review_status"] == "candidate"
+    assert updated.metadata["support_verification"] == {
+        "support": "ENTAILS",
+        "rationale": "The exact source supports this categorical decision.",
+        "model_id": "test:categorical-reviewer",
+        "verification_method": "agent",
+        "evidence_spans": [sentence],
+        "falsification": "A source statement with the opposite relation would falsify it.",
+    }
+    adjudication = updated.metadata["claim_semantic_adjudication"]
+    assert isinstance(adjudication, dict)
+    assert "confidence" not in adjudication
+    assert updated.confidence == draft.confidence
+
+
+@pytest.mark.asyncio
+async def test_incomplete_inventory_stays_review_only_after_positive_adjudication() -> (
+    None
+):
+    sentence = "TGF-beta down-regulates CD25."
+    draft = _draft(
+        subject="TGF-beta",
+        relation="INHIBITS",
+        object_="CD25",
+        sentence=sentence,
+        review_status="review_only",
+    )
+
+    (updated,), _ = await adjudicate_document_claims(
+        document=_document(sentence),
+        drafts=(draft,),
+        agent=_Agent(
+            ClaimAdjudicationOutput(
+                decisions=[_decision(claim_ref="claim-0001", span=sentence)],
+            ),
+        ),
+    )
+
+    assert updated.metadata["review_status"] == "review_only"
+    assert updated.metadata["review_reason_codes"] == [
+        "semantic_inventory_incomplete",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_same_claim_is_preserved_as_review_only_relation() -> None:
+    first = "TGF-beta down-regulates CD25."
+    second = "CD25 is suppressed by TGF-beta."
+    drafts = (
+        _draft(
+            subject="TGF-beta",
+            relation="INHIBITS",
+            object_="CD25",
+            sentence=first,
+        ),
+        _draft(
+            subject="TGF-beta",
+            relation="INHIBITS",
+            object_="CD25",
+            sentence=second,
+        ),
+    )
+    output = ClaimAdjudicationOutput(
+        decisions=[
+            _decision(claim_ref="claim-0001", span=first),
+            _decision(
+                claim_ref="claim-0002",
+                span=second,
+                relationship="SAME_AS",
+                target="claim-0001",
+            ),
+        ],
+    )
+
+    updated, _ = await adjudicate_document_claims(
+        document=_document(f"{first} {second}"),
+        drafts=drafts,
+        agent=_Agent(output),
+    )
+
+    assert updated[0].metadata["review_status"] == "candidate"
+    assert updated[1].metadata["review_status"] == "review_only"
+    assert "claim_relationship_same_as" in updated[1].metadata["review_reason_codes"]
+    assert (
+        updated[1].metadata["claim_semantic_adjudication"]["target_claim_ref"]
+        == "claim-0001"
+    )
+    assert updated[1].metadata["claim_relation_proposal"] == {
+        "relation_type": "SAME_AS",
+        "target_source_key": drafts[0].source_key,
+        "target_claim_fingerprint": None,
+        "evidence_summary": "The exact source supports this categorical decision.",
+        "review_status": "PROPOSED",
+    }
+
+
+@pytest.mark.asyncio
+async def test_bundled_or_unverified_claims_fail_closed_deterministically() -> None:
+    sentence = "IL-4 inhibits FOXP3 without interfering with TGF-beta signaling."
+    draft = _draft(
+        subject="IL-4",
+        relation="INHIBITS",
+        object_="FOXP3",
+        sentence=sentence,
+    )
+    output = ClaimAdjudicationOutput(
+        decisions=[
+            _decision(
+                claim_ref="claim-0001",
+                span=sentence,
+                atomicity="BUNDLED",
+                support="INSUFFICIENT",
+                relationship="ABSTAIN",
+            ),
+        ],
+    )
+
+    (updated,), _ = await adjudicate_document_claims(
+        document=_document(sentence),
+        drafts=(draft,),
+        agent=_Agent(output),
+    )
+
+    assert updated.metadata["review_status"] == "review_only"
+    assert "claim_atomicity_bundled" in updated.metadata["review_reason_codes"]
+    assert updated.metadata["support_verification"]["support"] == "NEUTRAL"
+    assert updated.confidence == 0.25
+    assert updated.ranking_score == 0.25
+
+
+@pytest.mark.asyncio
+async def test_invalid_agent_coverage_marks_every_claim_review_only() -> None:
+    sentence = "GATA3 represses FOXP3."
+    draft = _draft(
+        subject="GATA3",
+        relation="INHIBITS",
+        object_="FOXP3",
+        sentence=sentence,
+    )
+
+    (updated,), diagnostics = await adjudicate_document_claims(
+        document=_document(sentence),
+        drafts=(draft,),
+        agent=_Agent(ClaimAdjudicationOutput(decisions=[])),
+    )
+
+    assert diagnostics.status == "unavailable"
+    assert updated.metadata["review_status"] == "review_only"
+    assert "claim_adjudication_unavailable" in updated.metadata["review_reason_codes"]
+    assert updated.metadata["support_verification"]["verification_method"] == (
+        "unavailable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_relationship_target_fails_closed() -> None:
+    sentence = "GATA3 represses FOXP3."
+    draft = _draft(
+        subject="GATA3",
+        relation="INHIBITS",
+        object_="FOXP3",
+        sentence=sentence,
+    )
+    decision = _decision(
+        claim_ref="claim-0001",
+        span=sentence,
+        relationship="SAME_AS",
+        target="claim-9999",
+    )
+
+    (updated,), diagnostics = await adjudicate_document_claims(
+        document=_document(sentence),
+        drafts=(draft,),
+        agent=_Agent(ClaimAdjudicationOutput(decisions=[decision])),
+    )
+
+    assert diagnostics.status == "unavailable"
+    assert diagnostics.error == "claim relationship target is not in this document"
+    assert updated.metadata["review_status"] == "review_only"
+    assert "claim_adjudication_unavailable" in updated.metadata["review_reason_codes"]
+
+
+@pytest.mark.asyncio
+async def test_evidence_from_another_claim_cannot_entail_this_claim() -> None:
+    first = "GATA3 represses FOXP3."
+    second = "IL-4 activates STAT6."
+    drafts = (
+        _draft(
+            subject="GATA3",
+            relation="INHIBITS",
+            object_="FOXP3",
+            sentence=first,
+        ),
+        _draft(
+            subject="IL-4",
+            relation="ACTIVATES",
+            object_="STAT6",
+            sentence=second,
+        ),
+    )
+    output = ClaimAdjudicationOutput(
+        decisions=[
+            _decision(claim_ref="claim-0001", span=second),
+            _decision(claim_ref="claim-0002", span=second),
+        ],
+    )
+
+    updated, diagnostics = await adjudicate_document_claims(
+        document=_document(f"{first} {second}"),
+        drafts=drafts,
+        agent=_Agent(output),
+    )
+
+    assert diagnostics.status == "unavailable"
+    assert diagnostics.error == (
+        "claim evidence span is outside the adjudicated claim excerpt"
+    )
+    assert all(draft.metadata["review_status"] == "review_only" for draft in updated)
+
+
+def test_research_init_draft_preserves_adjudication_diagnostics() -> None:
+    draft = _draft(
+        subject="GATA3",
+        relation="INHIBITS",
+        object_="FOXP3",
+        sentence="GATA3 represses FOXP3.",
+    )
+
+    (updated,) = with_claim_adjudication_diagnostics(
+        drafts=(draft,),
+        diagnostics=ClaimAdjudicationDiagnostics(
+            status="unavailable",
+            model_id="openai:gpt-5.6-luna",
+            error="provider timeout",
+        ),
+    )
+
+    assert updated.metadata["claim_adjudication_diagnostics"] == {
+        "status": "unavailable",
+        "decision_count": 0,
+        "model_id": "openai:gpt-5.6-luna",
+        "error": "provider timeout",
+    }
+
+
+@pytest.mark.asyncio
+async def test_adjudication_batches_large_candidate_sets_in_source_order() -> None:
+    sentences = tuple(f"GENE{i} activates TARGET{i}." for i in range(13))
+    drafts = tuple(
+        _draft(
+            subject=f"GENE{index}",
+            relation="ACTIVATES",
+            object_=f"TARGET{index}",
+            sentence=sentence,
+        )
+        for index, sentence in enumerate(sentences)
+    )
+    agent = _BatchAgent(
+        spans_by_ref={
+            f"claim-{index:04d}": sentence
+            for index, sentence in enumerate(sentences, start=1)
+        },
+    )
+
+    updated, diagnostics = await adjudicate_document_claims(
+        document=_document(" ".join(sentences)),
+        drafts=drafts,
+        agent=agent,
+    )
+
+    assert agent.call_count == 2
+    assert diagnostics.status == "completed"
+    assert diagnostics.decision_count == 13
+    assert all("claim_semantic_adjudication" in draft.metadata for draft in updated)
+
+
+@pytest.mark.asyncio
+async def test_batch_cannot_target_prior_claim_outside_visible_context() -> None:
+    sentences = tuple(f"GENE{i} activates TARGET{i}." for i in range(37))
+    drafts = tuple(
+        _draft(
+            subject=f"GENE{index}",
+            relation="ACTIVATES",
+            object_=f"TARGET{index}",
+            sentence=sentence,
+        )
+        for index, sentence in enumerate(sentences)
+    )
+    agent = _BatchAgent(
+        spans_by_ref={
+            f"claim-{index:04d}": sentence
+            for index, sentence in enumerate(sentences, start=1)
+        },
+        relationship_target_by_ref={"claim-0037": "claim-0001"},
+    )
+
+    updated, diagnostics = await adjudicate_document_claims(
+        document=_document(" ".join(sentences)),
+        drafts=drafts,
+        agent=agent,
+    )
+
+    assert diagnostics.status == "unavailable"
+    assert diagnostics.error == (
+        "claim relationship target is outside the adjudication context"
+    )
+    assert all(draft.metadata["review_status"] == "review_only" for draft in updated)

--- a/services/artana_evidence_api/tests/unit/test_document_extraction.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction.py
@@ -1539,8 +1539,14 @@ async def test_extract_relation_candidates_with_llm_filters_pathway_target_sibli
         "Vemurafenib targets BRAF V600E and inhibits MAPK signaling.",
     )
 
-    assert len(candidates) == 1
+    assert len(candidates) == 2
     assert candidates[0].relation_type == "TARGETS"
+    assert candidates[1].relation_type == "INHIBITS"
+    assert candidates[1].review_status == "review_only"
+    assert (
+        "quality_filter_pathway_effect_shadowed_by_direct_target"
+        in candidates[1].review_reason_codes
+    )
     assert candidates[0].trusted_evidence_eligible is False
     assert candidates[0].review_status == "review_only"
     assert "review_only_object_grounding" in candidates[0].review_reason_codes
@@ -2100,8 +2106,14 @@ async def test_extract_relation_candidates_with_llm_prunes_redundant_generic_sib
         "MED13 activates EGFR and is associated with EGFR.",
     )
 
-    assert len(candidates) == 1
-    assert candidates[0].relation_type == "ACTIVATES"
+    assert len(candidates) == 2
+    assert candidates[0].relation_type == "ASSOCIATED_WITH"
+    assert candidates[0].review_status == "review_only"
+    assert (
+        "generic_relation_shadowed_by_specific_sibling"
+        in candidates[0].review_reason_codes
+    )
+    assert candidates[1].relation_type == "ACTIVATES"
     assert candidates[0].subject_label == "MED13"
     assert candidates[0].object_label == "EGFR"
 
@@ -2138,10 +2150,12 @@ async def test_discover_relation_candidates_reports_llm_pruned_generic_siblings(
         "MED13 activates EGFR and is associated with EGFR.",
     )
 
-    assert len(candidates) == 1
-    assert candidates[0].relation_type == "ACTIVATES"
+    assert len(candidates) == 2
+    assert candidates[0].relation_type == "ASSOCIATED_WITH"
+    assert candidates[0].review_status == "review_only"
+    assert candidates[1].relation_type == "ACTIVATES"
     assert diagnostics.llm_candidate_status == "completed"
-    assert diagnostics.llm_candidate_count == 1
+    assert diagnostics.llm_candidate_count == 2
     assert diagnostics.pruned_generic_relation_count == 1
     assert diagnostics.as_metadata()["pruned_generic_relation_count"] == 1
 

--- a/services/artana_evidence_api/tests/unit/test_document_extraction_modules.py
+++ b/services/artana_evidence_api/tests/unit/test_document_extraction_modules.py
@@ -1433,6 +1433,49 @@ def test_review_helpers_rank_specific_grounded_entailed_claim_above_generic_ungr
     assert ranked_weak.metadata["evidence_quality_component"] == 0.0
 
 
+def test_proposal_review_cannot_overwrite_adjudication_safety_ceiling() -> None:
+    context = build_document_review_context(objective="Study IL-4 and FOXP3.")
+    strong_review = DocumentProposalReview(
+        factual_support="strong",
+        goal_relevance="direct",
+        priority="prioritize",
+        rationale="The later reviewer rated this highly.",
+        factual_rationale="Strong according to the later pass.",
+        relevance_rationale="Directly relevant.",
+        method="unit_test",
+    )
+    draft = HarnessProposalDraft(
+        proposal_type="candidate_claim",
+        source_kind="document_extraction",
+        source_key="document-1:unsafe",
+        title="Bundled IL-4 claim",
+        summary="IL-4 inhibits FOXP3 without changing TGF-beta signaling.",
+        confidence=0.25,
+        ranking_score=0.25,
+        reasoning_path={},
+        evidence_bundle=[{"relevance": 0.1}],
+        payload={"proposed_claim_type": "INHIBITS"},
+        metadata={
+            "review_status": "review_only",
+            "claim_semantic_adjudication": {
+                "atomicity": "BUNDLED",
+                "source_support": "INSUFFICIENT",
+                "relationship": "ABSTAIN",
+            },
+        },
+        document_id="document-1",
+    )
+
+    updated = apply_document_proposal_review(
+        draft=draft,
+        review=strong_review,
+        review_context=context,
+    )
+
+    assert updated.confidence == 0.25
+    assert updated.ranking_score == 0.25
+
+
 def test_draft_builder_assembles_reviewed_proposals_from_candidates() -> None:
     gateway = _GraphGateway()
     candidate = ExtractedRelationCandidate(

--- a/services/artana_evidence_api/tests/unit/test_documents_router.py
+++ b/services/artana_evidence_api/tests/unit/test_documents_router.py
@@ -1377,9 +1377,13 @@ def test_extract_document_surfaces_llm_review_fallback_in_metadata(
         "llm_candidate_error": "synthetic candidate outage",
         "llm_review_status": "fallback_error",
         "llm_review_attempted": True,
-        "llm_review_failed": True,
-        "llm_review_error": "synthetic llm outage",
-    }
+            "llm_review_failed": True,
+            "llm_review_error": "synthetic llm outage",
+            "claim_adjudication": {
+                "status": "not_needed",
+                "decision_count": 0,
+            },
+        }
 
     stored_document = document_store.get_document(
         space_id=space_id,

--- a/services/artana_evidence_api/tests/unit/test_proposal_actions.py
+++ b/services/artana_evidence_api/tests/unit/test_proposal_actions.py
@@ -600,8 +600,9 @@ def test_build_graph_observation_request_preserves_source_measurement_provenance
     assert request.provenance.extraction_run_id == run_id
     assert request.provenance.mapping_method == "agent_source_measurement"
     assert request.provenance.raw_input is not None
-    assert request.provenance.raw_input["source_measurement"] == (
-        proposal.payload["source_measurement"]
+    assert (
+        request.provenance.raw_input["source_measurement"]
+        == (proposal.payload["source_measurement"])
     )
 
 
@@ -928,6 +929,17 @@ def _proposal_with_resolved_entities(
             "support_verification": {
                 "support": "ENTAILS",
                 "verification_method": "agent",
+                "model_id": "test:claim-adjudicator",
+            },
+            "claim_semantic_adjudication": {
+                "claim_ref": "claim-0001",
+                "atomicity": "ATOMIC",
+                "source_support": "ENTAILED",
+                "relationship": "CANONICAL",
+                "target_claim_ref": None,
+                "evidence_spans": [quote],
+                "reasoning": "The exact source supports the complete claim.",
+                "falsification": "An explicit source contradiction would falsify it.",
             },
             "proposal_review": {
                 "factual_support": "strong",
@@ -1573,6 +1585,83 @@ def test_promote_to_graph_claim_requires_agent_entailment_verification() -> None
     assert exc_info.value.detail["reason_code"] == "agent_support_not_verified"
     assert gateway.calls == []
     assert gateway.claim_calls == []
+
+
+def test_promote_to_graph_claim_requires_atomic_canonical_adjudication() -> None:
+    proposal = _proposal_with_resolved_entities()
+    gateway = _MockRelationGateway()
+    adjudication = {
+        **proposal.metadata["claim_semantic_adjudication"],
+        "atomicity": "BUNDLED",
+        "relationship": "ABSTAIN",
+    }
+
+    with pytest.raises(HTTPException) as exc_info:
+        promote_to_graph_claim(
+            space_id=UUID(proposal.space_id),
+            proposal=replace(
+                proposal,
+                metadata={
+                    **proposal.metadata,
+                    "claim_semantic_adjudication": adjudication,
+                },
+            ),
+            request_metadata={},
+            graph_api_gateway=gateway,
+            source_document=_source_document_for_proposal(proposal),
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["reason_code"] == (
+        "claim_semantic_adjudication_not_promotable"
+    )
+    assert gateway.calls == []
+    assert gateway.claim_calls == []
+
+
+def test_promotion_rejects_structurally_incomplete_adjudication_metadata() -> None:
+    proposal = _proposal_with_resolved_entities()
+    invalid_adjudication = {
+        key: value
+        for key, value in proposal.metadata["claim_semantic_adjudication"].items()
+        if key != "falsification"
+    }
+
+    with pytest.raises(ClaimFramePromotionError) as exc_info:
+        require_canonical_claim_promotion(
+            payload=proposal.payload,
+            metadata={
+                **proposal.metadata,
+                "claim_semantic_adjudication": invalid_adjudication,
+            },
+            source_text=proposal.summary,
+            source_sha256=hashlib.sha256(proposal.summary.encode("utf-8")).hexdigest(),
+        )
+
+    assert exc_info.value.reason_code == "invalid_claim_semantic_adjudication"
+
+
+def test_promotion_rejects_adjudication_evidence_from_another_source_region() -> None:
+    proposal = _proposal_with_resolved_entities()
+    unrelated_span = "IL-4 activates STAT6."
+    source_text = f"{proposal.summary} {unrelated_span}"
+    adjudication = {
+        **proposal.metadata["claim_semantic_adjudication"],
+        "evidence_spans": [unrelated_span],
+    }
+
+    with pytest.raises(ClaimFramePromotionError) as exc_info:
+        require_canonical_claim_promotion(
+            payload=proposal.payload,
+            metadata={
+                **proposal.metadata,
+                "claim_semantic_adjudication": adjudication,
+            },
+            source_text=source_text,
+            source_sha256=hashlib.sha256(source_text.encode("utf-8")).hexdigest(),
+        )
+
+    assert exc_info.value.reason_code == "claim_adjudication_evidence_mismatch"
 
 
 def test_source_document_gate_follows_structural_claim_preflight() -> None:

--- a/services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py
+++ b/services/artana_evidence_api/tests/unit/test_relation_candidate_quality_filter.py
@@ -6,6 +6,9 @@ import pytest
 from artana_evidence_api.document_extraction_contracts import (
     ExtractedRelationCandidate,
 )
+from artana_evidence_api.document_extraction_support.claim_adjudication.candidate_preservation import (
+    preserve_quality_filtered_candidates_for_adjudication,
+)
 from artana_evidence_api.document_extraction_support.claim_frames import (
     ClaimFrame,
     ClaimQualifier,
@@ -360,7 +363,9 @@ def test_quality_filter_merges_weak_review_and_promotion_safety_reasons() -> Non
     }
 
 
-def test_quality_filter_removes_companion_phenotype_when_disease_sibling_exists() -> None:
+def test_quality_filter_removes_companion_phenotype_when_disease_sibling_exists() -> (
+    None
+):
     disease_candidate = ExtractedRelationCandidate(
         subject_label="MECP2 pathogenic variants",
         relation_type="ASSOCIATED_WITH",
@@ -418,7 +423,9 @@ def test_quality_filter_marks_single_companion_phenotype_review_only() -> None:
     assert result.filtered_candidates == ()
 
 
-def test_quality_filter_marks_single_biochemical_companion_phenotype_review_only() -> None:
+def test_quality_filter_marks_single_biochemical_companion_phenotype_review_only() -> (
+    None
+):
     candidate = ExtractedRelationCandidate(
         subject_label="PAH pathogenic variants",
         relation_type="ASSOCIATED_WITH",
@@ -439,7 +446,9 @@ def test_quality_filter_marks_single_biochemical_companion_phenotype_review_only
     assert result.filtered_candidates == ()
 
 
-def test_quality_filter_removes_biochemical_companion_when_disease_sibling_exists() -> None:
+def test_quality_filter_removes_biochemical_companion_when_disease_sibling_exists() -> (
+    None
+):
     disease_candidate = ExtractedRelationCandidate(
         subject_label="PAH pathogenic variants",
         relation_type="ASSOCIATED_WITH",
@@ -482,8 +491,7 @@ def test_quality_filter_keeps_correlated_only_specific_relation_review_only() ->
         relation_type="CONFERS_RESISTANCE_TO",
         object_label="EGFR inhibition",
         sentence=(
-            "MET amplification was correlated with resistance to EGFR "
-            "inhibition."
+            "MET amplification was correlated with resistance to EGFR inhibition."
         ),
         review_status="review_only",
         review_reason_codes=("hedged_language", "correlated_only"),
@@ -518,7 +526,9 @@ def test_quality_filter_repairs_correlated_resistance_review_object() -> None:
     assert result.filtered_candidates == ()
 
 
-def test_quality_filter_clears_stale_object_curie_after_resistance_object_repair() -> None:
+def test_quality_filter_clears_stale_object_curie_after_resistance_object_repair() -> (
+    None
+):
     candidate = ExtractedRelationCandidate(
         subject_label="MET amplification",
         relation_type="ASSOCIATED_WITH",
@@ -601,7 +611,9 @@ def test_quality_filter_does_not_repair_bare_and_trend_but_reviews_response() ->
     )
 
 
-def test_quality_filter_does_not_repair_resistance_object_from_unrelated_clause() -> None:
+def test_quality_filter_does_not_repair_resistance_object_from_unrelated_clause() -> (
+    None
+):
     candidate = ExtractedRelationCandidate(
         subject_label="MET amplification",
         relation_type="ASSOCIATED_WITH",
@@ -618,7 +630,9 @@ def test_quality_filter_does_not_repair_resistance_object_from_unrelated_clause(
     assert result.candidates[0].object_label == "EGFR inhibition"
 
 
-def test_quality_filter_does_not_repair_resistance_object_from_bare_and_clause() -> None:
+def test_quality_filter_does_not_repair_resistance_object_from_bare_and_clause() -> (
+    None
+):
     candidate = ExtractedRelationCandidate(
         subject_label="MET amplification",
         relation_type="ASSOCIATED_WITH",
@@ -670,9 +684,23 @@ def test_quality_filter_deduplicates_repaired_review_candidates() -> None:
         "weak_review_agent_pass",
     )
     assert result.filtered_candidates == ()
+    assert len(result.unmerged_candidates) == 2
+
+    preserved = preserve_quality_filtered_candidates_for_adjudication(
+        candidates=(primary_candidate, weak_pass_candidate),
+        quality_filter_result=result,
+    )
+
+    assert len(preserved.candidates) == 2
+    assert all(
+        candidate.object_label == "resistance to EGFR inhibition"
+        for candidate in preserved.candidates
+    )
 
 
-def test_quality_filter_repairs_trend_response_relation_type_to_review_association() -> None:
+def test_quality_filter_repairs_trend_response_relation_type_to_review_association() -> (
+    None
+):
     candidate = ExtractedRelationCandidate(
         subject_label="EGFR expression",
         relation_type="BIOMARKER_FOR",
@@ -807,7 +835,9 @@ def test_quality_filter_keeps_pathway_effect_when_target_sibling_is_invalid() ->
     assert result.filtered_candidates[0].reason == "missing_relation_arguments"
 
 
-def test_quality_filter_keeps_pathway_effect_when_target_sibling_is_not_molecular() -> None:
+def test_quality_filter_keeps_pathway_effect_when_target_sibling_is_not_molecular() -> (
+    None
+):
     disease_target_candidate = ExtractedRelationCandidate(
         subject_label="Vemurafenib",
         relation_type="TARGETS",
@@ -840,7 +870,9 @@ def test_quality_filter_keeps_pathway_effect_when_target_sibling_is_not_molecula
     )
 
 
-def test_quality_filter_removes_binding_site_target_with_molecular_target_sibling() -> None:
+def test_quality_filter_removes_binding_site_target_with_molecular_target_sibling() -> (
+    None
+):
     target_candidate = ExtractedRelationCandidate(
         subject_label="Sotorasib",
         relation_type="TARGETS",
@@ -871,7 +903,9 @@ def test_quality_filter_removes_binding_site_target_with_molecular_target_siblin
     )
 
 
-def test_quality_filter_keeps_binding_site_target_without_molecular_target_sibling() -> None:
+def test_quality_filter_keeps_binding_site_target_without_molecular_target_sibling() -> (
+    None
+):
     pathway_target_candidate = ExtractedRelationCandidate(
         subject_label="SHP099",
         relation_type="TARGETS",
@@ -1029,7 +1063,9 @@ def test_quality_filter_marks_cell_context_activation_review_only() -> None:
     assert result.filtered_candidates == ()
 
 
-def test_quality_filter_removes_cell_context_activation_when_primary_relation_exists() -> None:
+def test_quality_filter_removes_cell_context_activation_when_primary_relation_exists() -> (
+    None
+):
     primary_candidate = ExtractedRelationCandidate(
         subject_label="IL6",
         relation_type="REGULATES",
@@ -1112,7 +1148,9 @@ def test_quality_filter_removes_candidate_that_drops_subject_modifier() -> None:
     assert result.filtered_candidates[0].reason == "dropped_subject_modifier"
 
 
-def test_quality_filter_removes_candidate_that_drops_common_biomedical_modifier() -> None:
+def test_quality_filter_removes_candidate_that_drops_common_biomedical_modifier() -> (
+    None
+):
     candidates = (
         ExtractedRelationCandidate(
             subject_label="BRCA1",
@@ -1137,12 +1175,14 @@ def test_quality_filter_removes_candidate_that_drops_common_biomedical_modifier(
     result = filter_low_value_relation_candidates(candidates)
 
     assert result.candidates == ()
-    assert {
-        filtered.reason for filtered in result.filtered_candidates
-    } == {"dropped_subject_modifier"}
+    assert {filtered.reason for filtered in result.filtered_candidates} == {
+        "dropped_subject_modifier"
+    }
 
 
-def test_quality_filter_removes_candidate_that_drops_hyphenated_object_modifier() -> None:
+def test_quality_filter_removes_candidate_that_drops_hyphenated_object_modifier() -> (
+    None
+):
     candidate = ExtractedRelationCandidate(
         subject_label="Homologous recombination DNA repair",
         relation_type="REGULATES",
@@ -1196,8 +1236,7 @@ def test_quality_filter_keeps_unmodified_claim_in_coordinated_clause() -> None:
         relation_type="ACTIVATES",
         object_label="DNA repair",
         sentence=(
-            "BRCA1 loss sensitizes tumors to cisplatin, and BRCA1 activates "
-            "DNA repair."
+            "BRCA1 loss sensitizes tumors to cisplatin, and BRCA1 activates DNA repair."
         ),
     )
 

--- a/tests/unit/test_nary_claim_evaluation.py
+++ b/tests/unit/test_nary_claim_evaluation.py
@@ -553,9 +553,7 @@ def _recovery_case_artifact(
             "provider_response_id": "resp_zero_recovery",
             "provider_output_sha256": "e" * 64,
             "payload_sha256": _sha256_json(empty_payload),
-            "prompt_sha256": hashlib.sha256(
-                zero_provider_prompt.encode()
-            ).hexdigest(),
+            "prompt_sha256": hashlib.sha256(zero_provider_prompt.encode()).hexdigest(),
             "kernel_run_id": f"research-init-extraction:{zero['invocation_id']}",
             "raw_model_payload": empty_payload,
         }
@@ -706,9 +704,7 @@ def _recovery_case_artifact(
     evidence["diagnostics"]["inventory_convergence_stop_reasons"] = [
         "RECOVERY_ABSTAINED" if decision == "ABSTAIN" else "CONFIRMED_COMPLETE"
     ]
-    evidence["diagnostics"]["inventory_convergence_round_traces"] = [
-        recovery_trace
-    ]
+    evidence["diagnostics"]["inventory_convergence_round_traces"] = [recovery_trace]
     return case, prediction, evidence
 
 
@@ -1268,13 +1264,13 @@ def test_evaluator_accepts_audited_semantic_incompleteness() -> None:
     prediction.update(
         {
             "events": [],
+            "review_only_events": [],
             "abstained": True,
             "execution_outcome": "SEMANTICALLY_INCOMPLETE",
         }
     )
-    evidence["diagnostics"]["claim_extraction_routing_status"] = (
-        "semantic_incomplete"
-    )
+    evidence["diagnostics"]["claim_extraction_routing_status"] = "semantic_incomplete"
+    evidence["diagnostics"]["review_only_event_count"] = 0
 
     expectations, topology = bind_semantically_incomplete_case_evidence(
         case=case,
@@ -1287,6 +1283,51 @@ def test_evaluator_accepts_audited_semantic_incompleteness() -> None:
     assert topology
 
 
+def test_evaluator_rejects_substituted_review_only_event() -> None:
+    case, prediction, evidence = _recovery_case_artifact(decision="ABSTAIN")
+    review_only_events = list(prediction["events"])
+    prediction.update(
+        {
+            "events": [],
+            "review_only_events": review_only_events,
+            "abstained": True,
+            "execution_outcome": "SEMANTICALLY_INCOMPLETE",
+        }
+    )
+    evidence["diagnostics"]["claim_extraction_routing_status"] = "semantic_incomplete"
+    evidence["diagnostics"]["review_only_event_count"] = len(review_only_events)
+
+    with pytest.raises(ValueError, match="review-only events differ"):
+        bind_semantically_incomplete_case_evidence(
+            case=case,
+            prediction=prediction,
+            case_record=evidence,
+            model_id="openai:gpt-5.6-luna",
+        )
+
+
+def test_evaluator_checks_review_only_count_even_when_inventory_is_empty() -> None:
+    case, prediction, evidence = _recovery_case_artifact(decision="ABSTAIN")
+    prediction.update(
+        {
+            "events": [],
+            "review_only_events": [],
+            "abstained": True,
+            "execution_outcome": "SEMANTICALLY_INCOMPLETE",
+        }
+    )
+    evidence["diagnostics"]["claim_extraction_routing_status"] = "semantic_incomplete"
+    evidence["diagnostics"]["review_only_event_count"] = 1
+
+    with pytest.raises(ValueError, match="review-only event count"):
+        bind_semantically_incomplete_case_evidence(
+            case=case,
+            prediction=prediction,
+            case_record=evidence,
+            model_id="openai:gpt-5.6-luna",
+        )
+
+
 def test_evaluator_rejects_fabricated_convergence_trace() -> None:
     case, prediction, evidence = _recovery_case_artifact(decision="ABSTAIN")
     prediction.update(
@@ -1296,9 +1337,7 @@ def test_evaluator_rejects_fabricated_convergence_trace() -> None:
             "execution_outcome": "SEMANTICALLY_INCOMPLETE",
         }
     )
-    evidence["diagnostics"]["claim_extraction_routing_status"] = (
-        "semantic_incomplete"
-    )
+    evidence["diagnostics"]["claim_extraction_routing_status"] = "semantic_incomplete"
     evidence["diagnostics"]["inventory_convergence_round_traces"][0][
         "recovery_round"
     ] = 2


### PR DESCRIPTION
## Stack

Depends on #168. Review and merge that PR first.

## What changed

- Preserve incomplete, pruned, and overflow claim candidates as visible review-only inventory instead of silently discarding them.
- Add independent source-only categorical adjudication for atomicity, support, and semantic relation, with exact evidence spans, reasoning, falsification, bounded context, and no numeric agent scoring.
- Compute adjudication metrics deterministically and fail closed when the agent is unavailable or returns invalid output.
- Require a complete validated adjudication artifact, exact ClaimFrame evidence binding, source lineage, and entity resolution before canonical promotion.
- Keep incomplete TG04 inventory out of executable events while proving review-only inventory completeness.
- Register the new agent-output schema and document the remediation gates and scientific stop/go boundary.

## Validation

- `make artana-evidence-api-service-checks`
- `make service-checks` (87.47% repository coverage before the final narrow visibility hardening)
- focused adjudication, candidate-preservation, promotion-policy, and TG04 regression suites
- adversarial review across three rounds; final review found no code defect after visible-target hardening
- commit hooks: graph/API lint and type checks

## Scientific status

This PR improves information preservation, auditability, and promotion safety. It does **not** claim that scientific extraction accuracy is now proven and it does not enable graph persistence for review-only claims. After this stack lands, the next gate is a small frozen live-agent experiment with human-style source adjudication and deterministic before/after metrics.