### PR TITLE
TG-04: recalibrate provider receipt custody

### DIFF
--- a/docs/validation/reports/2026-07-17-tg04-provider-receipt-recalibration.md
+++ b/docs/validation/reports/2026-07-17-tg04-provider-receipt-recalibration.md
@@ -1,0 +1,114 @@
+# TG-04 Provider Receipt Recalibration
+
+Date: 2026-07-17
+
+## Decision
+
+**THE MINIMAL CUSTODY SMOKE PASSED.** One existing real Luna response from the
+immutable finite source-unit artifact now verifies live after separating the
+provider-native response representation from Artana's adapter representation.
+
+This result proves only the corrected receipt boundary for one response. It does
+not qualify all 64 historical calls, improve scientific extraction, authorize a
+new benchmark, or permit graph persistence.
+
+## Frozen Evidence
+
+- Source artifact:
+  `/tmp/artana-tg04/finite-source-unit-2026-07-17/luna-r2.json`
+- Source artifact SHA-256:
+  `8c59553036a4dc58eb55e5b6381058401fcbff2a9069499f7f26b5abb1f3f58e`
+- Revalidated response ID:
+  `resp_0593ad7adffdf4cb006a5aad151ce8819ba8d5468cc386e7e9`
+- Model: `gpt-5.6-luna`
+- New model calls: `0`
+- Historical receipt result: `mismatched / output_schema_missing`
+- Recalibrated receipt result: `verified_live / none`
+
+## Root Causes
+
+### Response schema metadata is not retained on retrieval
+
+Artana previously required the retrieved response to contain
+`text.format.schema`. The live OpenAI retrieval omitted that field. The exact
+schema SHA-256 was still present in the Artana invocation binding inside the
+provider-retrieved input prompt.
+
+The verifier now records the categorical source of schema evidence:
+
+- `provider_response`
+- `provider_input_binding`
+- `provider_response_and_input_binding`
+- `not_required`
+- `unverified`
+
+The live smoke verified the schema through `provider_input_binding`. A missing
+or different retrieved binding still fails closed.
+
+### LiteLLM and provider retrieval expose different output shapes
+
+The execution-time adapter output and later provider-native output did not have
+the same canonical JSON hash. Provider retrieval included a reasoning item and
+provider-native message fields that were absent from the LiteLLM output retained
+by Artana.
+
+The scientific structured payload hash matched exactly. The verifier now keeps
+the raw hash mismatch visible and permits the categorical result
+`structured_payload_with_verified_envelope` only when all of these independently
+match:
+
+1. the provider output contains at most one inert reasoning item, exactly one
+   completed final-answer assistant message, exactly one structured
+   `output_text`, and no commentary message, refusal, function call, extra
+   message, or unknown output item;
+2. response ID, model, completion status, message role, and message status;
+3. structured payload SHA-256;
+4. provider-retrieved prompt SHA-256;
+5. invocation and kernel run IDs;
+6. source, input, and evidence-unit SHA-256 values;
+7. output-schema SHA-256 from the provider-retrieved invocation binding.
+
+If the structured payload also differs, verification still fails with the
+existing output or payload mismatch category. Exact raw-output equality remains
+the stronger `exact_provider_output` category.
+
+## Live Smoke Result
+
+| Field | Result |
+| --- | --- |
+| Receipt status | `verified_live` |
+| Failure | `none` |
+| Provider response completed | yes |
+| Exact raw output hash | no |
+| Output verification | `structured_payload_with_verified_envelope` |
+| Structured payload hash | exact match |
+| Input topology | verified |
+| Invocation topology | verified |
+| Schema evidence | `provider_input_binding` |
+| Schema hash | exact match |
+
+## Validation
+
+- New focused regressions cover response-omitted schema metadata, response plus
+  input schema evidence, mismatched input schema, exact provider output, and
+  adapter-transformed output with an exact structured payload.
+- Adversarial regressions reject extra assistant messages, refusal content,
+  function calls, unknown output items, and non-inert reasoning content.
+- Existing receipt failure tests continue to reject changed output, payload,
+  prompt, source, evidence-unit, model, role, status, and invocation evidence.
+- All focused receipt, finite-unit, and claim-frame tests passed.
+- Strict Ruff and mypy checks passed for the changed receipt boundary and tests.
+- An independent adversarial review found the initially permissive transformed
+  output grammar. The grammar was narrowed and regression-tested before commit.
+
+## Next Isolated Experiment
+
+After this custody-only PR merges, run exactly one procedure source unit through
+one extractor and one blinded verifier using the same frozen eligibility rules.
+The only question will be whether both agents categorize the unit as procedural
+and exclude it from scientific evidence. Do not include an expert event or an
+unannotated discovery in that run.
+
+Proceed to a one-event reconstruction experiment only if the procedure unit has
+two valid agent outputs, zero scientific candidates, zero binding failures,
+fallback zero, and every provider receipt verifies live.

