### PR TITLE
TG-04: test finite source-unit scientific recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ ARTANA_EVIDENCE_API_TEST_PATHS := \
 	 tests/e2e/artana_evidence_api \
 	 services/artana_evidence_api/tests/integration \
 	 services/artana_evidence_api/tests/unit \
+	 tests/unit/test_finite_source_unit_audit.py \
+	 tests/unit/test_nary_claim_evaluation.py \
+	 tests/unit/test_nary_claim_runner.py \
 	 tests/unit/test_run_evidence_selection_expert_study_gate.py \
 	 tests/unit/test_run_evidence_selection_review_calibration_gate.py \
 	 tests/unit/test_agent_output_boundary_validator.py
@@ -323,6 +326,7 @@ artana-evidence-api-type-check: ## Run strict mypy on evidence API package
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/validate_evidence_selection_semantic_benchmark_v2.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/run_evidence_selection_semantic_agent_evaluation.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/run_evidence_selection_semantic_model_comparison.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
+	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/run_finite_source_unit_audit.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 	cd services && $(USE_PYTHON_ABS) -m mypy ../scripts/ci/validate_agent_output_boundaries.py --no-warn-unused-configs $(ARTANA_EVIDENCE_API_STRICT_IMPORT_MYPY_FLAGS)
 
 artana-evidence-api-type-check-strict-imports: ## Explicit strict-import evidence API mypy gate

--- a/docs/validation/reports/2026-07-17-tg04-finite-source-unit-pilot.md
+++ b/docs/validation/reports/2026-07-17-tg04-finite-source-unit-pilot.md
@@ -1,0 +1,219 @@
+# TG-04 Finite Source-Unit Pilot
+
+Date: 2026-07-17
+
+## Decision
+
+**STOP AND RECALIBRATE.** Dividing the documents into 32 finite sentence units
+removed the unbounded-completeness loop, but it did not produce one exact frozen
+whole event. The pilot therefore does not authorize a larger panel, production
+workflow confirmation, persistence, or trusted-graph promotion.
+
+This is not evidence that Luna found no useful science. A separate Luna verifier
+judged 28 extracted events source-entailed, including several close to the four
+expert events. It is also not proof that those 28 are all valuable or correct:
+the verifier used the same model family, disagreed with the extractor about
+procedural units, and produced four invalid outputs. The honest conclusion is
+that finite enumeration improved task boundedness while exposing a still
+underspecified event contract and incomplete exact event reconstruction.
+
+## Frozen Experiment
+
+- Model: `openai:gpt-5.6-luna`
+- Harness commit: `13175ae50ab629fb3f1ddfe7a7a6e4a4849e21dc`
+- Cases: the same four frozen TG-04 diagnostic cases used before PR `#168`
+- Source units: `32` deterministic sentence locations (`7`, `9`, `11`, `5`)
+- Agent calls: one extraction and one source-only verification call per unit
+- Agent outputs: categorical findings and explanations, never numeric scores
+- Numeric metrics and stop/go decision: deterministic code only
+- Biomedical fallback: disabled and credited fallback count `0`
+- Production extraction path: not exercised; this qualifies only the experimental task
+- Artifact: `/tmp/artana-tg04/finite-source-unit-2026-07-17/luna-r2.json`
+- Artifact SHA-256: `8c59553036a4dc58eb55e5b6381058401fcbff2a9069499f7f26b5abb1f3f58e`
+- Inner report SHA-256: `53dea580b834f0d12481d503c1e1484746ce8a1bf9867e434b375cbf779f06e9`
+
+The inner digest was independently recomputed after removing the embedded
+`report_sha256` field and matched exactly. All 64 provider calls returned unique
+response IDs with provider status `completed`.
+
+## Invalid First Attempt
+
+The first run, `tg04-finite-source-unit-luna-01`, is retained but has no
+scientific interpretation. Its pilot-specific kernel run ID disagreed with the
+invocation-bound Artana run ID, so all 32 payloads failed custody before model
+output could be accepted. The owning boundary was fixed and regression-tested;
+the frozen model, source, prompts, schemas, metrics, and gates were unchanged
+for the single authorized replacement.
+
+## Gate Result
+
+| Requirement | Result | Evidence |
+| --- | --- | --- |
+| All four cases executable | fail | `1/4`; four verifier outputs invalidated three scientific cases |
+| All source-unit inventories confirmed | fail | `0/4`; missing-event findings or invalid verification remained in every case |
+| At least one exact whole event | fail | `0/4` gold events recovered exactly |
+| Methods control empty | pass | extraction emitted `0` events |
+| Negative or unmatched leakage zero | fail | `14/14` predictions in the scored gold case were not exact gold matches |
+| Epistemic escalation zero | fail | `1/2` qualified gold comparisons escalated |
+| Item-binding rejections zero | fail | `13` candidates rejected by source binding |
+| Invalid agent outputs zero | fail | `4` verification outputs invalid |
+| Provider lineage complete | pass | `64/64` calls had unique response IDs |
+| Provider receipts verified live | fail | `0/64`; provider retrieval omitted output-schema metadata |
+
+The pre-registered decision is `STOP_AND_RECALIBRATE`.
+
+## Scientific Result
+
+The strict qualification case contained four expert corpus events. Luna emitted
+14 independently source-entailed candidates, but none matched a complete expert
+event key.
+
+Important near misses show why exact recovery failed:
+
+1. Luna found `TGF-beta-mediated induction of FOXP3` with the correct trigger,
+   type, and participants, but assigned TGF-beta the event role `AGENT` instead
+   of the expert role `CAUSE`.
+2. Luna found `GATA3 ... repressing FOXP3`, but promoted the expert
+   `UNCERTAIN` polarity and epistemic status to `SUPPORT` and `HYPOTHESIS`.
+   This is a real scientific qualification failure, not a string mismatch.
+3. Luna found CD25 reduction content, but merged several measurements into a
+   broader malformed event instead of reconstructing the expert two-argument
+   negative-regulation event.
+4. Luna found the asserted IL-4 inhibition of FOXP3 expression but did not
+   reconstruct the expert uncertain GATA3-dependent mechanism event.
+
+Deterministic aggregate metrics were:
+
+- whole-event precision: `0/14`
+- whole-event recall: `0/4`
+- trigger recall: `2/4`
+- event-type fidelity: `2/4`
+- argument recall: `1/8`
+- argument precision: `1/36`
+- epistemic fidelity: `2/4`
+- methods-control false positives: `0/1`
+
+These numbers measure exact expert-event reconstruction. They do not establish
+that all unmatched events are false.
+
+## Non-Lossy Discovery Lane
+
+The independent source-only calls judged `28` candidates `ENTAILED`: `4` in the
+WT1 stress case, `10` in the differentiation stress case, and `14` in the gold
+qualification case. Two additional candidates were retained as `INSUFFICIENT`.
+No unmatched source-entailed claim was silently discarded or promoted.
+
+The 28 events are a mixture that the four-event gold set cannot adjudicate by
+itself:
+
+- several are plainly explicit source statements, such as IL-4 inhibiting
+  FOXP3 expression and the null differential-growth finding;
+- several split one sentence into multiple scientifically defensible event
+  views;
+- some are likely too procedural, broad, or weakly typed to be useful graph
+  claims;
+- all were verified by another call to the same model family, so they are
+  review evidence rather than independent scientific ground truth.
+
+The scorer's `negative_null_leakage` label counts every non-exact prediction in
+this case. Here it means 14 unmatched candidates, not 14 independently proven
+false claims. Exact precision remains a valid strict gate, while source validity
+and decision value require separate categorical adjudication.
+
+## Root Causes
+
+### 1. Event Eligibility Is Not Governed Consistently
+
+The extractor was explicitly told that assay procedures are not biomedical
+events. The verifier was asked to find every explicit biomedical event but did
+not receive the same procedure and measurement exclusion rule. Consequently,
+the extractor correctly returned no methods events while the verifier called
+resting cells, electroporation, and luciferase measurement missing events. This
+prompt-contract asymmetry made complete coverage impossible even on the true
+negative control.
+
+### 2. Sentence Boundaries Do Not Define Complete Scientific Events
+
+Finite locations solved the endless search problem, but event arguments and
+epistemic qualifiers still cross clauses and sentences. Luna frequently found
+the right biological idea while choosing a different trigger scope, participant
+role, or uncertainty representation from the expert event.
+
+### 3. Verbatim Binding Exposes Real Generation Defects
+
+Thirteen candidates failed because their canonical argument span was absent
+from the anchor, an argument occurred outside the selected claim span, or the
+context did not identify one occurrence. These are model-output defects that
+must remain fail-closed. They should not be repaired with deterministic
+biomedical guesses.
+
+### 4. The Gold Set Is Precise But Not Exhaustive
+
+The BioNLP expert events are strong targets for exact event fidelity, but the
+four selected annotations do not label every valid or valuable statement in the
+source. Exact-match failure therefore proves poor reconstruction of those four
+events; it does not prove that every additional source-entailed event is wrong.
+
+### 5. Provider Receipt Qualification Is Currently Impossible
+
+Provider retrieval confirmed all 64 response IDs as completed, but did not
+return the output-schema identity or associated invocation hashes. The receipt
+gate therefore reported `output_schema_missing` for all calls. This is a custody
+integration limitation separate from the negative scientific result. It must be
+fixed without pretending that provider completion alone verifies Artana's full
+invocation envelope.
+
+## Smallest Next Experiment
+
+Do not run a larger panel or add another generic adversarial pass yet. First
+make the provider-custody contract verifiable with a tiny no-science smoke call.
+Then freeze a three-unit **event-eligibility and target-reconstruction**
+diagnostic containing exactly:
+
+- one source unit containing a known expert gold event;
+- one true-negative methods unit;
+- one explicit source event that is absent from the finite gold annotations.
+
+For those three units:
+
+1. Give extraction and verification one shared governed eligibility contract
+   with categorical outcomes: `FINDING`, `HYPOTHESIS`, `NULL_RESULT`,
+   `PROCEDURE`, `MEASUREMENT_ONLY`, `NO_EVENT`, or `ABSTAIN`.
+2. Preserve procedures and measurements for audit, but exclude them from the
+   scientific-event completeness gate deterministically from those categories.
+3. Ask the agent to reconstruct the finite source-anchored target without
+   revealing the gold answer. Return trigger, direction, complete typed
+   participants, polarity, epistemic status, and nested-event structure.
+4. Use a separate blinded agent to return categorical equivalence and source
+   entailment findings with exact evidence and falsification explanations.
+5. Compute exact recovery, near-match error categories, unsupported-event rate,
+   and repeatability deterministically. Keep unmatched entailed discoveries in
+   a separate review lane; do not count them automatically as either correct or
+   false.
+6. In parallel, define a provider-supported receipt contract that verifies live
+   completion externally and Artana's schema, prompt, source, and invocation
+   hashes internally without claiming the provider returned fields it does not
+   expose.
+
+Proceed to the unchanged four-case panel only if all three units are executable,
+the methods unit is consistently excluded, the expert event is exact, the
+unannotated source event remains visible without being mislabeled false, no
+uncertainty is escalated, all accepted candidates bind, and the custody contract
+verifies. If target reconstruction still fails, compare Luna against one
+stronger model on the unchanged three units. A second Luna reviewer is useful
+for error detection, but this run shows that same-family review alone is not
+sufficient evidence of scientific correctness.
+
+## Validation
+
+- Focused finite-unit unit, regression, semantic-binding, truth-table, receipt,
+  and timeout tests passed.
+- `make service-checks` passed with `87.53%` repository coverage.
+- Evidence API lint, type, boundary, contract, architecture, migration, and test
+  gates passed.
+- An adversarial implementation review was completed before the live run; its
+  findings were fixed and regression-tested.
+- A separate post-run adversarial review confirmed the stop decision, the
+  benchmark-undercoverage caveat, and the three-unit isolation experiment.
+- The replacement ran from a clean tracked worktree and the immutable artifact
+  remained unchanged during analysis.