--- a/scripts/validation/claim_frames/provider_receipts.py
+++ b/scripts/validation/claim_frames/provider_receipts.py
@@ -64,6 +64,18 @@ ProviderReceiptFailure = Literal[
     "prompt_hash_mismatch",
     "duplicate_response_id",
 ]
+OutputSchemaVerificationSource = Literal[
+    "unverified",
+    "not_required",
+    "provider_response",
+    "provider_input_binding",
+    "provider_response_and_input_binding",
+]
+ProviderOutputVerificationSource = Literal[
+    "unverified",
+    "exact_provider_output",
+    "structured_payload_with_verified_envelope",
+]
 
 
 def canonical_provider_model_id(model_id: str) -> str:
@@ -117,6 +129,8 @@ class ProviderReceiptEvidence:
     retrieved_model_id: str | None
     expected_output_sha256: str
     retrieved_output_sha256: str | None
+    provider_output_hash_matched: bool
+    provider_output_verification_source: ProviderOutputVerificationSource
     expected_payload_sha256: str | None
     retrieved_payload_sha256: str | None
     expected_prompt_sha256: str
@@ -133,6 +147,8 @@ class ProviderReceiptEvidence:
     retrieved_evidence_unit_sha256: str | None
     expected_output_schema_sha256: str | None
     retrieved_output_schema_sha256: str | None
+    output_schema_verification_source: OutputSchemaVerificationSource
+    provider_response_schema_supported: bool
     provider_status: str | None
     response_completed_verified: bool
     incomplete_details_absent: bool
@@ -152,6 +168,10 @@ class ProviderReceiptEvidence:
             "retrieved_model_id": self.retrieved_model_id,
             "expected_output_sha256": self.expected_output_sha256,
             "retrieved_output_sha256": self.retrieved_output_sha256,
+            "provider_output_hash_matched": self.provider_output_hash_matched,
+            "provider_output_verification_source": (
+                self.provider_output_verification_source
+            ),
             "expected_payload_sha256": self.expected_payload_sha256,
             "retrieved_payload_sha256": self.retrieved_payload_sha256,
             "expected_prompt_sha256": self.expected_prompt_sha256,
@@ -168,6 +188,12 @@ class ProviderReceiptEvidence:
             "retrieved_evidence_unit_sha256": self.retrieved_evidence_unit_sha256,
             "expected_output_schema_sha256": self.expected_output_schema_sha256,
             "retrieved_output_schema_sha256": self.retrieved_output_schema_sha256,
+            "output_schema_verification_source": (
+                self.output_schema_verification_source
+            ),
+            "provider_response_schema_supported": (
+                self.provider_response_schema_supported
+            ),
             "provider_status": self.provider_status,
             "response_completed_verified": self.response_completed_verified,
             "incomplete_details_absent": self.incomplete_details_absent,
@@ -226,6 +252,10 @@ ProviderInputItemsRetriever = Callable[[str], Sequence[Mapping[str, object]]]
 class _RetrievedReceiptFields:
     model_id: str | None = None
     output_sha256: str | None = None
+    provider_output_hash_matched: bool = False
+    provider_output_verification_source: ProviderOutputVerificationSource = (
+        "unverified"
+    )
     payload_sha256: str | None = None
     prompt_sha256: str | None = None
     invocation_id: str | None = None