--- a/docs/validation/tg04-finite-source-unit-pilot-protocol.md
+++ b/docs/validation/tg04-finite-source-unit-pilot-protocol.md
@@ -2,7 +2,7 @@
 
 Created: 2026-07-17
 
-Status: pre-registered before model execution
+Status: completed; restart gate failed on 2026-07-17
 
 ## Decision Question
 
@@ -165,3 +165,22 @@ replacement execution named `tg04-finite-source-unit-luna-02`. The frozen
 source panel, model, prompts, schemas, metrics, and stop/go thresholds remain
 unchanged. The replacement writes create-once to `luna-r2.json`; the invalid
 artifact is never overwritten or counted as a replicate.
+
+## Completed Replacement
+
+The authorized replacement completed on committed harness
+`13175ae50ab629fb3f1ddfe7a7a6e4a4849e21dc`:
+
+- run ID: `tg04-finite-source-unit-luna-02`
+- artifact:
+  `/tmp/artana-tg04/finite-source-unit-2026-07-17/luna-r2.json`
+- artifact SHA-256:
+  `8c59553036a4dc58eb55e5b6381058401fcbff2a9069499f7f26b5abb1f3f58e`
+- inner report SHA-256:
+  `53dea580b834f0d12481d503c1e1484746ce8a1bf9867e434b375cbf779f06e9`
+- decision: `STOP_AND_RECALIBRATE`
+
+The inner digest was recomputed from the immutable artifact after removing its
+`report_sha256` field and matched exactly. The detailed scientific and
+operational interpretation is recorded in
+`docs/validation/reports/2026-07-17-tg04-finite-source-unit-pilot.md`.

--- a/docs/validation/tg04-finite-source-unit-pilot-protocol.md
+++ b/docs/validation/tg04-finite-source-unit-pilot-protocol.md
@@ -1,0 +1,142 @@
+# TG-04 Finite Source-Unit Pilot Protocol
+
+Created: 2026-07-17
+
+Status: pre-registered before model execution
+
+## Decision Question
+
+Does replacing the open-ended request to find every meaningful claim with a
+finite location-by-location event audit recover at least one exact expert event
+without weakening Artana's source, safety, or provider-custody boundaries?
+
+This is one non-qualifying diagnostic. It cannot authorize persistence,
+trusted-graph promotion, or a larger benchmark by itself.
+
+The pilot uses Artana's kernel, model adapter, structured invocation binding,
+source binder, event contracts, scorer, and provider custody. It deliberately
+tests a new finite experimental extraction task rather than the current
+production document-extraction entry point. A positive result qualifies the
+task design only. The unchanged task must subsequently pass through the real
+production workflow before claiming improvement for an Artana user.
+
+## Frozen Inputs
+
+- Model: `openai:gpt-5.6-luna`
+- Run count: one
+- Source fixture:
+  `scripts/validation/claim_events/fixtures/tg04_bionlp_ge_development_v1.json`
+- Panel: the same four cases used by the preceding TG-04 diagnostics:
+  - `bionlp-ge-2011:PMID-9361029`
+  - `bionlp-ge-2011:PMC-2222968-03-Results-02`
+  - `bionlp-ge-2011:PMC-2222968-05-Results-04`
+  - `bionlp-ge-2011:PMC-2222968-15-Materials_and_Methods-07`
+- Deterministic source-unit count: 32 sentence locations, respectively
+  `7`, `9`, `11`, and `5` per case.
+- Repository state: a clean committed branch descended from merged PR `#168`.
+
+The title and every sentence remain visible units. Model-visible unit IDs are
+opaque hashes; case identifiers containing `Results` or `Materials_and_Methods`
+remain only in deterministic custody metadata. Unit enumeration assigns no
+biomedical meaning and does not inspect benchmark labels.
+
+## Agent Tasks
+
+For each finite source unit, the extraction agent returns one category:
+
+- `EXPLICIT_EVENT`
+- `NO_EVENT`
+- `ABSTAIN`
+
+An explicit event must include an exact trigger, complete event span, typed
+arguments, event type, polarity, and epistemic status. Existing deterministic
+Artana binding validates every candidate independently. Invalid siblings remain
+auditable and cannot remove valid candidates.
+
+Every unit, including `NO_EVENT` and `ABSTAIN` extraction results, receives a
+separate source-only call. It first returns one inventory-coverage category:
+
+- `CANDIDATES_COMPLETE`
+- `NO_EVENT_CONFIRMED`
+- `MISSING_EVENT`
+- `ABSTAIN`
+
+For each bound candidate, the same call also returns:
+
+- `ENTAILED`
+- `CONTRADICTED`
+- `INSUFFICIENT`
+- `ABSTAIN`
+
+The verifier receives no extractor reasoning or mention-selection rationale.
+It must cite literal evidence inside the candidate covering the trigger and
+every material argument, explain its decision, and state a falsification
+condition. Extraction and verification are independent invocations of Luna,
+not independent model families. Neither agent returns a numeric score. Code
+computes every count, rate, and stop/go decision.
+
+There are no model retries in this pilot. Schema-invalid, semantically invalid,
+unidentified, unavailable, or timed-out calls fail closed for their source unit
+and remain visible in the report instead of preventing artifact creation.
+
+## Measurement Lanes
+
+The report keeps two questions separate:
+
+1. **Strict frozen benchmark:** exact whole-event precision and recall, trigger,
+   event type, complete typed arguments, polarity, epistemic status, negative
+   control leakage, and abstention.
+2. **Non-lossy discoveries:** independently source-entailed events that do not
+   exactly match the finite gold set, including representability-stress cases.
+   They are counted directly from verified candidates, remain review evidence,
+   and are not silently discarded, promoted, or used to rewrite frozen gold.
+
+Representability-stress output remains descriptive and outside qualification
+precision. The methods control remains a true negative.
+
+## Custody And Safety
+
+- The CLI refuses a dirty tracked worktree.
+- Output is create-once and written outside the repository during execution.
+- Every call uses Artana's structured model client and invocation binding.
+- Prompt, input, source, schema, provider output, payload, invocation, run, and
+  evidence-unit identities are recorded.
+- Provider response IDs must be unique and retrievable.
+- Deterministic biomedical fallback is absent and credited fallback is zero.
+- No candidate is persisted or promoted.
+
+## Restart Gate
+
+Proceed to a larger frozen panel only when every condition is true:
+
+- all four cases are executable;
+- every source unit has independently confirmed inventory coverage;
+- at least one exact whole event is recovered;
+- the methods control has no event;
+- negative or null leakage is zero;
+- epistemic escalation is zero;
+- deterministic item-binding rejections are zero;
+- invalid agent output is zero;
+- provider lineage is complete;
+- live provider receipts verify.
+
+Otherwise stop and inspect the categorical failure evidence. If exact recovery
+is still zero but unmatched events are independently source-entailed, evaluate
+benchmark coverage and event projection separately. If both exact recovery and
+useful unmatched discovery remain weak, stop model-only extraction and compare
+an expert-seeded or hybrid candidate workflow.
+
+## Execution
+
+After the harness commit is clean and the environment selects Luna:
+
+```bash
+export ARTANA_AI_ALLOW_RUNTIME_MODEL_OVERRIDES=true
+export ARTANA_AI_EVIDENCE_EXTRACTION_MODEL=openai:gpt-5.6-luna
+uv run python scripts/run_finite_source_unit_audit.py \
+  --run-id tg04-finite-source-unit-luna-01 \
+  --output /tmp/artana-tg04/finite-source-unit-2026-07-17/luna-r1.json
+```
+
+The result report must be generated from the immutable JSON without editing the
+payload or changing the gates after model output is observed.

--- a/docs/validation/tg04-finite-source-unit-pilot-protocol.md
+++ b/docs/validation/tg04-finite-source-unit-pilot-protocol.md
@@ -140,3 +140,28 @@ uv run python scripts/run_finite_source_unit_audit.py \
 
 The result report must be generated from the immutable JSON without editing the
 payload or changing the gates after model output is observed.
+
+## Invalidated Orchestration Attempt
+
+The first invocation on committed harness `2fe238a3f212b8f34a0f634b2adeb0c73fb29f2d`
+is retained as an invalid experiment artifact:
+
+- run ID: `tg04-finite-source-unit-luna-01`
+- artifact:
+  `/tmp/artana-tg04/finite-source-unit-2026-07-17/luna-r1.json`
+- artifact SHA-256:
+  `6b2876a1340516fedde918fd6549a60c5b99f27fc642977d4e24eb2157f2e2f4`
+- provider payloads returned: `32`
+- accepted extraction attempts: `0`
+- terminal category: `StructuredModelInvocationTopologyError`
+
+The experimental client used a pilot-specific kernel run namespace instead of
+the run ID already bound into Artana's provider invocation envelope. Every
+payload therefore failed custody before schema or semantic evaluation. The
+artifact has no scientific interpretation and is not a failed model run.
+
+The owning run-ID boundary is corrected and regression-tested before one
+replacement execution named `tg04-finite-source-unit-luna-02`. The frozen
+source panel, model, prompts, schemas, metrics, and stop/go thresholds remain
+unchanged. The replacement writes create-once to `luna-r2.json`; the invalid
+artifact is never overwritten or counted as a replicate.