@@ -234,6 +264,8 @@ class _RetrievedReceiptFields:
     input_sha256: str | None = None
     evidence_unit_sha256: str | None = None
     output_schema_sha256: str | None = None
+    output_schema_verification_source: OutputSchemaVerificationSource = "unverified"
+    provider_response_schema_supported: bool = False
     provider_status: str | None = None
     response_completed_verified: bool = False
     incomplete_details_absent: bool = False
@@ -339,14 +371,12 @@ def _verify_response_output(
             retrieved=fields,
         )
     output_hash = canonical_provider_output_sha256(output)
-    fields = replace(fields, output_sha256=output_hash)
-    if output_hash != expectation.expected_output_sha256:
-        return _receipt_evidence(
-            expectation,
-            status="mismatched",
-            failure="output_hash_mismatch",
-            retrieved=fields,
-        )
+    output_hash_matched = output_hash == expectation.expected_output_sha256
+    fields = replace(
+        fields,
+        output_sha256=output_hash,
+        provider_output_hash_matched=output_hash_matched,
+    )
     if expectation.expected_payload_sha256 is None:
         return _receipt_evidence(
             expectation,
@@ -369,10 +399,21 @@ def _verify_response_output(
         return _receipt_evidence(
             expectation,
             status="mismatched",
-            failure="payload_hash_mismatch",
+            failure=(
+                "payload_hash_mismatch"
+                if output_hash_matched
+                else "output_hash_mismatch"
+            ),
             retrieved=fields,
         )
-    return fields
+    return replace(
+        fields,
+        provider_output_verification_source=(
+            "exact_provider_output"
+            if output_hash_matched
+            else "structured_payload_with_verified_envelope"
+        ),
+    )
 
 
 def _verify_response_schema(
@@ -382,33 +423,33 @@ def _verify_response_schema(
 ) -> _RetrievedReceiptFields | ProviderReceiptEvidence:
     expected = expectation.expected_output_schema_sha256
     if expected is None:
-        return retrieved
+        return replace(
+            retrieved,
+            output_schema_verification_source="not_required",
+        )
     text = response.get("text")
     if not isinstance(text, Mapping):
-        return _receipt_evidence(
-            expectation,
-            status="mismatched",
-            failure="output_schema_missing",
-            retrieved=retrieved,
-        )
+        return retrieved
     output_format = text.get("format")
     if not isinstance(output_format, Mapping):
-        return _receipt_evidence(
-            expectation,
-            status="mismatched",
-            failure="output_schema_missing",
-            retrieved=retrieved,
-        )
+        return retrieved
     schema = output_format.get("schema")
+    if schema is None:
+        return retrieved
     if not isinstance(schema, Mapping):
         return _receipt_evidence(
             expectation,
             status="mismatched",
-            failure="output_schema_missing",
+            failure="output_schema_mismatch",
             retrieved=retrieved,
         )
     schema_sha256 = canonical_provider_output_sha256(schema)
-    fields = replace(retrieved, output_schema_sha256=schema_sha256)
+    fields = replace(
+        retrieved,
+        output_schema_sha256=schema_sha256,
+        output_schema_verification_source="provider_response",
+        provider_response_schema_supported=True,
+    )
     if schema_sha256 != expected:
         return _receipt_evidence(
             expectation,
@@ -586,17 +627,14 @@ def _verify_provider_input(
             failure="invocation_topology_mismatch",
             retrieved=retrieved,
         )
-    if (
-        expectation.expected_output_schema_sha256 is not None
-        and invocation_binding.output_schema_sha256
-        != expectation.expected_output_schema_sha256
-    ):
-        return _receipt_evidence(
-            expectation,
-            status="mismatched",
-            failure="output_schema_mismatch",
-            retrieved=retrieved,
-        )
+    schema_result = _bind_retrieved_output_schema(
+        expectation,
+        retrieved=retrieved,
+        input_schema_sha256=invocation_binding.output_schema_sha256,
+    )
+    if isinstance(schema_result, ProviderReceiptEvidence):
+        return schema_result
+    retrieved = schema_result
     prompt_hash = _sha256_text(retrieved_prompt)
     bound_fields = replace(
         retrieved,
@@ -656,6 +694,39 @@ def _verify_provider_input(
         status="verified_live",
         failure="none",
         retrieved=bound_fields,
+    )
+
+
+def _bind_retrieved_output_schema(
+    expectation: ProviderReceiptExpectation,
+    *,
+    retrieved: _RetrievedReceiptFields,
+    input_schema_sha256: str,
+) -> _RetrievedReceiptFields | ProviderReceiptEvidence:
+    """Bind schema custody to provider response metadata or retrieved input."""
+
+    expected = expectation.expected_output_schema_sha256
+    if expected is not None and input_schema_sha256 != expected:
+        return _receipt_evidence(
+            expectation,
+            status="mismatched",
+            failure="output_schema_mismatch",
+            retrieved=retrieved,
+        )
+    if expected is None:
+        return replace(
+            retrieved,
+            output_schema_verification_source="not_required",
+        )
+    source: OutputSchemaVerificationSource = (
+        "provider_response_and_input_binding"
+        if retrieved.provider_response_schema_supported
+        else "provider_input_binding"
+    )
+    return replace(
+        retrieved,
+        output_schema_sha256=input_schema_sha256,
+        output_schema_verification_source=source,
     )
 
 
@@ -726,6 +797,10 @@ def _receipt_evidence(
         retrieved_model_id=fields.model_id,
         expected_output_sha256=expectation.expected_output_sha256,
         retrieved_output_sha256=fields.output_sha256,
+        provider_output_hash_matched=fields.provider_output_hash_matched,
+        provider_output_verification_source=(
+            fields.provider_output_verification_source
+        ),
         expected_payload_sha256=expectation.expected_payload_sha256,
         retrieved_payload_sha256=fields.payload_sha256,
         expected_prompt_sha256=expectation.expected_prompt_sha256,
@@ -742,6 +817,12 @@ def _receipt_evidence(
         retrieved_evidence_unit_sha256=fields.evidence_unit_sha256,
         expected_output_schema_sha256=expectation.expected_output_schema_sha256,
         retrieved_output_schema_sha256=fields.output_schema_sha256,
+        output_schema_verification_source=(
+            fields.output_schema_verification_source
+        ),
+        provider_response_schema_supported=(
+            fields.provider_response_schema_supported
+        ),
         provider_status=fields.provider_status,
         response_completed_verified=fields.response_completed_verified,
         incomplete_details_absent=fields.incomplete_details_absent,
@@ -755,29 +836,101 @@ def _receipt_evidence(
 
 def _structured_payload_from_output(output: Sequence[object]) -> JsonObject:
     output_texts: list[str] = []
+    message_count = reasoning_count = 0
     for raw_item in output:
         if not isinstance(raw_item, Mapping):
             raise TypeError("provider output items must be objects")
         item_type = raw_item.get("type")
-        if item_type == "output_text":
-            output_texts.append(_output_text(raw_item))
+        if item_type == "reasoning":
+            reasoning_count += 1
+            _validate_inert_reasoning_item(raw_item)
             continue
         if item_type != "message":
-            continue
+            raise ValueError("provider output contains an unsupported item type")
+        message_count += 1
+        _validate_output_message_item(raw_item)
         content = raw_item.get("content")
         if not isinstance(content, Sequence) or isinstance(content, str | bytes):
             raise TypeError("provider message content must be a list")
         for raw_part in content:
             if not isinstance(raw_part, Mapping):
                 raise TypeError("provider message content parts must be objects")
-            if raw_part.get("type") == "output_text":
-                output_texts.append(_output_text(raw_part))
-    if len(output_texts) != 1:
-        raise ValueError("provider response must contain one structured output text")
+            if raw_part.get("type") != "output_text":
+                raise ValueError("provider message contains non-output text content")
+            _validate_output_text_part(raw_part)
+            output_texts.append(_output_text(raw_part))
+    if message_count != 1 or reasoning_count > 1 or len(output_texts) != 1:
+        raise ValueError(
+            "provider response must contain one message and one structured output text",
+        )
     parsed = json.loads(output_texts[0])
     if not isinstance(parsed, dict):
         raise TypeError("provider structured output must parse to an object")
     return cast("JsonObject", parsed)
+
+
+def _validate_inert_reasoning_item(item: Mapping[str, object]) -> None:
+    """Accept only the provider reasoning envelope omitted by the adapter."""
+
+    _reject_unknown_keys(
+        item,
+        allowed={
+            "content",
+            "encrypted_content",
+            "id",
+            "status",
+            "summary",
+            "type",
+        },
+        label="provider reasoning item",
+    )
+    if not isinstance(item.get("id"), str):
+        raise TypeError("provider reasoning item ID must be text")
+    if item.get("status") not in (None, "completed"):
+        raise ValueError("provider reasoning item status is unsupported")
+    summary = item.get("summary")
+    if summary != []:
+        raise ValueError("provider reasoning summary must be empty")
+    content = item.get("content")
+    if content not in (None, []):
+        raise ValueError("provider reasoning content must be opaque")
+    encrypted_content = item.get("encrypted_content")
+    if encrypted_content is not None and not isinstance(encrypted_content, str):
+        raise TypeError("provider encrypted reasoning must be text or null")
+
+
+def _validate_output_message_item(item: Mapping[str, object]) -> None:
+    _reject_unknown_keys(
+        item,
+        allowed={"content", "id", "phase", "role", "status", "type"},
+        label="provider output message",
+    )
+    if not isinstance(item.get("id"), str):
+        raise TypeError("provider output message ID must be text")
+    if item.get("phase") not in (None, "final_answer"):
+        raise ValueError("provider output message phase is unsupported")
+
+
+def _validate_output_text_part(part: Mapping[str, object]) -> None:
+    _reject_unknown_keys(
+        part,
+        allowed={"annotations", "logprobs", "text", "type"},
+        label="provider output text",
+    )
+    if part.get("annotations") not in (None, []):
+        raise ValueError("provider output text annotations must be empty")
+    if part.get("logprobs") not in (None, []):
+        raise ValueError("provider output text logprobs must be empty")
+
+
+def _reject_unknown_keys(
+    value: Mapping[str, object],
+    *,
+    allowed: set[str],
+    label: str,
+) -> None:
+    if unknown := set(value) - allowed:
+        raise ValueError(f"{label} contains unsupported fields: {sorted(unknown)}")
 
 
 def _output_message_failure(
@@ -852,6 +1005,8 @@ def _aggregate_receipt_status(
 __all__ = [
     "EXECUTION_MODEL_ID",
     "OpenAIProviderReceiptVerifier",
+    "OutputSchemaVerificationSource",
+    "ProviderOutputVerificationSource",
     "PROVIDER_MODEL_ID",
     "ProviderReceiptEvidence",
     "ProviderReceiptExpectation",

--- a/tests/unit/test_provider_receipts.py
+++ b/tests/unit/test_provider_receipts.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+from artana_evidence_api.document_extraction_support.llm_extraction.invocation_binding import (
+    bind_prompt_to_invocation,
+)
+
+from scripts.validation.claim_frames.provider_receipts import (
+    OpenAIProviderReceiptVerifier,
+    ProviderReceiptExpectation,
+    canonical_provider_output_sha256,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _RetrievedResponse:
+    response_id: str
+    output: list[dict[str, object]]
+    text: dict[str, object] | None = None
+
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "json"
+        return {
+            "id": self.response_id,
+            "model": "gpt-5.6-luna",
+            "status": "completed",
+            "incomplete_details": None,
+            "error": None,
+            "instructions": None,
+            "previous_response_id": None,
+            "conversation": None,
+            "prompt": None,
+            "tools": [],
+            "context_management": [],
+            "metadata": {},
+            "output": copy.deepcopy(self.output),
+            "text": copy.deepcopy(self.text),
+        }
+
+
+def test_schema_custody_uses_provider_input_when_response_omits_format() -> None:
+    expectation, response, input_items, _schema = _receipt_fixture()
+
+    evidence = OpenAIProviderReceiptVerifier(
+        lambda _response_id: response,
+        lambda _response_id: input_items,
+    ).verify(expectation)
+
+    assert evidence.status == "verified_live"
+    assert evidence.failure == "none"
+    assert evidence.retrieved_output_schema_sha256 == (
+        expectation.expected_output_schema_sha256
+    )
+    assert evidence.output_schema_verification_source == "provider_input_binding"
+    assert evidence.provider_response_schema_supported is False
+    assert evidence.provider_output_hash_matched is True
+    assert evidence.provider_output_verification_source == "exact_provider_output"
+
+
+def test_schema_custody_records_response_and_input_evidence_when_available() -> None:
+    expectation, response, input_items, schema = _receipt_fixture(
+        include_response_schema=True,
+    )
+    assert response.text == {"format": {"schema": schema}}
+
+    evidence = OpenAIProviderReceiptVerifier(
+        lambda _response_id: response,
+        lambda _response_id: input_items,
+    ).verify(expectation)
+
+    assert evidence.status == "verified_live"
+    assert evidence.output_schema_verification_source == (
+        "provider_response_and_input_binding"
+    )
+    assert evidence.provider_response_schema_supported is True
+
+
+def test_schema_custody_rejects_mismatched_provider_input_binding() -> None:
+    expectation, response, _input_items, _schema = _receipt_fixture()
+    mismatched_input = _input_items_for(
+        expectation,
+        output_schema_sha256="f" * 64,
+    )
+
+    evidence = OpenAIProviderReceiptVerifier(
+        lambda _response_id: response,
+        lambda _response_id: mismatched_input,
+    ).verify(expectation)
+
+    assert evidence.status == "mismatched"
+    assert evidence.failure == "output_schema_mismatch"
+    assert evidence.output_schema_verification_source == "unverified"
+
+
+def test_adapter_output_shape_may_differ_when_payload_and_envelope_match() -> None:
+    expectation, response, input_items, _schema = _receipt_fixture()
+    retrieved_output: list[dict[str, object]] = [
+        {
+            "id": "reasoning_provider_receipt_schema",
+            "type": "reasoning",
+            "status": None,
+            "summary": [],
+            "content": [],
+            "encrypted_content": "provider-native-reasoning",
+        },
+        *response.output,
+    ]
+    transformed_response = _RetrievedResponse(
+        response_id=response.response_id,
+        output=retrieved_output,
+    )
+
+    evidence = OpenAIProviderReceiptVerifier(
+        lambda _response_id: transformed_response,
+        lambda _response_id: input_items,
+    ).verify(expectation)
+
+    assert evidence.status == "verified_live"
+    assert evidence.provider_output_hash_matched is False
+    assert evidence.provider_output_verification_source == (
+        "structured_payload_with_verified_envelope"
+    )
+    assert evidence.retrieved_payload_sha256 == evidence.expected_payload_sha256
+
+
+def test_adapter_transformation_accepts_null_inert_reasoning_content() -> None:
+    expectation, response, input_items, _schema = _receipt_fixture()
+    transformed_response = _RetrievedResponse(
+        response_id=response.response_id,
+        output=[
+            {
+                "id": "reasoning_provider_receipt_schema",
+                "type": "reasoning",
+                "status": None,
+                "summary": [],
+                "content": None,
+                "encrypted_content": None,
+            },
+            *response.output,
+        ],
+    )
+
+    evidence = OpenAIProviderReceiptVerifier(
+        lambda _response_id: transformed_response,
+        lambda _response_id: input_items,
+    ).verify(expectation)
+
+    assert evidence.status == "verified_live"
+    assert evidence.provider_output_verification_source == (
+        "structured_payload_with_verified_envelope"
+    )
+
+
+@pytest.mark.parametrize(
+    "unexpected_output",
+    [
+        {
+            "id": "msg_extra",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": '{"decision":"NO_EVENT"}'}],
+        },
+        {
+            "id": "msg_refusal",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "refusal", "refusal": "Cannot comply."}],
+        },
+        {
+            "id": "call_unexpected",
+            "type": "function_call",
+            "status": "completed",
+            "name": "unexpected_tool",
+            "arguments": "{}",
+        },
+        {
+            "id": "item_unexpected",
+            "type": "file_search_call",
+            "status": "completed",
+        },
+        {
+            "id": "reasoning_unrepresented",
+            "type": "reasoning",
+            "status": None,
+            "summary": [],
+            "content": [
+                {"type": "reasoning_text", "text": "Unrepresented reasoning."}
+            ],
+            "encrypted_content": None,
+        },
+        {
+            "id": "reasoning_summary",
+            "type": "reasoning",
+            "status": None,
+            "summary": [{"type": "summary_text", "text": "Visible summary."}],
+            "content": [],
+            "encrypted_content": None,
+        },
+        {
+            "id": "reasoning_unknown_field",
+            "type": "reasoning",
+            "status": None,
+            "summary": [],
+            "content": [],
+            "encrypted_content": None,
+            "unexpected": "not represented by the adapter",
+        },
+    ],
+)
+def test_adapter_transformation_rejects_unrepresented_provider_output(
+    unexpected_output: dict[str, object],
+) -> None:
+    expectation, response, input_items, _schema = _receipt_fixture()
+    transformed_response = _RetrievedResponse(
+        response_id=response.response_id,
+        output=[*response.output, unexpected_output],
+    )
+
+    evidence = OpenAIProviderReceiptVerifier(
+        lambda _response_id: transformed_response,
+        lambda _response_id: input_items,
+    ).verify(expectation)
+
+    assert evidence.status == "mismatched"
+    assert evidence.failure == "payload_parse_failed"
+    assert evidence.provider_output_verification_source == "unverified"
+
+
+def test_adapter_transformation_rejects_unknown_message_fields() -> None:
+    expectation, response, input_items, _schema = _receipt_fixture()
+    output = copy.deepcopy(response.output)
+    output[0]["unexpected"] = "not represented by the adapter"
+    transformed_response = _RetrievedResponse(
+        response_id=response.response_id,
+        output=output,
+    )
+
+    evidence = OpenAIProviderReceiptVerifier(
+        lambda _response_id: transformed_response,
+        lambda _response_id: input_items,
+    ).verify(expectation)
+
+    assert evidence.status == "mismatched"
+    assert evidence.failure == "payload_parse_failed"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("annotations", [{"type": "url_citation"}]),
+        ("logprobs", [{"token": "NO_EVENT"}]),
+        ("unexpected", "not represented by the adapter"),
+    ],
+)
+def test_adapter_transformation_rejects_unrepresented_output_text_fields(
+    field: str,
+    value: object,
+) -> None:
+    expectation, response, input_items, _schema = _receipt_fixture()
+    output = copy.deepcopy(response.output)
+    content = cast("list[dict[str, object]]", output[0]["content"])
+    content[0][field] = value
+    transformed_response = _RetrievedResponse(
+        response_id=response.response_id,
+        output=output,
+    )
+
+    evidence = OpenAIProviderReceiptVerifier(
+        lambda _response_id: transformed_response,
+        lambda _response_id: input_items,
+    ).verify(expectation)
+
+    assert evidence.status == "mismatched"
+    assert evidence.failure == "payload_parse_failed"
+
+
+def test_adapter_transformation_rejects_commentary_message_phase() -> None:
+    expectation, response, input_items, _schema = _receipt_fixture()
+    output = copy.deepcopy(response.output)
+    output[0]["phase"] = "commentary"
+    transformed_response = _RetrievedResponse(
+        response_id=response.response_id,
+        output=output,
+    )
+
+    evidence = OpenAIProviderReceiptVerifier(
+        lambda _response_id: transformed_response,
+        lambda _response_id: input_items,
+    ).verify(expectation)
+
+    assert evidence.status == "mismatched"
+    assert evidence.failure == "payload_parse_failed"
+
+
+def _receipt_fixture(
+    *,
+    include_response_schema: bool = False,
+) -> tuple[
+    ProviderReceiptExpectation,
+    _RetrievedResponse,
+    list[dict[str, object]],
+    dict[str, object],
+]:
+    response_id = "resp_provider_receipt_schema"
+    invocation_id = "provider-receipt-schema"
+    source_sha256 = _sha256_text("IL-4 inhibited FOXP3 expression.")
+    input_sha256 = _sha256_text("finite-source-unit-input")
+    evidence_unit_sha256 = _sha256_text("finite-source-unit")
+    schema = {
+        "type": "object",
+        "properties": {"decision": {"type": "string"}},
+        "required": ["decision"],
+        "additionalProperties": False,
+    }
+    schema_sha256 = canonical_provider_output_sha256(schema)
+    payload = {"decision": "NO_EVENT"}
+    output: list[dict[str, object]] = [
+        {
+            "id": "msg_provider_receipt_schema",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": json.dumps(
+                        payload,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                },
+            ],
+        },
+    ]
+    prompt = bind_prompt_to_invocation(
+        prompt="Classify the frozen source unit.",
+        invocation_id=invocation_id,
+        source_sha256=source_sha256,
+        input_sha256=input_sha256,
+        evidence_unit_sha256=evidence_unit_sha256,
+        output_schema_sha256=schema_sha256,
+    )
+    expectation = ProviderReceiptExpectation(
+        response_id=response_id,
+        expected_case_id="source-unit-1",
+        expected_model_id="gpt-5.6-luna",
+        expected_output_sha256=canonical_provider_output_sha256(output),
+        expected_payload_sha256=canonical_provider_output_sha256(payload),
+        expected_prompt_sha256=_sha256_text(prompt),
+        expected_invocation_id=invocation_id,
+        expected_kernel_run_id=f"research-init-extraction:{invocation_id}",
+        expected_source_sha256=source_sha256,
+        expected_input_sha256=input_sha256,
+        expected_evidence_unit_sha256=evidence_unit_sha256,
+        expected_output_schema_sha256=schema_sha256,
+    )
+    response = _RetrievedResponse(
+        response_id=response_id,
+        output=output,
+        text={"format": {"schema": schema}} if include_response_schema else None,
+    )
+    return expectation, response, _input_items_for(expectation), schema
+
+
+def _input_items_for(
+    expectation: ProviderReceiptExpectation,
+    *,
+    output_schema_sha256: str | None = None,
+) -> list[dict[str, object]]:
+    prompt = bind_prompt_to_invocation(
+        prompt="Classify the frozen source unit.",
+        invocation_id=expectation.expected_invocation_id,
+        source_sha256=expectation.expected_source_sha256,
+        input_sha256=expectation.expected_input_sha256,
+        evidence_unit_sha256=expectation.expected_evidence_unit_sha256,
+        output_schema_sha256=(
+            output_schema_sha256
+            or expectation.expected_output_schema_sha256
+            or "0" * 64
+        ),
+    )
+    return [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": prompt}],
+        },
+    ]
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()


### PR DESCRIPTION
## Scope

Custody-only recalibration. This PR does not run a new scientific benchmark, claim scientific improvement, or enable graph persistence.

## Root causes

- OpenAI retrieval omits response schema metadata that remains cryptographically bound in the provider-retrieved invocation input.
- LiteLLM and provider retrieval expose different output envelopes, so their raw hashes differ even when the structured payload and full invocation chain match.

## Change

- Record categorical schema and output verification sources.
- Permit adapter-transformed output only when the exact structured payload and complete provider-retrieved envelope match.
- Reject unknown output items, extra messages, refusals, function calls, commentary phases, non-inert reasoning, annotations, logprobs, and unknown fields.
- Add focused regressions and a custody report.

## Validation

- One existing Luna response verified live with zero new model calls.
- Exact structured payload, prompt, invocation, source, input, evidence unit, schema, model, and completion envelope matched.
- Raw output mismatch remains visible as `structured_payload_with_verified_envelope`.
- 157 focused tests passed.
- `make service-checks` passed with 87.47% coverage.
- Ruff, mypy, commit hooks, and push hooks passed.
- Independent adversarial review found no remaining false-positive path.

## Stop rule

After merge, run exactly one procedure-only source unit. Do not add an expert event or unannotated discovery until that isolated experiment passes.