--- a/scripts/run_finite_source_unit_audit.py
+++ b/scripts/run_finite_source_unit_audit.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Run the one-shot TG-04 finite source-unit scientific diagnostic."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SERVICES_ROOT = _REPO_ROOT / "services"
+for _path in (_REPO_ROOT, _SERVICES_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from scripts.validation.claim_events.finite_source_unit.runner import (  # noqa: E402
+    run_finite_source_unit_pilot,
+)
+from scripts.validation.claim_events.fixture import (  # noqa: E402
+    DEFAULT_DEVELOPMENT_FIXTURE_PATH,
+    load_fixture,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=_REPO_ROOT / DEFAULT_DEVELOPMENT_FIXTURE_PATH,
+    )
+    args = parser.parse_args()
+    report = run_finite_source_unit_pilot(
+        fixture=load_fixture(args.fixture),
+        run_id=args.run_id,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("x", encoding="utf-8") as output_file:
+        output_file.write(
+            json.dumps(report, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        )
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/claim_events/finite_source_unit/__init__.py
+++ b/scripts/validation/claim_events/finite_source_unit/__init__.py
@@ -1,0 +1,23 @@
+"""Finite source-unit TG-04 diagnostic contracts and execution helpers."""
+
+from scripts.validation.claim_events.finite_source_unit.contracts import (
+    EntailmentDecision,
+    SourceUnitCoverageDecision,
+    SourceUnitDecision,
+    SourceUnitExtractionOutput,
+    SourceUnitVerificationOutput,
+)
+from scripts.validation.claim_events.finite_source_unit.source_units import (
+    FrozenSourceUnit,
+    enumerate_source_units,
+)
+
+__all__ = [
+    "EntailmentDecision",
+    "FrozenSourceUnit",
+    "SourceUnitDecision",
+    "SourceUnitCoverageDecision",
+    "SourceUnitExtractionOutput",
+    "SourceUnitVerificationOutput",
+    "enumerate_source_units",
+]

--- a/scripts/validation/claim_events/finite_source_unit/contracts.py
+++ b/scripts/validation/claim_events/finite_source_unit/contracts.py
@@ -1,0 +1,182 @@
+"""Closed agent-output contracts for the finite source-unit diagnostic."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from artana_evidence_api.document_extraction_support.claim_frames import (
+    ClaimInventoryItem,  # noqa: TC002 - Pydantic resolves this model at runtime.
+)
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class SourceUnitDecision(StrEnum):
+    """Agent decision about one deterministically supplied source location."""
+
+    EXPLICIT_EVENT = "EXPLICIT_EVENT"
+    NO_EVENT = "NO_EVENT"
+    ABSTAIN = "ABSTAIN"
+
+
+class EntailmentDecision(StrEnum):
+    """Independent source-only judgment for one bound event candidate."""
+
+    ENTAILED = "ENTAILED"
+    CONTRADICTED = "CONTRADICTED"
+    INSUFFICIENT = "INSUFFICIENT"
+    ABSTAIN = "ABSTAIN"
+
+
+class SourceUnitCoverageDecision(StrEnum):
+    """Independent inventory-coverage finding for one finite source unit."""
+
+    CANDIDATES_COMPLETE = "CANDIDATES_COMPLETE"
+    NO_EVENT_CONFIRMED = "NO_EVENT_CONFIRMED"
+    MISSING_EVENT = "MISSING_EVENT"
+    ABSTAIN = "ABSTAIN"
+
+
+class SourceUnitExtractionOutput(BaseModel):
+    """Categorical extraction result for exactly one frozen source unit."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    unit_id: str = Field(..., min_length=1, max_length=300)
+    decision: SourceUnitDecision = Field(..., strict=False)
+    events: tuple[ClaimInventoryItem, ...] = Field(default=(), max_length=16)
+    reasoning: str = Field(..., min_length=1, max_length=4000)
+
+    @field_validator("events", mode="before")
+    @classmethod
+    def freeze_events(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @model_validator(mode="after")
+    def require_decision_payload_consistency(self) -> SourceUnitExtractionOutput:
+        if self.decision is SourceUnitDecision.EXPLICIT_EVENT and not self.events:
+            raise ValueError("EXPLICIT_EVENT requires at least one event")
+        if self.decision is not SourceUnitDecision.EXPLICIT_EVENT and self.events:
+            raise ValueError("NO_EVENT and ABSTAIN cannot contain events")
+        return self
+
+
+class CandidateVerification(BaseModel):
+    """One categorical verification bound to a stable candidate identity."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    candidate_id: str = Field(..., min_length=1, max_length=300)
+    decision: EntailmentDecision = Field(..., strict=False)
+    evidence_spans: tuple[str, ...] = Field(default=(), max_length=16)
+    reasoning: str = Field(..., min_length=1, max_length=4000)
+    falsification_condition: str = Field(..., min_length=1, max_length=4000)
+
+    @field_validator("evidence_spans", mode="before")
+    @classmethod
+    def freeze_evidence_spans(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("evidence_spans")
+    @classmethod
+    def require_nonempty_unique_spans(
+        cls,
+        value: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        if any(not span.strip() for span in value):
+            raise ValueError("verification evidence spans must be nonempty")
+        if len(set(value)) != len(value):
+            raise ValueError("verification evidence spans must be unique")
+        return value
+
+    @model_validator(mode="after")
+    def require_evidence_for_decisive_findings(self) -> CandidateVerification:
+        if self.decision in {
+            EntailmentDecision.ENTAILED,
+            EntailmentDecision.CONTRADICTED,
+        } and not self.evidence_spans:
+            raise ValueError("decisive verification requires exact evidence spans")
+        return self
+
+
+class SourceUnitVerificationOutput(BaseModel):
+    """Independent verification results for every supplied candidate."""
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    unit_id: str = Field(..., min_length=1, max_length=300)
+    coverage_decision: SourceUnitCoverageDecision = Field(..., strict=False)
+    coverage_reasoning: str = Field(..., min_length=1, max_length=4000)
+    covered_candidate_ids: tuple[str, ...] = Field(default=(), max_length=16)
+    decisions: tuple[CandidateVerification, ...] = Field(default=(), max_length=16)
+
+    @field_validator("covered_candidate_ids", mode="before")
+    @classmethod
+    def freeze_covered_candidate_ids(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("covered_candidate_ids")
+    @classmethod
+    def require_unique_covered_candidate_ids(
+        cls,
+        value: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        if any(not candidate_id.strip() for candidate_id in value):
+            raise ValueError("covered candidate IDs must be nonempty")
+        if len(set(value)) != len(value):
+            raise ValueError("covered candidate IDs must be unique")
+        return value
+
+    @field_validator("decisions", mode="before")
+    @classmethod
+    def freeze_decisions(cls, value: object) -> object:
+        if isinstance(value, list):
+            return tuple(value)
+        return value
+
+    @field_validator("decisions")
+    @classmethod
+    def require_unique_candidate_ids(
+        cls,
+        value: tuple[CandidateVerification, ...],
+    ) -> tuple[CandidateVerification, ...]:
+        ids = tuple(decision.candidate_id for decision in value)
+        if len(set(ids)) != len(ids):
+            raise ValueError("verification candidate IDs must be unique")
+        return value
+
+    @model_validator(mode="after")
+    def bind_coverage_to_entailed_candidates(self) -> SourceUnitVerificationOutput:
+        entailed_ids = {
+            decision.candidate_id
+            for decision in self.decisions
+            if decision.decision is EntailmentDecision.ENTAILED
+        }
+        if set(self.covered_candidate_ids) != entailed_ids:
+            raise ValueError("covered candidate IDs must equal ENTAILED candidates")
+        if (
+            self.coverage_decision is SourceUnitCoverageDecision.CANDIDATES_COMPLETE
+            and not entailed_ids
+        ):
+            raise ValueError("CANDIDATES_COMPLETE requires an ENTAILED candidate")
+        if (
+            self.coverage_decision is SourceUnitCoverageDecision.NO_EVENT_CONFIRMED
+            and entailed_ids
+        ):
+            raise ValueError("NO_EVENT_CONFIRMED cannot contain ENTAILED candidates")
+        return self
+
+
+__all__ = [
+    "CandidateVerification",
+    "EntailmentDecision",
+    "SourceUnitCoverageDecision",
+    "SourceUnitDecision",
+    "SourceUnitExtractionOutput",
+    "SourceUnitVerificationOutput",
+]

--- a/scripts/validation/claim_events/finite_source_unit/runner.py
+++ b/scripts/validation/claim_events/finite_source_unit/runner.py
@@ -1,0 +1,474 @@
+"""Sealed four-case runner for the finite source-unit TG-04 diagnostic."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from contextlib import suppress
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Final, cast
+from uuid import uuid4
+
+from artana_evidence_api.document_extraction_support.llm_extraction.invocation_binding import (
+    output_schema_json_sha256,
+)
+from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+    start_model_attempt_audit,
+    stop_model_attempt_audit,
+)
+
+from scripts.validation.claim_events.finite_source_unit.contracts import (
+    EntailmentDecision,
+    SourceUnitCoverageDecision,
+    SourceUnitExtractionOutput,
+    SourceUnitVerificationOutput,
+)
+from scripts.validation.claim_events.finite_source_unit.service import (
+    as_model_client,
+    extract_source_unit,
+    verify_source_unit_candidates,
+)
+from scripts.validation.claim_events.finite_source_unit.source_units import (
+    enumerate_source_units,
+)
+from scripts.validation.claim_events.fixture import require_frozen_development_fixture
+from scripts.validation.claim_events.runner import (
+    build_tg04_runtime,
+    nary_events_from_bound_inventory,
+    receipt_expectation_from_attempt,
+)
+from scripts.validation.claim_events.scoring import score_fixture
+from scripts.validation.claim_frames.evidence import collect_repository_evidence
+from scripts.validation.claim_frames.provider_receipts import (
+    OpenAIProviderReceiptVerifier,
+    ProviderReceiptExpectation,
+    verify_provider_receipts,
+)
+
+if TYPE_CHECKING:
+    from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+        ModelAttemptAuditRecord,
+    )
+
+    from scripts.validation.claim_events.contracts import (
+        NaryClaimCase,
+        NaryClaimFixture,
+    )
+    from scripts.validation.claim_events.scoring import BenchmarkFixtureContract
+
+_REPO_ROOT: Final = Path(__file__).resolve().parents[4]
+_MODEL_ID: Final = "openai:gpt-5.6-luna"
+_PANEL_CASE_IDS: Final = (
+    "bionlp-ge-2011:PMID-9361029",
+    "bionlp-ge-2011:PMC-2222968-03-Results-02",
+    "bionlp-ge-2011:PMC-2222968-05-Results-04",
+    "bionlp-ge-2011:PMC-2222968-15-Materials_and_Methods-07",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _DiagnosticPanel:
+    cases: tuple[NaryClaimCase, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _CaseResult:
+    prediction: dict[str, object]
+    evidence: dict[str, object]
+    records: tuple[ModelAttemptAuditRecord, ...]
+    executable: bool
+    coverage_confirmed: bool
+    entailed_count: int
+    binding_rejection_count: int
+    review_only_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class RestartGateInputs:
+    case_count: int
+    executable_case_count: int
+    coverage_confirmed_case_count: int
+    exact_whole_event_match_count: int
+    empty_control_false_positive_count: int
+    negative_or_null_leakage_count: int
+    epistemic_escalation_count: int
+    binding_rejection_count: int
+    invalid_agent_output_count: int
+    unidentified_provider_attempt_count: int
+    provider_receipts_verified: bool
+
+
+def run_finite_source_unit_pilot(
+    *,
+    fixture: NaryClaimFixture,
+    run_id: str,
+) -> dict[str, object]:
+    """Run the one-shot diagnostic against the frozen four-case panel."""
+
+    require_frozen_development_fixture(fixture)
+    repository_evidence = collect_repository_evidence(_REPO_ROOT)
+    if repository_evidence["clean"] is not True:
+        raise RuntimeError("finite source-unit runs require a clean tracked worktree")
+    panel = _select_panel(fixture)
+    return asyncio.run(
+        _run_panel(
+            fixture=fixture,
+            panel=panel,
+            run_id=run_id,
+            repository_evidence=repository_evidence,
+        ),
+    )
+
+
+async def _run_panel(
+    *,
+    fixture: NaryClaimFixture,
+    panel: _DiagnosticPanel,
+    run_id: str,
+    repository_evidence: dict[str, object],
+) -> dict[str, object]:
+    client, tenant, execution_model_id, kernel, store = build_tg04_runtime(_MODEL_ID)
+    model_client = as_model_client(client)
+    predictions: list[dict[str, object]] = []
+    case_evidence: list[dict[str, object]] = []
+    all_records: list[ModelAttemptAuditRecord] = []
+    executable_cases = coverage_confirmed_cases = 0
+    entailed_count = binding_rejections = review_only_count = 0
+    try:
+        for case in panel.cases:
+            result = await _execute_case(
+                case=case,
+                client=model_client,
+                tenant=tenant,
+                model_id=execution_model_id,
+                run_id=run_id,
+            )
+            predictions.append(result.prediction)
+            case_evidence.append(result.evidence)
+            all_records.extend(result.records)
+            executable_cases += int(result.executable)
+            coverage_confirmed_cases += int(result.coverage_confirmed)
+            entailed_count += result.entailed_count
+            binding_rejections += result.binding_rejection_count
+            review_only_count += result.review_only_count
+    finally:
+        with suppress(Exception):
+            await kernel.close()
+        with suppress(Exception):
+            await store.close()
+
+    if collect_repository_evidence(_REPO_ROOT) != repository_evidence:
+        raise RuntimeError("repository state changed during the finite source-unit run")
+
+    score = score_fixture(cast("BenchmarkFixtureContract", panel), predictions)
+    expectations, invalid_count, unidentified_count = _receipt_expectations(all_records)
+    receipts = verify_provider_receipts(
+        expectations,
+        OpenAIProviderReceiptVerifier.from_environment(),
+    )
+    metrics = asdict(score.metrics)
+    whole_matches = score.metrics.whole_event_recall.count
+    source_supported_unmatched = source_supported_unmatched_count(
+        entailed_count=entailed_count,
+        exact_match_count=whole_matches,
+    )
+    requirements = restart_gate_requirements(
+        RestartGateInputs(
+            case_count=len(panel.cases),
+            executable_case_count=executable_cases,
+            coverage_confirmed_case_count=coverage_confirmed_cases,
+            exact_whole_event_match_count=whole_matches,
+            empty_control_false_positive_count=(
+                score.metrics.empty_control_false_positive.count
+            ),
+            negative_or_null_leakage_count=(
+                score.metrics.negative_null_leakage.count
+            ),
+            epistemic_escalation_count=score.metrics.epistemic_escalation.count,
+            binding_rejection_count=binding_rejections,
+            invalid_agent_output_count=invalid_count,
+            unidentified_provider_attempt_count=unidentified_count,
+            provider_receipts_verified=receipts.gate_passed,
+        ),
+    )
+    gate = all(requirements.values())
+    report: dict[str, object] = {
+        "schema_version": "tg04_finite_source_unit_pilot.v1",
+        "run_id": run_id,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "model_id": _MODEL_ID,
+        "task_id": "finite_source_unit_event_audit",
+        "conclusion_scope": {
+            "qualifies_experimental_task_only": True,
+            "production_document_extraction_exercised": False,
+            "production_path_confirmation_required": True,
+        },
+        "fixture_sha256": fixture.sha256,
+        "panel_case_ids": list(_PANEL_CASE_IDS),
+        "panel_sha256": _panel_sha256(fixture.sha256),
+        "repository_evidence": repository_evidence,
+        "predictions": predictions,
+        "metrics": metrics,
+        "case_scores": [asdict(case) for case in score.cases],
+        "diagnostic_measurements": {
+            "executable_case_count": executable_cases,
+            "case_count": len(panel.cases),
+            "coverage_confirmed_case_count": coverage_confirmed_cases,
+            "exact_whole_event_match_count": whole_matches,
+            "source_entailed_event_count": entailed_count,
+            "source_supported_unmatched_count": source_supported_unmatched,
+            "review_only_candidate_count": review_only_count,
+            "binding_rejection_count": binding_rejections,
+        },
+        "safety": {
+            "fallback_count": 0,
+            "invalid_agent_output_count": invalid_count,
+            "unidentified_provider_attempt_count": unidentified_count,
+            "provider_receipt_status": receipts.status,
+            "verified_provider_receipt_count": receipts.verified_count,
+            "provider_response_id_count": len(expectations),
+        },
+        "provider_receipts": receipts.as_json(),
+        "case_evidence": case_evidence,
+        "restart_gate": {
+            "passed": gate,
+            "decision": "PROCEED_TO_LARGER_PANEL" if gate else "STOP_AND_RECALIBRATE",
+            "requirements": requirements,
+        },
+    }
+    report["report_sha256"] = _sha256_json(report)
+    return report
+
+
+async def _execute_case(
+    *,
+    case: NaryClaimCase,
+    client: object,
+    tenant: object,
+    model_id: str,
+    run_id: str,
+) -> _CaseResult:
+    from artana_evidence_api.document_extraction import normalize_text_document
+
+    from scripts.validation.claim_events.finite_source_unit.service import (
+        FiniteSourceUnitModelClient,
+    )
+
+    normalized_text = normalize_text_document(case.source_text)
+    units = enumerate_source_units(case_id=case.case_id, source_text=normalized_text)
+    audit = start_model_attempt_audit(evidence_unit_id=case.case_id)
+    unit_evidence: list[dict[str, object]] = []
+    entailed_claims = []
+    review_only: list[dict[str, object]] = []
+    binding_rejection_count = 0
+    executable = True
+    coverage_confirmed = True
+    namespace = f"{run_id}:{case.case_id}:{uuid4().hex}"
+    try:
+        for unit in units:
+            try:
+                extraction = await extract_source_unit(
+                    client=cast("FiniteSourceUnitModelClient", client),
+                    tenant=tenant,
+                    model_id=model_id,
+                    execution_namespace=namespace,
+                    unit=unit,
+                )
+            except Exception as exc:  # noqa: BLE001 - preserve failed run evidence
+                executable = False
+                coverage_confirmed = False
+                unit_evidence.append(_failed_unit_evidence(unit.unit_id, "extraction", exc))
+                continue
+
+            extracted = extraction.value
+            binding_rejection_count += len(extracted.rejected)
+            unit_record: dict[str, object] = {
+                "unit_id": unit.unit_id,
+                "source_start": unit.source_start,
+                "source_end": unit.source_end,
+                "decision": extracted.output.decision.value,
+                "accepted_candidate_ids": [
+                    candidate.inventory_id for candidate in extracted.accepted
+                ],
+                "binding_rejections": [
+                    rejection.as_json() for rejection in extracted.rejected
+                ],
+            }
+            try:
+                verification = await verify_source_unit_candidates(
+                    client=cast("FiniteSourceUnitModelClient", client),
+                    tenant=tenant,
+                    model_id=model_id,
+                    execution_namespace=namespace,
+                    unit=unit,
+                    candidates=extracted.accepted,
+                )
+            except Exception as exc:  # noqa: BLE001 - preserve failed run evidence
+                executable = False
+                coverage_confirmed = False
+                unit_record["verification_error"] = type(exc).__name__
+                unit_evidence.append(unit_record)
+                continue
+
+            coverage_decision = verification.parsed.coverage_decision
+            unit_record["coverage_decision"] = coverage_decision.value
+            unit_record["coverage_reasoning"] = (
+                verification.parsed.coverage_reasoning
+            )
+            coverage_confirmed = coverage_confirmed and coverage_decision in {
+                SourceUnitCoverageDecision.CANDIDATES_COMPLETE,
+                SourceUnitCoverageDecision.NO_EVENT_CONFIRMED,
+            }
+            decisions: list[dict[str, object]] = []
+            for candidate in verification.value:
+                serialized = {
+                    "candidate_id": candidate.claim.inventory_id,
+                    **candidate.verification.model_dump(mode="json"),
+                }
+                decisions.append(serialized)
+                if candidate.verification.decision is EntailmentDecision.ENTAILED:
+                    entailed_claims.append(candidate.claim)
+                else:
+                    review_only.append(serialized)
+            unit_record["verification_decisions"] = decisions
+            unit_evidence.append(unit_record)
+    finally:
+        stop_model_attempt_audit(audit)
+
+    events = nary_events_from_bound_inventory(tuple(entailed_claims))
+    return _CaseResult(
+        prediction={
+            "case_id": case.case_id,
+            "events": events,
+            "review_only_events": review_only,
+            "abstained": not events,
+            "execution_outcome": "COMPLETE" if executable else "INVALID",
+        },
+        evidence={
+            "case_id": case.case_id,
+            "source_unit_count": len(units),
+            "units": unit_evidence,
+            "attempts": [record.as_json() for record in audit.records],
+        },
+        records=tuple(audit.records),
+        executable=executable,
+        coverage_confirmed=coverage_confirmed,
+        entailed_count=len(entailed_claims),
+        binding_rejection_count=binding_rejection_count,
+        review_only_count=len(review_only),
+    )
+
+
+def _receipt_expectations(
+    records: list[ModelAttemptAuditRecord],
+) -> tuple[list[ProviderReceiptExpectation], int, int]:
+    expectations: list[ProviderReceiptExpectation] = []
+    seen: set[str] = set()
+    invalid_count = unidentified_count = 0
+    schema_hashes = {
+        "primary": output_schema_json_sha256(SourceUnitExtractionOutput),
+        "weak_review": output_schema_json_sha256(SourceUnitVerificationOutput),
+    }
+    for record in records:
+        invalid_count += int(record.validation_outcome != "accepted")
+        if record.provider_response_id is None:
+            unidentified_count += 1
+            continue
+        if record.provider_response_id in seen:
+            raise RuntimeError("finite source-unit provider response IDs must be unique")
+        seen.add(record.provider_response_id)
+        expectations.append(
+            receipt_expectation_from_attempt(
+                case_id=record.semantic_unit_id or "unknown-source-unit",
+                report_model_id=_MODEL_ID,
+                record=record.as_json(),
+                expected_output_schema_sha256=schema_hashes[record.pass_role],
+            ),
+        )
+    return expectations, invalid_count, unidentified_count
+
+
+def _select_panel(fixture: NaryClaimFixture) -> _DiagnosticPanel:
+    by_id = {case.case_id: case for case in fixture.cases}
+    if set(_PANEL_CASE_IDS) - set(by_id):
+        raise RuntimeError("frozen finite source-unit panel is missing cases")
+    return _DiagnosticPanel(cases=tuple(by_id[case_id] for case_id in _PANEL_CASE_IDS))
+
+
+def _panel_sha256(fixture_sha256: str) -> str:
+    return _sha256_json(
+        {"fixture_sha256": fixture_sha256, "case_ids": _PANEL_CASE_IDS},
+    )
+
+
+def _failed_unit_evidence(
+    unit_id: str,
+    phase: str,
+    error: BaseException,
+) -> dict[str, object]:
+    return {
+        "unit_id": unit_id,
+        "phase": phase,
+        "error_type": type(error).__name__,
+    }
+
+
+def source_supported_unmatched_count(
+    *,
+    entailed_count: int,
+    exact_match_count: int,
+) -> int:
+    """Count verified events outside exact gold, including stress-case output."""
+
+    if not 0 <= exact_match_count <= entailed_count:
+        raise ValueError("exact matches must be bounded by entailed events")
+    return entailed_count - exact_match_count
+
+
+def restart_gate_requirements(inputs: RestartGateInputs) -> dict[str, bool]:
+    """Derive every pre-registered stop/go requirement deterministically."""
+
+    return {
+        "all_four_cases_executable": (
+            inputs.executable_case_count == inputs.case_count
+        ),
+        "all_source_units_coverage_confirmed": (
+            inputs.coverage_confirmed_case_count == inputs.case_count
+        ),
+        "at_least_one_exact_whole_event": (
+            inputs.exact_whole_event_match_count >= 1
+        ),
+        "methods_control_empty": inputs.empty_control_false_positive_count == 0,
+        "negative_or_null_leakage_zero": (
+            inputs.negative_or_null_leakage_count == 0
+        ),
+        "epistemic_escalation_zero": inputs.epistemic_escalation_count == 0,
+        "binding_rejection_zero": inputs.binding_rejection_count == 0,
+        "invalid_agent_output_zero": inputs.invalid_agent_output_count == 0,
+        "provider_lineage_complete": (
+            inputs.unidentified_provider_attempt_count == 0
+        ),
+        "provider_receipts_verified": inputs.provider_receipts_verified,
+    }
+
+
+def _sha256_json(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8"),
+    ).hexdigest()
+
+
+__all__ = [
+    "RestartGateInputs",
+    "restart_gate_requirements",
+    "run_finite_source_unit_pilot",
+    "source_supported_unmatched_count",
+]

--- a/scripts/validation/claim_events/finite_source_unit/service.py
+++ b/scripts/validation/claim_events/finite_source_unit/service.py
@@ -11,6 +11,9 @@ from artana_evidence_api.document_extraction_support.claim_frames import (
     ClaimInventoryBindingRejection,
     bind_claim_inventory_items,
 )
+from artana_evidence_api.document_extraction_support.llm_extraction.invocation_binding import (
+    kernel_run_id_for_invocation,
+)
 from artana_evidence_api.document_extraction_support.llm_extraction.structured_step import (
     AuditedStructuredStepResult,
     StructuredModelSemanticError,
@@ -172,7 +175,7 @@ async def extract_source_unit(
 
     async def invoke(invocation_id: str, provider_prompt: str) -> ModelStepResult:
         return await client.step(
-            run_id=f"tg04-finite-source-unit:{invocation_id}",
+            run_id=kernel_run_id_for_invocation(invocation_id),
             tenant=tenant,
             model=model_id,
             prompt=provider_prompt,
@@ -230,7 +233,7 @@ async def verify_source_unit_candidates(  # noqa: PLR0913
 
     async def invoke(invocation_id: str, provider_prompt: str) -> ModelStepResult:
         return await client.step(
-            run_id=f"tg04-finite-source-verification:{invocation_id}",
+            run_id=kernel_run_id_for_invocation(invocation_id),
             tenant=tenant,
             model=model_id,
             prompt=provider_prompt,

--- a/scripts/validation/claim_events/finite_source_unit/service.py
+++ b/scripts/validation/claim_events/finite_source_unit/service.py
@@ -1,0 +1,375 @@
+"""Audited extraction and verification for finite TG-04 source units."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, cast
+
+from artana_evidence_api.document_extraction_support.claim_frames import (
+    BoundClaimInventoryItem,
+    ClaimInventoryBindingRejection,
+    bind_claim_inventory_items,
+)
+from artana_evidence_api.document_extraction_support.llm_extraction.structured_step import (
+    AuditedStructuredStepResult,
+    StructuredModelSemanticError,
+    run_audited_structured_step,
+)
+from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+    ModelAttemptAuditContext,
+    ModelStepResult,
+    fingerprinted_step_key,
+)
+
+from scripts.validation.claim_events.finite_source_unit.contracts import (
+    CandidateVerification,
+    EntailmentDecision,
+    SourceUnitCoverageDecision,
+    SourceUnitExtractionOutput,
+    SourceUnitVerificationOutput,
+)
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+    from scripts.validation.claim_events.finite_source_unit.source_units import (
+        FrozenSourceUnit,
+    )
+
+_EXTRACTION_PROMPT_VERSION = "tg04.finite_source_unit.extraction.v1"
+_VERIFICATION_PROMPT_VERSION = "tg04.finite_source_unit.verification.v1"
+
+
+class FiniteSourceUnitModelClient(Protocol):
+    """Model-client surface required by the sealed diagnostic."""
+
+    async def step(  # noqa: PLR0913
+        self,
+        *,
+        run_id: str,
+        tenant: object,
+        model: str,
+        prompt: str,
+        output_schema: type[BaseModel],
+        step_key: str,
+        replay_policy: str,
+    ) -> ModelStepResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SourceUnitExtractionResult:
+    """Schema-valid categorical output plus item-level source binding."""
+
+    output: SourceUnitExtractionOutput
+    accepted: tuple[BoundClaimInventoryItem, ...]
+    rejected: tuple[ClaimInventoryBindingRejection, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedEventCandidate:
+    """A bound event and its independent categorical source verification."""
+
+    claim: BoundClaimInventoryItem
+    verification: CandidateVerification
+
+
+def bind_source_unit_extraction(
+    output: SourceUnitExtractionOutput,
+    *,
+    unit: FrozenSourceUnit,
+) -> SourceUnitExtractionResult:
+    """Bind every event independently and preserve rejected siblings."""
+
+    if output.unit_id != unit.unit_id:
+        raise StructuredModelSemanticError("extraction output unit_id mismatch")
+    binding = bind_claim_inventory_items(
+        output.events,
+        source_text=unit.text,
+        source_sha256=unit.source_sha256,
+        chunk_index=unit.index,
+        source_start_offset=unit.source_start,
+    )
+    return SourceUnitExtractionResult(
+        output=output,
+        accepted=binding.accepted,
+        rejected=binding.rejected,
+    )
+
+
+def bind_source_unit_verification(
+    output: SourceUnitVerificationOutput,
+    *,
+    unit: FrozenSourceUnit,
+    candidates: tuple[BoundClaimInventoryItem, ...],
+) -> tuple[VerifiedEventCandidate, ...]:
+    """Require one source-bound categorical decision per supplied candidate."""
+
+    if output.unit_id != unit.unit_id:
+        raise StructuredModelSemanticError("verification output unit_id mismatch")
+    by_id = {candidate.inventory_id: candidate for candidate in candidates}
+    decision_by_id = {
+        decision.candidate_id: decision for decision in output.decisions
+    }
+    if set(decision_by_id) != set(by_id):
+        raise StructuredModelSemanticError(
+            "verification decisions must cover the supplied candidates exactly",
+        )
+    if (
+        not candidates
+        and output.coverage_decision is SourceUnitCoverageDecision.CANDIDATES_COMPLETE
+    ):
+        raise StructuredModelSemanticError(
+            "CANDIDATES_COMPLETE requires supplied candidates",
+        )
+
+    verified: list[VerifiedEventCandidate] = []
+    for candidate in candidates:
+        decision = decision_by_id[candidate.inventory_id]
+        claim_text = candidate.item.exact_span
+        if any(span not in claim_text for span in decision.evidence_spans):
+            raise StructuredModelSemanticError(
+                "verification evidence must occur inside the candidate claim",
+            )
+        if decision.decision is EntailmentDecision.ENTAILED:
+            required_spans = (
+                candidate.item.relation_cue_span,
+                *(argument.exact_span for argument in candidate.item.arguments),
+            )
+            if any(
+                not any(required in evidence for evidence in decision.evidence_spans)
+                for required in required_spans
+            ):
+                raise StructuredModelSemanticError(
+                    "ENTAILED evidence must cover the trigger and every argument",
+                )
+        verified.append(
+            VerifiedEventCandidate(claim=candidate, verification=decision),
+        )
+    return tuple(verified)
+
+
+async def extract_source_unit(
+    *,
+    client: FiniteSourceUnitModelClient,
+    tenant: object,
+    model_id: str,
+    execution_namespace: str,
+    unit: FrozenSourceUnit,
+) -> AuditedStructuredStepResult[
+    SourceUnitExtractionOutput,
+    SourceUnitExtractionResult,
+]:
+    """Run one categorical event decision through Artana's audited agent path."""
+
+    prompt = _extraction_prompt(unit)
+    step_key = fingerprinted_step_key(
+        _EXTRACTION_PROMPT_VERSION,
+        model_id,
+        unit.input_sha256,
+        execution_namespace,
+    )
+
+    async def invoke(invocation_id: str, provider_prompt: str) -> ModelStepResult:
+        return await client.step(
+            run_id=f"tg04-finite-source-unit:{invocation_id}",
+            tenant=tenant,
+            model=model_id,
+            prompt=provider_prompt,
+            output_schema=SourceUnitExtractionOutput,
+            step_key=step_key,
+            replay_policy="fork_on_drift",
+        )
+
+    return await run_audited_structured_step(
+        invoke_model=invoke,
+        model_id=model_id,
+        prompt=prompt,
+        output_schema=SourceUnitExtractionOutput,
+        step_key=step_key,
+        audit_context=ModelAttemptAuditContext(
+            attempt_role="primary",
+            pass_role="primary",  # noqa: S106 - categorical audit role
+            retry_context=None,
+            source_sha256=unit.source_sha256,
+            input_sha256=unit.input_sha256,
+            semantic_unit_id=unit.unit_id,
+        ),
+        validate_semantics=lambda output: bind_source_unit_extraction(
+            output,
+            unit=unit,
+        ),
+    )
+
+
+async def verify_source_unit_candidates(  # noqa: PLR0913
+    *,
+    client: FiniteSourceUnitModelClient,
+    tenant: object,
+    model_id: str,
+    execution_namespace: str,
+    unit: FrozenSourceUnit,
+    candidates: tuple[BoundClaimInventoryItem, ...],
+) -> AuditedStructuredStepResult[
+    SourceUnitVerificationOutput,
+    tuple[VerifiedEventCandidate, ...],
+]:
+    """Independently verify every accepted candidate using only its source unit."""
+
+    prompt = _verification_prompt(unit=unit, candidates=candidates)
+    candidate_identity = "\n".join(
+        candidate.inventory_id for candidate in candidates
+    )
+    step_key = fingerprinted_step_key(
+        _VERIFICATION_PROMPT_VERSION,
+        model_id,
+        unit.input_sha256,
+        candidate_identity,
+        execution_namespace,
+    )
+
+    async def invoke(invocation_id: str, provider_prompt: str) -> ModelStepResult:
+        return await client.step(
+            run_id=f"tg04-finite-source-verification:{invocation_id}",
+            tenant=tenant,
+            model=model_id,
+            prompt=provider_prompt,
+            output_schema=SourceUnitVerificationOutput,
+            step_key=step_key,
+            replay_policy="fork_on_drift",
+        )
+
+    return await run_audited_structured_step(
+        invoke_model=invoke,
+        model_id=model_id,
+        prompt=prompt,
+        output_schema=SourceUnitVerificationOutput,
+        step_key=step_key,
+        audit_context=ModelAttemptAuditContext(
+            attempt_role="weak_review",
+            pass_role="weak_review",  # noqa: S106 - categorical audit role
+            retry_context=None,
+            source_sha256=unit.source_sha256,
+            input_sha256=unit.input_sha256,
+            semantic_unit_id=unit.unit_id,
+        ),
+        validate_semantics=lambda output: bind_source_unit_verification(
+            output,
+            unit=unit,
+            candidates=candidates,
+        ),
+    )
+
+
+def _extraction_prompt(unit: FrozenSourceUnit) -> str:
+    return f"""You are the event-extraction agent in a sealed biomedical diagnostic.
+
+Use only the frozen source unit below. Do not use outside knowledge. Decide one
+closed category: EXPLICIT_EVENT, NO_EVENT, or ABSTAIN. EXPLICIT_EVENT means the
+unit literally states at least one biomedical event with a trigger and at least
+two material typed arguments. Return every distinct explicit event in this unit.
+NO_EVENT means it contains no explicit biomedical event, including procedural
+instructions that merely describe an assay. ABSTAIN means the source cannot
+safely resolve the category.
+
+For each event, copy exact_span, relation_cue_span, and every argument span
+verbatim. Use normalized_extraction_text as source_locator. Keep claim_kind,
+event_type, polarity, and epistemic_status independent. Do not invent missing
+participants, normalize surface text, merge events, or return numeric scores.
+
+prompt_version: {_EXTRACTION_PROMPT_VERSION}
+unit_id: {unit.unit_id}
+unit_char_range: {unit.source_start}-{unit.source_end}
+unit_input_sha256: {unit.input_sha256}
+
+--- FROZEN SOURCE UNIT ---
+{unit.text}
+--- END SOURCE UNIT ---
+"""
+
+
+def _verification_prompt(
+    *,
+    unit: FrozenSourceUnit,
+    candidates: tuple[BoundClaimInventoryItem, ...],
+) -> str:
+    payload = [
+        {
+            "candidate_id": candidate.inventory_id,
+            "candidate": _blinded_candidate(candidate),
+        }
+        for candidate in candidates
+    ]
+    return f"""You are an independent source-only biomedical verifier.
+
+Use only the frozen source unit. First decide whether the candidate inventory is
+CANDIDATES_COMPLETE, NO_EVENT_CONFIRMED, MISSING_EVENT, or ABSTAIN. Review the
+unit even when no candidates were supplied. NO_EVENT_CONFIRMED is valid only
+when the unit contains no explicit biomedical event. CANDIDATES_COMPLETE is
+valid only when supplied candidates cover every explicit event in the unit.
+Return covered_candidate_ids as exactly the candidate IDs judged ENTAILED. A
+false extracted candidate may be rejected while the unit is NO_EVENT_CONFIRMED.
+
+For every supplied candidate, return exactly one categorical decision:
+ENTAILED, CONTRADICTED, INSUFFICIENT, or ABSTAIN.
+ENTAILED requires the complete event, its direction, polarity, epistemic status,
+trigger, and all material arguments to be explicit in the source. Copy literal
+evidence spans from inside that candidate's exact_span. The evidence must cover
+the trigger and every material argument. Provide concise reasoning and a
+condition that would falsify your decision. Do not repair candidates, use
+outside knowledge, compare against benchmark labels, or return numeric scores.
+
+prompt_version: {_VERIFICATION_PROMPT_VERSION}
+unit_id: {unit.unit_id}
+unit_input_sha256: {unit.input_sha256}
+
+--- FROZEN SOURCE UNIT ---
+{unit.text}
+--- END SOURCE UNIT ---
+
+--- CANDIDATES ---
+{json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True)}
+--- END CANDIDATES ---
+"""
+
+
+def _blinded_candidate(candidate: BoundClaimInventoryItem) -> dict[str, object]:
+    """Remove extractor reasoning and mention choices from verifier input."""
+
+    item = candidate.item
+    return {
+        "exact_span": item.exact_span,
+        "relation_cue_span": item.relation_cue_span,
+        "source_locator": item.source_locator,
+        "claim_kind": item.claim_kind.value,
+        "event_type": item.event_type.value,
+        "polarity": item.polarity.value,
+        "epistemic_status": item.epistemic_status.value,
+        "arguments": [
+            {
+                "role": argument.role.value,
+                "event_role": argument.event_role.value,
+                "exact_span": argument.exact_span,
+            }
+            for argument in item.arguments
+        ],
+    }
+
+
+def as_model_client(client: object) -> FiniteSourceUnitModelClient:
+    """Narrow the runtime's dynamic model client at one checked boundary."""
+
+    if not callable(getattr(client, "step", None)):
+        raise TypeError("finite source-unit runtime client lacks step()")
+    return cast("FiniteSourceUnitModelClient", client)
+
+
+__all__ = [
+    "SourceUnitExtractionResult",
+    "VerifiedEventCandidate",
+    "as_model_client",
+    "bind_source_unit_extraction",
+    "bind_source_unit_verification",
+    "extract_source_unit",
+    "verify_source_unit_candidates",
+]

--- a/scripts/validation/claim_events/finite_source_unit/source_units.py
+++ b/scripts/validation/claim_events/finite_source_unit/source_units.py
@@ -1,0 +1,80 @@
+"""Deterministic location-only source enumeration for the TG-04 pilot."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from artana_evidence_api.document_extraction_support.full_text_chunking import (
+    sentence_boundary_end_offsets,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenSourceUnit:
+    """One stable source location without agent-authored biomedical meaning."""
+
+    unit_id: str
+    index: int
+    source_start: int
+    source_end: int
+    text: str
+    source_sha256: str
+
+    @property
+    def input_sha256(self) -> str:
+        return hashlib.sha256(
+            (
+                f"{self.unit_id}\n{self.source_start}:{self.source_end}\n{self.text}"
+            ).encode(),
+        ).hexdigest()
+
+
+def enumerate_source_units(
+    *,
+    case_id: str,
+    source_text: str,
+) -> tuple[FrozenSourceUnit, ...]:
+    """Enumerate trimmed sentence locations while preserving source offsets."""
+
+    if not case_id.strip():
+        raise ValueError("case_id must be nonempty")
+    if not source_text.strip():
+        raise ValueError("source_text must be nonempty")
+
+    source_sha256 = hashlib.sha256(source_text.encode("utf-8")).hexdigest()
+    boundaries = (*sentence_boundary_end_offsets(source_text), len(source_text))
+    units: list[FrozenSourceUnit] = []
+    cursor = 0
+    for boundary in boundaries:
+        if boundary <= cursor:
+            continue
+        start = cursor
+        while start < boundary and source_text[start].isspace():
+            start += 1
+        end = boundary
+        while end > start and source_text[end - 1].isspace():
+            end -= 1
+        cursor = boundary
+        if start == end:
+            continue
+        index = len(units)
+        opaque_identity = hashlib.sha256(
+            f"{case_id}:{index}:{source_sha256}".encode(),
+        ).hexdigest()
+        units.append(
+            FrozenSourceUnit(
+                unit_id=f"source-unit-{opaque_identity}",
+                index=index,
+                source_start=start,
+                source_end=end,
+                text=source_text[start:end],
+                source_sha256=source_sha256,
+            ),
+        )
+    if not units:
+        raise ValueError("source-unit enumeration produced no locations")
+    return tuple(units)
+
+
+__all__ = ["FrozenSourceUnit", "enumerate_source_units"]

--- a/scripts/validation/claim_events/runner.py
+++ b/scripts/validation/claim_events/runner.py
@@ -100,7 +100,7 @@ async def _run_live_arm(
     run_id: str,
     repository_evidence: dict[str, object],
 ) -> dict[str, object]:
-    client, tenant, execution_model_id, kernel, store = _build_inventory_runtime(
+    client, tenant, execution_model_id, kernel, store = build_tg04_runtime(
         model_id,
     )
 
@@ -282,7 +282,11 @@ async def _execute_case(
         ),
         terminal_error=terminal_error,
     )
-    framed_events = _nary_events(inventory.claims) if inventory is not None else []
+    framed_events = (
+        nary_events_from_bound_inventory(inventory.claims)
+        if inventory is not None
+        else []
+    )
     events = framed_events if executable else []
     review_only_events = framed_events if inventory is not None and not executable else []
     outcome = _execution_outcome(
@@ -384,7 +388,7 @@ def _terminal_error_category(error: BaseException) -> str:
     )
 
 
-def _build_inventory_runtime(
+def build_tg04_runtime(
     model_id: str,
 ) -> tuple[object, object, str, _AsyncClosable, _AsyncClosable]:
     from artana.agent import SingleStepModelClient
@@ -452,7 +456,7 @@ def _case_receipt_expectations(
     return expectations, invalid_count, unidentified_count
 
 
-def _nary_events(
+def nary_events_from_bound_inventory(
     claims: tuple[BoundClaimInventoryItem, ...],
 ) -> list[dict[str, object]]:
     events: list[dict[str, object]] = []
@@ -528,6 +532,7 @@ def receipt_expectation_from_attempt(
     case_id: str,
     report_model_id: str,
     record: dict[str, object],
+    expected_output_schema_sha256: str | None = None,
 ) -> ProviderReceiptExpectation:
     def required(name: str) -> str:
         value = record.get(name)
@@ -550,7 +555,11 @@ def receipt_expectation_from_attempt(
         expected_source_sha256=required("source_sha256"),
         expected_input_sha256=required("input_sha256"),
         expected_evidence_unit_sha256=required("evidence_unit_sha256"),
-        expected_output_schema_sha256=_attempt_output_schema_sha256(record),
+        expected_output_schema_sha256=(
+            expected_output_schema_sha256
+            if expected_output_schema_sha256 is not None
+            else _attempt_output_schema_sha256(record)
+        ),
     )
 
 
@@ -586,4 +595,12 @@ def _sha256_json(value: object) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-__all__ = ["receipt_expectation_from_attempt", "run_live_arm"]
+_nary_events = nary_events_from_bound_inventory
+
+
+__all__ = [
+    "build_tg04_runtime",
+    "nary_events_from_bound_inventory",
+    "receipt_expectation_from_attempt",
+    "run_live_arm",
+]

--- a/tests/unit/test_finite_source_unit_audit.py
+++ b/tests/unit/test_finite_source_unit_audit.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from artana_evidence_api.document_extraction_support.claim_frames import (
+    ClaimInventoryItem,
+)
+from artana_evidence_api.document_extraction_support.llm_extraction.structured_step import (
+    StructuredModelSemanticError,
+)
+from pydantic import ValidationError
+
+from scripts.validation.claim_events.finite_source_unit.contracts import (
+    SourceUnitExtractionOutput,
+    SourceUnitVerificationOutput,
+)
+from scripts.validation.claim_events.finite_source_unit.runner import (
+    RestartGateInputs,
+    _execute_case,
+    _select_panel,
+    restart_gate_requirements,
+    source_supported_unmatched_count,
+)
+from scripts.validation.claim_events.finite_source_unit.service import (
+    bind_source_unit_extraction,
+    bind_source_unit_verification,
+)
+from scripts.validation.claim_events.finite_source_unit.source_units import (
+    enumerate_source_units,
+)
+from scripts.validation.claim_events.fixture import load_fixture
+
+
+class _TimeoutClient:
+    async def step(self, **_kwargs: object) -> object:
+        raise TimeoutError("provider unavailable")
+
+
+def _event_item(
+    *,
+    exact_span: str = "IL-4 inhibited FOXP3 expression.",
+) -> ClaimInventoryItem:
+    return ClaimInventoryItem.model_validate(
+        {
+            "exact_span": exact_span,
+            "relation_cue_span": "inhibited",
+            "source_locator": "normalized_extraction_text",
+            "claim_kind": "SCIENTIFIC_FINDING",
+            "event_type": "NEGATIVE_REGULATION",
+            "polarity": "SUPPORT",
+            "epistemic_status": "ASSERTED",
+            "inventory_rationale": "The source states an inhibition event.",
+            "arguments": [
+                {
+                    "role": "GENE_OR_PROTEIN",
+                    "event_role": "AGENT",
+                    "exact_span": "IL-4",
+                    "role_rationale": "IL-4 is the source-stated inhibitor.",
+                },
+                {
+                    "role": "GENE_OR_PROTEIN",
+                    "event_role": "THEME",
+                    "exact_span": "FOXP3",
+                    "role_rationale": "FOXP3 expression is inhibited.",
+                },
+            ],
+        },
+    )
+
+
+def test_source_units_preserve_deterministic_offsets_and_coverage() -> None:
+    source = "Title.\n\nIL-4 inhibited FOXP3 expression. Methods followed."
+
+    units = enumerate_source_units(case_id="case-1", source_text=source)
+
+    assert [unit.text for unit in units] == [
+        "Title.",
+        "IL-4 inhibited FOXP3 expression.",
+        "Methods followed.",
+    ]
+    assert [source[unit.source_start : unit.source_end] for unit in units] == [
+        unit.text for unit in units
+    ]
+    assert len({unit.unit_id for unit in units}) == len(units)
+    assert all("case-1" not in unit.unit_id for unit in units)
+    assert {unit.source_sha256 for unit in units} == {
+        hashlib.sha256(source.encode()).hexdigest()
+    }
+
+
+def test_extraction_contract_rejects_category_payload_conflicts() -> None:
+    with pytest.raises(ValidationError, match="requires at least one event"):
+        SourceUnitExtractionOutput.model_validate(
+            {
+                "unit_id": "unit-1",
+                "decision": "EXPLICIT_EVENT",
+                "events": [],
+                "reasoning": "No event supplied.",
+            },
+        )
+
+    with pytest.raises(ValidationError, match="cannot contain events"):
+        SourceUnitExtractionOutput.model_validate(
+            {
+                "unit_id": "unit-1",
+                "decision": "NO_EVENT",
+                "events": [_event_item().model_dump(mode="json")],
+                "reasoning": "Conflicting payload.",
+            },
+        )
+
+
+def test_item_binding_preserves_valid_candidate_and_rejected_sibling() -> None:
+    source = "Title. IL-4 inhibited FOXP3 expression."
+    unit = enumerate_source_units(case_id="case-1", source_text=source)[1]
+    output = SourceUnitExtractionOutput(
+        unit_id=unit.unit_id,
+        decision="EXPLICIT_EVENT",
+        events=(
+            _event_item(),
+            _event_item(exact_span="IL-4 activated missing protein."),
+        ),
+        reasoning="Two event candidates were returned.",
+    )
+
+    result = bind_source_unit_extraction(output, unit=unit)
+
+    assert len(result.accepted) == 1
+    assert result.accepted[0].source_start == source.index("IL-4")
+    assert len(result.rejected) == 1
+    assert result.rejected[0].disposition.value == "EXACT_SPAN_MISSING"
+
+
+def test_verification_requires_exact_candidate_coverage_and_local_evidence() -> None:
+    source = "Title. IL-4 inhibited FOXP3 expression."
+    unit = enumerate_source_units(case_id="case-1", source_text=source)[1]
+    extraction = bind_source_unit_extraction(
+        SourceUnitExtractionOutput(
+            unit_id=unit.unit_id,
+            decision="EXPLICIT_EVENT",
+            events=(_event_item(),),
+            reasoning="One explicit event.",
+        ),
+        unit=unit,
+    )
+    candidate_id = extraction.accepted[0].inventory_id
+    valid = SourceUnitVerificationOutput.model_validate(
+        {
+            "unit_id": unit.unit_id,
+            "coverage_decision": "CANDIDATES_COMPLETE",
+            "coverage_reasoning": "The supplied event covers the unit.",
+            "covered_candidate_ids": [candidate_id],
+            "decisions": [
+                {
+                    "candidate_id": candidate_id,
+                    "decision": "ENTAILED",
+                    "evidence_spans": ["IL-4 inhibited FOXP3 expression."],
+                    "reasoning": "The complete event is literal.",
+                    "falsification_condition": "The source omitted inhibition.",
+                }
+            ],
+        },
+    )
+
+    verified = bind_source_unit_verification(
+        valid,
+        unit=unit,
+        candidates=extraction.accepted,
+    )
+
+    assert verified[0].verification.decision.value == "ENTAILED"
+
+    missing = SourceUnitVerificationOutput(
+        unit_id=unit.unit_id,
+        coverage_decision="MISSING_EVENT",
+        coverage_reasoning="The candidate inventory is unresolved.",
+        covered_candidate_ids=(),
+        decisions=(),
+    )
+    with pytest.raises(StructuredModelSemanticError, match="cover"):
+        bind_source_unit_verification(
+            missing,
+            unit=unit,
+            candidates=extraction.accepted,
+        )
+
+    fabricated = SourceUnitVerificationOutput.model_validate(
+        {
+            "unit_id": unit.unit_id,
+            "coverage_decision": "CANDIDATES_COMPLETE",
+            "coverage_reasoning": "The supplied event covers the unit.",
+            "covered_candidate_ids": [candidate_id],
+            "decisions": [
+                {
+                    "candidate_id": candidate_id,
+                    "decision": "ENTAILED",
+                    "evidence_spans": ["Outside knowledge"],
+                    "reasoning": "Unsupported evidence.",
+                    "falsification_condition": "The evidence is absent.",
+                }
+            ],
+        },
+    )
+    with pytest.raises(StructuredModelSemanticError, match="inside"):
+        bind_source_unit_verification(
+            fabricated,
+            unit=unit,
+            candidates=extraction.accepted,
+        )
+
+    partial = SourceUnitVerificationOutput.model_validate(
+        {
+            "unit_id": unit.unit_id,
+            "coverage_decision": "CANDIDATES_COMPLETE",
+            "coverage_reasoning": "The supplied event covers the unit.",
+            "covered_candidate_ids": [candidate_id],
+            "decisions": [
+                {
+                    "candidate_id": candidate_id,
+                    "decision": "ENTAILED",
+                    "evidence_spans": ["IL-4"],
+                    "reasoning": "Only one participant was cited.",
+                    "falsification_condition": "The full event is unsupported.",
+                }
+            ],
+        },
+    )
+    with pytest.raises(StructuredModelSemanticError, match="trigger and every"):
+        bind_source_unit_verification(
+            partial,
+            unit=unit,
+            candidates=extraction.accepted,
+        )
+
+
+def test_no_event_unit_receives_independent_coverage_review() -> None:
+    unit = enumerate_source_units(
+        case_id="Materials_and_Methods-control",
+        source_text="Cells were measured by luciferase assay.",
+    )[0]
+    output = SourceUnitVerificationOutput(
+        unit_id=unit.unit_id,
+        coverage_decision="NO_EVENT_CONFIRMED",
+        coverage_reasoning="The source describes a procedure without a result.",
+        covered_candidate_ids=(),
+        decisions=(),
+    )
+
+    assert bind_source_unit_verification(output, unit=unit, candidates=()) == ()
+    assert "Materials_and_Methods" not in unit.unit_id
+
+
+def test_false_candidate_can_be_rejected_while_unit_confirms_no_event() -> None:
+    source = "The label inhibited appeared beside IL-4 and FOXP3 measurements."
+    unit = enumerate_source_units(case_id="case-1", source_text=source)[0]
+    item = _event_item(exact_span=source)
+    extraction = bind_source_unit_extraction(
+        SourceUnitExtractionOutput(
+            unit_id=unit.unit_id,
+            decision="EXPLICIT_EVENT",
+            events=(item,),
+            reasoning="The extractor proposed a relationship.",
+        ),
+        unit=unit,
+    )
+    candidate_id = extraction.accepted[0].inventory_id
+    verification = SourceUnitVerificationOutput.model_validate(
+        {
+            "unit_id": unit.unit_id,
+            "coverage_decision": "NO_EVENT_CONFIRMED",
+            "coverage_reasoning": "Measurement alone does not state a relationship.",
+            "covered_candidate_ids": [],
+            "decisions": [
+                {
+                    "candidate_id": candidate_id,
+                    "decision": "INSUFFICIENT",
+                    "evidence_spans": [],
+                    "reasoning": "The proposed inhibition is absent.",
+                    "falsification_condition": "The source explicitly states inhibition.",
+                }
+            ],
+        },
+    )
+
+    bound = bind_source_unit_verification(
+        verification,
+        unit=unit,
+        candidates=extraction.accepted,
+    )
+    assert bound[0].verification.decision.value == "INSUFFICIENT"
+
+
+@pytest.mark.parametrize(
+    ("coverage_decision", "candidate_decision", "covered_ids", "error"),
+    [
+        (
+            "CANDIDATES_COMPLETE",
+            "INSUFFICIENT",
+            [],
+            "requires an ENTAILED candidate",
+        ),
+        (
+            "MISSING_EVENT",
+            "ENTAILED",
+            [],
+            "must equal ENTAILED candidates",
+        ),
+        (
+            "NO_EVENT_CONFIRMED",
+            "ENTAILED",
+            ["candidate-1"],
+            "cannot contain ENTAILED candidates",
+        ),
+    ],
+)
+def test_verification_rejects_contradictory_coverage_truth_table(
+    coverage_decision: str,
+    candidate_decision: str,
+    covered_ids: list[str],
+    error: str,
+) -> None:
+    with pytest.raises(ValidationError, match=error):
+        SourceUnitVerificationOutput.model_validate(
+            {
+                "unit_id": "opaque-unit",
+                "coverage_decision": coverage_decision,
+                "coverage_reasoning": "Adversarial truth-table probe.",
+                "covered_candidate_ids": covered_ids,
+                "decisions": [
+                    {
+                        "candidate_id": "candidate-1",
+                        "decision": candidate_decision,
+                        "evidence_spans": (
+                            ["complete event"]
+                            if candidate_decision == "ENTAILED"
+                            else []
+                        ),
+                        "reasoning": "Categorical candidate decision.",
+                        "falsification_condition": "The source differs.",
+                    }
+                ],
+            },
+        )
+
+
+def test_agent_contracts_contain_no_numeric_score_fields() -> None:
+    extraction_fields = set(SourceUnitExtractionOutput.model_fields)
+    verification_fields = set(SourceUnitVerificationOutput.model_fields)
+
+    assert extraction_fields == {"unit_id", "decision", "events", "reasoning"}
+    assert verification_fields == {
+        "unit_id",
+        "coverage_decision",
+        "coverage_reasoning",
+        "covered_candidate_ids",
+        "decisions",
+    }
+
+
+def test_restart_gate_blocks_binding_rejections_and_unconfirmed_coverage() -> None:
+    baseline = RestartGateInputs(
+        case_count=4,
+        executable_case_count=4,
+        coverage_confirmed_case_count=4,
+        exact_whole_event_match_count=1,
+        empty_control_false_positive_count=0,
+        negative_or_null_leakage_count=0,
+        epistemic_escalation_count=0,
+        binding_rejection_count=0,
+        invalid_agent_output_count=0,
+        unidentified_provider_attempt_count=0,
+        provider_receipts_verified=True,
+    )
+
+    assert all(restart_gate_requirements(baseline).values())
+
+    rejected = replace(
+        baseline,
+        binding_rejection_count=1,
+        coverage_confirmed_case_count=3,
+    )
+    requirements = restart_gate_requirements(rejected)
+    assert requirements["binding_rejection_zero"] is False
+    assert requirements["all_source_units_coverage_confirmed"] is False
+
+
+def test_unmatched_discovery_count_includes_stress_lane_events() -> None:
+    assert source_supported_unmatched_count(
+        entailed_count=3,
+        exact_match_count=1,
+    ) == 2
+
+
+@pytest.mark.asyncio
+async def test_provider_timeout_produces_failed_case_evidence() -> None:
+    fixture = load_fixture(
+        Path("scripts/validation/claim_events/fixtures/tg04_bionlp_ge_development_v1.json"),
+    )
+    case = _select_panel(fixture).cases[-1]
+
+    result = await _execute_case(
+        case=case,
+        client=_TimeoutClient(),
+        tenant=object(),
+        model_id="openai/gpt-5.6-luna",
+        run_id="timeout-regression",
+    )
+
+    assert result.executable is False
+    assert result.coverage_confirmed is False
+    units = result.evidence["units"]
+    assert isinstance(units, list)
+    assert len(units) == 5
+    assert {unit["error_type"] for unit in units} == {"TimeoutError"}

--- a/tests/unit/test_finite_source_unit_audit.py
+++ b/tests/unit/test_finite_source_unit_audit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from artana_evidence_api.document_extraction_support.claim_frames import (
@@ -10,6 +11,10 @@ from artana_evidence_api.document_extraction_support.claim_frames import (
 )
 from artana_evidence_api.document_extraction_support.llm_extraction.structured_step import (
     StructuredModelSemanticError,
+)
+from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+    start_model_attempt_audit,
+    stop_model_attempt_audit,
 )
 from pydantic import ValidationError
 
@@ -27,6 +32,7 @@ from scripts.validation.claim_events.finite_source_unit.runner import (
 from scripts.validation.claim_events.finite_source_unit.service import (
     bind_source_unit_extraction,
     bind_source_unit_verification,
+    extract_source_unit,
 )
 from scripts.validation.claim_events.finite_source_unit.source_units import (
     enumerate_source_units,
@@ -37,6 +43,21 @@ from scripts.validation.claim_events.fixture import load_fixture
 class _TimeoutClient:
     async def step(self, **_kwargs: object) -> object:
         raise TimeoutError("provider unavailable")
+
+
+class _SuccessfulClient:
+    def __init__(self, output: SourceUnitExtractionOutput) -> None:
+        self._output = output
+
+    async def step(self, **kwargs: object) -> object:
+        return SimpleNamespace(
+            output=self._output,
+            run_id=kwargs["run_id"],
+            seq=1,
+            replayed=False,
+            response_id=None,
+            response_output_items=(),
+        )
 
 
 def _event_item(
@@ -89,6 +110,33 @@ def test_source_units_preserve_deterministic_offsets_and_coverage() -> None:
     assert {unit.source_sha256 for unit in units} == {
         hashlib.sha256(source.encode()).hexdigest()
     }
+
+
+@pytest.mark.asyncio
+async def test_extraction_uses_artana_invocation_bound_run_id() -> None:
+    unit = enumerate_source_units(case_id="case-1", source_text="Methods only.")[0]
+    output = SourceUnitExtractionOutput(
+        unit_id=unit.unit_id,
+        decision="NO_EVENT",
+        events=(),
+        reasoning="No explicit event is stated.",
+    )
+    audit = start_model_attempt_audit(evidence_unit_id="case-1")
+    try:
+        result = await extract_source_unit(
+            client=_SuccessfulClient(output),
+            tenant=object(),
+            model_id="openai/gpt-5.6-luna",
+            execution_namespace="topology-regression",
+            unit=unit,
+        )
+    finally:
+        stop_model_attempt_audit(audit)
+
+    assert result.value.output.decision.value == "NO_EVENT"
+    assert result.attempt_record.kernel_run_id == (
+        f"research-init-extraction:{result.attempt_record.invocation_id}"
+    )
 
 
 def test_extraction_contract_rejects_category_payload_conflicts() -> None:


### PR DESCRIPTION
## Summary

- add a frozen finite source-unit scientific pilot over the four TG-04 diagnostic cases
- run every unit through the real audited Luna extraction and blinded verification path with no deterministic biomedical fallback
- preserve item-level binding failures, invalid outputs, unmatched source-entailed discoveries, provider lineage, and deterministic stop/go evidence
- record the immutable live result and the required controlled stop

## Scientific result

The preregistered restart gate failed and the report says so explicitly:

- exact whole-event precision: 0/14
- exact whole-event recall: 0/4
- executable cases: 1/4
- source-entailed unmatched candidates: 28
- item-binding rejections: 13
- invalid verifier outputs: 4
- methods-control extraction false positives: 0
- deterministic fallback: 0
- provider receipts verified: 0/64 because provider retrieval omitted output-schema metadata

This PR does not authorize a larger panel, persistence, or trusted-graph promotion. It distinguishes exact expert-event reconstruction failure from the non-lossy discovery lane, where unmatched claims may reflect both benchmark undercoverage and model over-segmentation.

## Root causes

- extraction and verification did not share one governed event-eligibility contract
- sentence units bounded the search but did not resolve canonical participant roles, nested events, polarity, or epistemic status
- strict source binding exposed 13 real span/anchor defects
- the finite gold set is precise but not exhaustive
- the live provider receipt contract currently requires metadata the provider retrieval response does not expose

## Next gate

Run no larger benchmark yet. First verify provider custody with a tiny smoke call, then run a frozen three-unit diagnostic: one known expert event, one methods negative, and one explicit source event absent from gold.

## Validation

- focused finite-unit tests passed
- Evidence API lint passed
- Evidence API strict type checks passed
- full `make service-checks` passed before the immutable live run with 87.53% coverage
- pre-run and post-run adversarial reviews completed
