### PR TITLE
TG-04: isolate procedure source-unit recognition

### DIFF
--- a/docs/validation/reports/2026-07-18-tg04-procedure-source-unit.md
+++ b/docs/validation/reports/2026-07-18-tg04-procedure-source-unit.md
@@ -1,0 +1,125 @@
+# TG-04 Procedure Source-Unit Experiment
+
+Date: 2026-07-18
+
+## Decision
+
+**PROCEED TO ONE KNOWN EXPERT EVENT.** The isolated procedure-recognition gate
+passed on its first and only authorized run. The extractor and blinded verifier
+independently classified the previously disputed electroporation sentence as
+`PROCEDURE`. Neither agent treated it as a scientific event.
+
+This result resolves the specific event-eligibility asymmetry exposed by the
+earlier finite source-unit pilot. It does not measure scientific event
+reconstruction, discovery value, graph quality, or readiness for persistence.
+
+## Frozen Experiment
+
+- Harness commit: `4935a8cc`
+- Model: `openai:gpt-5.6-luna`
+- Run ID: `tg04-procedure-source-unit-luna-01`
+- Agent calls: exactly `2`
+- Extraction calls: `1`
+- Blinded verification calls: `1`
+- Biomedical fallback: `0`
+- Artifact:
+  `/tmp/artana-tg04/procedure-source-unit-2026-07-18/luna-r1.json`
+- Artifact SHA-256:
+  `1edea7a836ad766724ac402d9375ad616d94d5a1051c1030f1a8b8b418168116`
+- Embedded report SHA-256:
+  `f739d25d9a0ac4ad74b066ddd7a0e32c63ef5355e8cfe5662fe0ff59daf7363e`
+
+The embedded digest was recomputed after removing `report_sha256` and matched
+exactly. The output path was create-once and no replacement run was made.
+
+## Source Unit
+
+The unit was pre-registered from the true-negative BioNLP methods control. It
+was selected by case ID, sentence index, opaque unit ID, and input hash.
+
+- Unit ID:
+  `source-unit-063ab2e2ce044fe71c9f700805f4ed61be4a66879bd9aa3d50e7a683c2ee3af1`
+- Input SHA-256:
+  `19f72827611fa17d2b45c457ed6b632a1f549a9e44c3bb58387dc8d86dbdf47d`
+- Source range: `118-359`
+
+The sentence describes adding reporter vectors to CD4+ T cells and
+electroporating them with a specified Nucleofector program. In the previous
+pilot, the extractor excluded it while the verifier incorrectly reported a
+missing biomedical event.
+
+## Agent Results
+
+The extraction agent returned:
+
+- eligibility category: `PROCEDURE`
+- extraction decision: `NO_EVENT`
+- scientific candidates: `0`
+- binding rejections: `0`
+
+Its explanation identified vector addition, cell resuspension, and
+electroporation as experimental setup without a biological result or proposed
+mechanism.
+
+The blinded verification agent returned:
+
+- eligibility category: `PROCEDURE`
+- coverage decision: `NO_EVENT_CONFIRMED`
+- candidate decisions: `0`
+
+Its independent explanation likewise identified sample preparation and
+intervention application without a biological result or proposed mechanism.
+
+## Deterministic Gate
+
+Every pre-registered requirement passed:
+
+- both agent executions completed;
+- both agents specifically returned `PROCEDURE`;
+- the independent categories agreed;
+- no scientific candidate was extracted;
+- the verifier confirmed no scientific event;
+- binding rejections, invalid outputs, and fallback were zero;
+- one provider response belonged to extraction and one to verification;
+- the two provider response IDs were distinct;
+- both provider receipts verified live.
+
+The CLI is fail-closed: it returns a nonzero exit status whenever any gate
+requirement fails.
+
+## What Improved
+
+The earlier pilot gave extraction and verification different definitions of a
+scientific event. The revised contract makes both agents return the same closed
+eligibility category before event and coverage decisions. Deterministic code
+rejects category-decision contradictions, cross-agent disagreement, generic
+`NO_EVENT` agreement, abstention carrying entailed evidence, missing lineage,
+or an unverified receipt.
+
+This is meaningful progress in event eligibility and false-positive control.
+It is not yet evidence that Artana can reconstruct a complete expert event.
+
+## Next Isolated Step
+
+After this PR merges, run exactly one frozen source unit containing one known
+expert event. Use the same extraction and blinded verification roles. Require:
+
+- both agents to return the same relation-eligible scientific category;
+- an exact source-bound trigger and all material typed participants;
+- exact event type, polarity, epistemic status, and nested structure;
+- zero binding rejection, invalid output, fallback, and uncertainty escalation;
+- one distinct provider receipt per role, both verified live.
+
+Stop if any condition fails. Do not run the unannotated discovery unit until
+the one expert-event reconstruction passes.
+
+## Validation
+
+- `45` focused finite-unit and provider-receipt tests passed.
+- Ruff and mypy passed on all changed files.
+- `make service-checks` passed with `87.47%` coverage.
+- Commit and push hooks remained enabled.
+- An independent adversarial review found and drove closure of category
+  disagreement, abstention leakage, generic `NO_EVENT` false pass, disconnected
+  gate, role-lineage, exact-call-count, and CLI-exit-status weaknesses before
+  the live run.

--- a/scripts/run_procedure_source_unit_audit.py
+++ b/scripts/run_procedure_source_unit_audit.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Run the one-shot TG-04 procedure source-unit experiment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SERVICES_ROOT = _REPO_ROOT / "services"
+for _path in (_REPO_ROOT, _SERVICES_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from scripts.validation.claim_events.finite_source_unit.procedure_runner import (  # noqa: E402
+    run_procedure_source_unit_pilot,
+)
+from scripts.validation.claim_events.fixture import (  # noqa: E402
+    DEFAULT_DEVELOPMENT_FIXTURE_PATH,
+    load_fixture,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=_REPO_ROOT / DEFAULT_DEVELOPMENT_FIXTURE_PATH,
+    )
+    args = parser.parse_args()
+    report = run_procedure_source_unit_pilot(
+        fixture=load_fixture(args.fixture),
+        run_id=args.run_id,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("x", encoding="utf-8") as output_file:
+        output_file.write(
+            json.dumps(report, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        )
+    print(args.output)
+    return procedure_report_exit_code(report)
+
+
+def procedure_report_exit_code(report: dict[str, object]) -> int:
+    """Return failure unless the deterministic procedure gate passed."""
+
+    gate = report.get("gate")
+    return 0 if isinstance(gate, dict) and gate.get("passed") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/claim_events/finite_source_unit/contracts.py
+++ b/scripts/validation/claim_events/finite_source_unit/contracts.py
@@ -18,6 +18,28 @@ class SourceUnitDecision(StrEnum):
     ABSTAIN = "ABSTAIN"
 
 
+class SourceUnitEligibilityCategory(StrEnum):
+    """Shared scientific-eligibility category returned by both agents."""
+
+    FINDING = "FINDING"
+    HYPOTHESIS = "HYPOTHESIS"
+    NULL_RESULT = "NULL_RESULT"
+    PROCEDURE = "PROCEDURE"
+    MEASUREMENT_ONLY = "MEASUREMENT_ONLY"
+    NO_EVENT = "NO_EVENT"
+    ABSTAIN = "ABSTAIN"
+
+    @property
+    def scientific(self) -> bool:
+        """Return whether the category describes relation-eligible science."""
+
+        return self in {
+            SourceUnitEligibilityCategory.FINDING,
+            SourceUnitEligibilityCategory.HYPOTHESIS,
+            SourceUnitEligibilityCategory.NULL_RESULT,
+        }
+
+
 class EntailmentDecision(StrEnum):
     """Independent source-only judgment for one bound event candidate."""
 
@@ -42,6 +64,7 @@ class SourceUnitExtractionOutput(BaseModel):
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
     unit_id: str = Field(..., min_length=1, max_length=300)
+    eligibility_category: SourceUnitEligibilityCategory = Field(..., strict=False)
     decision: SourceUnitDecision = Field(..., strict=False)
     events: tuple[ClaimInventoryItem, ...] = Field(default=(), max_length=16)
     reasoning: str = Field(..., min_length=1, max_length=4000)
@@ -55,6 +78,20 @@ class SourceUnitExtractionOutput(BaseModel):
 
     @model_validator(mode="after")
     def require_decision_payload_consistency(self) -> SourceUnitExtractionOutput:
+        expected_decision = (
+            SourceUnitDecision.EXPLICIT_EVENT
+            if self.eligibility_category.scientific
+            else (
+                SourceUnitDecision.ABSTAIN
+                if self.eligibility_category
+                is SourceUnitEligibilityCategory.ABSTAIN
+                else SourceUnitDecision.NO_EVENT
+            )
+        )
+        if self.decision is not expected_decision:
+            raise ValueError(
+                "extraction decision must match the eligibility category",
+            )
         if self.decision is SourceUnitDecision.EXPLICIT_EVENT and not self.events:
             raise ValueError("EXPLICIT_EVENT requires at least one event")
         if self.decision is not SourceUnitDecision.EXPLICIT_EVENT and self.events:
@@ -108,6 +145,7 @@ class SourceUnitVerificationOutput(BaseModel):
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
     unit_id: str = Field(..., min_length=1, max_length=300)
+    eligibility_category: SourceUnitEligibilityCategory = Field(..., strict=False)
     coverage_decision: SourceUnitCoverageDecision = Field(..., strict=False)
     coverage_reasoning: str = Field(..., min_length=1, max_length=4000)
     covered_candidate_ids: tuple[str, ...] = Field(default=(), max_length=16)
@@ -169,6 +207,24 @@ class SourceUnitVerificationOutput(BaseModel):
             and entailed_ids
         ):
             raise ValueError("NO_EVENT_CONFIRMED cannot contain ENTAILED candidates")
+        if (
+            self.eligibility_category is SourceUnitEligibilityCategory.ABSTAIN
+            and entailed_ids
+        ):
+            raise ValueError("ABSTAIN cannot contain ENTAILED candidates")
+        if self.eligibility_category.scientific:
+            allowed_coverage = {
+                SourceUnitCoverageDecision.CANDIDATES_COMPLETE,
+                SourceUnitCoverageDecision.MISSING_EVENT,
+            }
+        elif self.eligibility_category is SourceUnitEligibilityCategory.ABSTAIN:
+            allowed_coverage = {SourceUnitCoverageDecision.ABSTAIN}
+        else:
+            allowed_coverage = {SourceUnitCoverageDecision.NO_EVENT_CONFIRMED}
+        if self.coverage_decision not in allowed_coverage:
+            raise ValueError(
+                "verification coverage must match the eligibility category",
+            )
         return self
 
 
@@ -177,6 +233,7 @@ __all__ = [
     "EntailmentDecision",
     "SourceUnitCoverageDecision",
     "SourceUnitDecision",
+    "SourceUnitEligibilityCategory",
     "SourceUnitExtractionOutput",
     "SourceUnitVerificationOutput",
 ]

--- a/scripts/validation/claim_events/finite_source_unit/procedure_gate.py
+++ b/scripts/validation/claim_events/finite_source_unit/procedure_gate.py
@@ -1,0 +1,82 @@
+"""Deterministic stop/go gate for the single TG-04 procedure source unit."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from scripts.validation.claim_events.finite_source_unit.contracts import (
+    SourceUnitCoverageDecision,
+    SourceUnitDecision,
+    SourceUnitEligibilityCategory,
+)
+
+_EXPECTED_PROVIDER_CALL_COUNT: Final = 2
+
+
+@dataclass(frozen=True, slots=True)
+class ProcedureUnitGateInputs:
+    """Machine evidence required before leaving the procedure-only step."""
+
+    agent_execution_complete: bool
+    extraction_category: SourceUnitEligibilityCategory | None
+    verification_category: SourceUnitEligibilityCategory | None
+    extraction_decision: SourceUnitDecision | None
+    verification_coverage: SourceUnitCoverageDecision | None
+    extracted_candidate_count: int
+    verification_decision_count: int
+    binding_rejection_count: int
+    invalid_agent_output_count: int
+    unidentified_provider_attempt_count: int
+    extraction_provider_response_id_count: int
+    verification_provider_response_id_count: int
+    distinct_provider_response_id_count: int
+    verified_provider_receipt_count: int
+    provider_receipt_gate_passed: bool
+    fallback_count: int
+
+
+def procedure_unit_gate_requirements(
+    inputs: ProcedureUnitGateInputs,
+) -> dict[str, bool]:
+    """Derive the pre-registered procedure-unit decision without model scores."""
+
+    return {
+        "agent_execution_complete": inputs.agent_execution_complete,
+        "extractor_recognized_procedure": (
+            inputs.extraction_category is SourceUnitEligibilityCategory.PROCEDURE
+        ),
+        "verifier_recognized_procedure": (
+            inputs.verification_category is SourceUnitEligibilityCategory.PROCEDURE
+        ),
+        "independent_categories_agree": (
+            inputs.extraction_category is inputs.verification_category
+        ),
+        "extractor_excluded_scientific_candidates": (
+            inputs.extraction_decision is SourceUnitDecision.NO_EVENT
+            and inputs.extracted_candidate_count == 0
+        ),
+        "verifier_confirmed_no_scientific_event": (
+            inputs.verification_coverage
+            is SourceUnitCoverageDecision.NO_EVENT_CONFIRMED
+            and inputs.verification_decision_count == 0
+        ),
+        "binding_rejection_zero": inputs.binding_rejection_count == 0,
+        "invalid_agent_output_zero": inputs.invalid_agent_output_count == 0,
+        "provider_lineage_complete": (
+            inputs.unidentified_provider_attempt_count == 0
+            and inputs.extraction_provider_response_id_count == 1
+            and inputs.verification_provider_response_id_count == 1
+            and inputs.distinct_provider_response_id_count
+            == _EXPECTED_PROVIDER_CALL_COUNT
+        ),
+        "provider_receipts_verified": (
+            inputs.provider_receipt_gate_passed
+            and inputs.verified_provider_receipt_count
+            == _EXPECTED_PROVIDER_CALL_COUNT
+        ),
+        "fallback_zero": inputs.fallback_count == 0,
+    }
+
+
+__all__ = ["ProcedureUnitGateInputs", "procedure_unit_gate_requirements"]

--- a/scripts/validation/claim_events/finite_source_unit/procedure_runner.py
+++ b/scripts/validation/claim_events/finite_source_unit/procedure_runner.py
@@ -1,0 +1,319 @@
+"""One-unit TG-04 procedure-recognition experiment."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from contextlib import suppress
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+from uuid import uuid4
+
+from artana_evidence_api.document_extraction import normalize_text_document
+from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+    start_model_attempt_audit,
+    stop_model_attempt_audit,
+)
+
+from scripts.validation.claim_events.finite_source_unit.procedure_gate import (
+    ProcedureUnitGateInputs,
+    procedure_unit_gate_requirements,
+)
+from scripts.validation.claim_events.finite_source_unit.runner import (
+    receipt_expectations_for_finite_source_records,
+)
+from scripts.validation.claim_events.finite_source_unit.service import (
+    as_model_client,
+    extract_source_unit,
+    verify_source_unit_candidates,
+)
+from scripts.validation.claim_events.finite_source_unit.source_units import (
+    FrozenSourceUnit,
+    enumerate_source_units,
+)
+from scripts.validation.claim_events.fixture import require_frozen_development_fixture
+from scripts.validation.claim_events.runner import build_tg04_runtime
+from scripts.validation.claim_frames.evidence import collect_repository_evidence
+from scripts.validation.claim_frames.provider_receipts import (
+    OpenAIProviderReceiptVerifier,
+    verify_provider_receipts,
+)
+
+if TYPE_CHECKING:
+    from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+        ModelAttemptAuditRecord,
+    )
+
+    from scripts.validation.claim_events.contracts import NaryClaimFixture
+    from scripts.validation.claim_events.finite_source_unit.contracts import (
+        SourceUnitExtractionOutput,
+        SourceUnitVerificationOutput,
+    )
+    from scripts.validation.claim_events.finite_source_unit.service import (
+        FiniteSourceUnitModelClient,
+    )
+
+_REPO_ROOT: Final = Path(__file__).resolve().parents[4]
+_MODEL_ID: Final = "openai:gpt-5.6-luna"
+_CASE_ID: Final = "bionlp-ge-2011:PMC-2222968-15-Materials_and_Methods-07"
+_UNIT_INDEX: Final = 2
+_EXPECTED_UNIT_ID: Final = (
+    "source-unit-063ab2e2ce044fe71c9f700805f4ed61be4a66879bd9aa3d50e7a683c2ee3af1"
+)
+_EXPECTED_INPUT_SHA256: Final = (
+    "19f72827611fa17d2b45c457ed6b632a1f549a9e44c3bb58387dc8d86dbdf47d"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _AgentRunEvidence:
+    extraction: SourceUnitExtractionOutput | None
+    verification: SourceUnitVerificationOutput | None
+    extracted_candidate_count: int
+    verification_decision_count: int
+    binding_rejection_count: int
+    records: tuple[ModelAttemptAuditRecord, ...]
+    error_type: str | None
+
+
+def run_procedure_source_unit_pilot(
+    *,
+    fixture: NaryClaimFixture,
+    run_id: str,
+) -> dict[str, object]:
+    """Run exactly one extractor and one verifier on the frozen procedure unit."""
+
+    require_frozen_development_fixture(fixture)
+    repository_evidence = collect_repository_evidence(_REPO_ROOT)
+    if repository_evidence["clean"] is not True:
+        raise RuntimeError("procedure source-unit runs require a clean tracked worktree")
+    unit = select_procedure_unit(fixture)
+    return asyncio.run(
+        _run_procedure_source_unit(
+            unit=unit,
+            run_id=run_id,
+            repository_evidence=repository_evidence,
+        ),
+    )
+
+
+def select_procedure_unit(fixture: NaryClaimFixture) -> FrozenSourceUnit:
+    """Select the pre-registered disputed electroporation sentence by identity."""
+
+    case = next((case for case in fixture.cases if case.case_id == _CASE_ID), None)
+    if case is None:
+        raise RuntimeError("frozen procedure-control case is missing")
+    units = enumerate_source_units(
+        case_id=case.case_id,
+        source_text=normalize_text_document(case.source_text),
+    )
+    if len(units) <= _UNIT_INDEX:
+        raise RuntimeError("frozen procedure source unit is missing")
+    unit = units[_UNIT_INDEX]
+    if (
+        unit.unit_id != _EXPECTED_UNIT_ID
+        or unit.input_sha256 != _EXPECTED_INPUT_SHA256
+    ):
+        raise RuntimeError("frozen procedure source-unit identity changed")
+    return unit
+
+
+async def _run_procedure_source_unit(
+    *,
+    unit: FrozenSourceUnit,
+    run_id: str,
+    repository_evidence: dict[str, object],
+) -> dict[str, object]:
+    client, tenant, execution_model_id, kernel, store = build_tg04_runtime(_MODEL_ID)
+    try:
+        agent_run = await _execute_agents(
+            client=as_model_client(client),
+            tenant=tenant,
+            model_id=execution_model_id,
+            execution_namespace=f"{run_id}:{unit.unit_id}:{uuid4().hex}",
+            unit=unit,
+        )
+    finally:
+        with suppress(Exception):
+            await kernel.close()
+        with suppress(Exception):
+            await store.close()
+
+    if collect_repository_evidence(_REPO_ROOT) != repository_evidence:
+        raise RuntimeError("repository state changed during procedure source-unit run")
+
+    expectations, invalid_count, unidentified_count = (
+        receipt_expectations_for_finite_source_records(list(agent_run.records))
+    )
+    receipts = verify_provider_receipts(
+        expectations,
+        OpenAIProviderReceiptVerifier.from_environment(),
+    )
+    extraction_ids = _provider_response_ids(agent_run.records, "primary")
+    verification_ids = _provider_response_ids(agent_run.records, "weak_review")
+    distinct_ids = extraction_ids | verification_ids
+    gate_inputs = ProcedureUnitGateInputs(
+        agent_execution_complete=(
+            agent_run.extraction is not None
+            and agent_run.verification is not None
+            and agent_run.error_type is None
+        ),
+        extraction_category=(
+            None
+            if agent_run.extraction is None
+            else agent_run.extraction.eligibility_category
+        ),
+        verification_category=(
+            None
+            if agent_run.verification is None
+            else agent_run.verification.eligibility_category
+        ),
+        extraction_decision=(
+            None if agent_run.extraction is None else agent_run.extraction.decision
+        ),
+        verification_coverage=(
+            None
+            if agent_run.verification is None
+            else agent_run.verification.coverage_decision
+        ),
+        extracted_candidate_count=agent_run.extracted_candidate_count,
+        verification_decision_count=agent_run.verification_decision_count,
+        binding_rejection_count=agent_run.binding_rejection_count,
+        invalid_agent_output_count=invalid_count,
+        unidentified_provider_attempt_count=unidentified_count,
+        extraction_provider_response_id_count=len(extraction_ids),
+        verification_provider_response_id_count=len(verification_ids),
+        distinct_provider_response_id_count=len(distinct_ids),
+        verified_provider_receipt_count=receipts.verified_count,
+        provider_receipt_gate_passed=receipts.gate_passed,
+        fallback_count=0,
+    )
+    requirements = procedure_unit_gate_requirements(gate_inputs)
+    gate_passed = all(requirements.values())
+    report: dict[str, object] = {
+        "schema_version": "tg04_procedure_source_unit.v1",
+        "run_id": run_id,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "model_id": _MODEL_ID,
+        "task_id": "procedure_source_unit_recognition",
+        "repository_evidence": repository_evidence,
+        "unit": {
+            "case_id": _CASE_ID,
+            "unit_id": unit.unit_id,
+            "unit_index": unit.index,
+            "source_start": unit.source_start,
+            "source_end": unit.source_end,
+            "source_sha256": unit.source_sha256,
+            "input_sha256": unit.input_sha256,
+            "text": unit.text,
+        },
+        "agent_outputs": {
+            "extraction": _model_json(agent_run.extraction),
+            "verification": _model_json(agent_run.verification),
+            "error_type": agent_run.error_type,
+        },
+        "attempts": [record.as_json() for record in agent_run.records],
+        "provider_receipts": receipts.as_json(),
+        "gate_inputs": asdict(gate_inputs),
+        "gate": {
+            "passed": gate_passed,
+            "decision": (
+                "PROCEED_TO_ONE_EXPERT_EVENT"
+                if gate_passed
+                else "STOP_AND_RECALIBRATE"
+            ),
+            "requirements": requirements,
+        },
+        "conclusion_scope": {
+            "procedure_recognition_only": True,
+            "scientific_accuracy_measured": False,
+            "new_discovery_measured": False,
+            "persistence_authorized": False,
+        },
+    }
+    report["report_sha256"] = _sha256_json(report)
+    return report
+
+
+async def _execute_agents(
+    *,
+    client: FiniteSourceUnitModelClient,
+    tenant: object,
+    model_id: str,
+    execution_namespace: str,
+    unit: FrozenSourceUnit,
+) -> _AgentRunEvidence:
+    audit = start_model_attempt_audit(evidence_unit_id=unit.unit_id)
+    extraction_output: SourceUnitExtractionOutput | None = None
+    verification_output: SourceUnitVerificationOutput | None = None
+    extracted_candidate_count = verification_decision_count = 0
+    binding_rejection_count = 0
+    error_type: str | None = None
+    try:
+        extraction = await extract_source_unit(
+            client=client,
+            tenant=tenant,
+            model_id=model_id,
+            execution_namespace=execution_namespace,
+            unit=unit,
+        )
+        extraction_output = extraction.value.output
+        extracted_candidate_count = len(extraction.value.accepted)
+        binding_rejection_count = len(extraction.value.rejected)
+        verification = await verify_source_unit_candidates(
+            client=client,
+            tenant=tenant,
+            model_id=model_id,
+            execution_namespace=execution_namespace,
+            unit=unit,
+            candidates=extraction.value.accepted,
+        )
+        verification_output = verification.parsed
+        verification_decision_count = len(verification.parsed.decisions)
+    except Exception as exc:  # noqa: BLE001 - preserve categorical failure evidence
+        error_type = type(exc).__name__
+    finally:
+        stop_model_attempt_audit(audit)
+    return _AgentRunEvidence(
+        extraction=extraction_output,
+        verification=verification_output,
+        extracted_candidate_count=extracted_candidate_count,
+        verification_decision_count=verification_decision_count,
+        binding_rejection_count=binding_rejection_count,
+        records=tuple(audit.records),
+        error_type=error_type,
+    )
+
+
+def _provider_response_ids(
+    records: tuple[ModelAttemptAuditRecord, ...],
+    pass_role: str,
+) -> set[str]:
+    return {
+        record.provider_response_id
+        for record in records
+        if record.pass_role == pass_role and record.provider_response_id is not None
+    }
+
+
+def _model_json(
+    model: SourceUnitExtractionOutput | SourceUnitVerificationOutput | None,
+) -> dict[str, object] | None:
+    return None if model is None else model.model_dump(mode="json")
+
+
+def _sha256_json(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8"),
+    ).hexdigest()
+
+
+__all__ = ["run_procedure_source_unit_pilot", "select_procedure_unit"]

--- a/scripts/validation/claim_events/finite_source_unit/runner.py
+++ b/scripts/validation/claim_events/finite_source_unit/runner.py
@@ -23,10 +23,12 @@ from artana_evidence_api.document_extraction_support.llm_fulltext_extraction imp
 from scripts.validation.claim_events.finite_source_unit.contracts import (
     EntailmentDecision,
     SourceUnitCoverageDecision,
+    SourceUnitEligibilityCategory,
     SourceUnitExtractionOutput,
     SourceUnitVerificationOutput,
 )
 from scripts.validation.claim_events.finite_source_unit.service import (
+    VerifiedEventCandidate,
     as_model_client,
     extract_source_unit,
     verify_source_unit_candidates,
@@ -49,6 +51,9 @@ from scripts.validation.claim_frames.provider_receipts import (
 )
 
 if TYPE_CHECKING:
+    from artana_evidence_api.document_extraction_support.claim_frames import (
+        BoundClaimInventoryItem,
+    )
     from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
         ModelAttemptAuditRecord,
     )
@@ -164,7 +169,9 @@ async def _run_panel(
         raise RuntimeError("repository state changed during the finite source-unit run")
 
     score = score_fixture(cast("BenchmarkFixtureContract", panel), predictions)
-    expectations, invalid_count, unidentified_count = _receipt_expectations(all_records)
+    expectations, invalid_count, unidentified_count = (
+        receipt_expectations_for_finite_source_records(all_records)
+    )
     receipts = verify_provider_receipts(
         expectations,
         OpenAIProviderReceiptVerifier.from_environment(),
@@ -261,7 +268,7 @@ async def _execute_case(
     units = enumerate_source_units(case_id=case.case_id, source_text=normalized_text)
     audit = start_model_attempt_audit(evidence_unit_id=case.case_id)
     unit_evidence: list[dict[str, object]] = []
-    entailed_claims = []
+    entailed_claims: list[BoundClaimInventoryItem] = []
     review_only: list[dict[str, object]] = []
     binding_rejection_count = 0
     executable = True
@@ -289,6 +296,9 @@ async def _execute_case(
                 "unit_id": unit.unit_id,
                 "source_start": unit.source_start,
                 "source_end": unit.source_end,
+                "eligibility_category": (
+                    extracted.output.eligibility_category.value
+                ),
                 "decision": extracted.output.decision.value,
                 "accepted_candidate_ids": [
                     candidate.inventory_id for candidate in extracted.accepted
@@ -313,26 +323,22 @@ async def _execute_case(
                 unit_evidence.append(unit_record)
                 continue
 
-            coverage_decision = verification.parsed.coverage_decision
-            unit_record["coverage_decision"] = coverage_decision.value
-            unit_record["coverage_reasoning"] = (
-                verification.parsed.coverage_reasoning
+            categories_agree, unit_coverage_confirmed = _record_eligibility_review(
+                unit_record,
+                extracted.output.eligibility_category,
+                verification.parsed,
             )
-            coverage_confirmed = coverage_confirmed and coverage_decision in {
-                SourceUnitCoverageDecision.CANDIDATES_COMPLETE,
-                SourceUnitCoverageDecision.NO_EVENT_CONFIRMED,
-            }
-            decisions: list[dict[str, object]] = []
-            for candidate in verification.value:
-                serialized = {
-                    "candidate_id": candidate.claim.inventory_id,
-                    **candidate.verification.model_dump(mode="json"),
-                }
-                decisions.append(serialized)
-                if candidate.verification.decision is EntailmentDecision.ENTAILED:
-                    entailed_claims.append(candidate.claim)
-                else:
-                    review_only.append(serialized)
+            if not categories_agree:
+                executable = False
+                coverage_confirmed = False
+                unit_evidence.append(unit_record)
+                continue
+            coverage_confirmed = coverage_confirmed and unit_coverage_confirmed
+            decisions, accepted, rejected = _partition_verified_candidates(
+                verification.value,
+            )
+            entailed_claims.extend(accepted)
+            review_only.extend(rejected)
             unit_record["verification_decisions"] = decisions
             unit_evidence.append(unit_record)
     finally:
@@ -362,7 +368,7 @@ async def _execute_case(
     )
 
 
-def _receipt_expectations(
+def receipt_expectations_for_finite_source_records(
     records: list[ModelAttemptAuditRecord],
 ) -> tuple[list[ProviderReceiptExpectation], int, int]:
     expectations: list[ProviderReceiptExpectation] = []
@@ -428,6 +434,59 @@ def source_supported_unmatched_count(
     return entailed_count - exact_match_count
 
 
+def _record_eligibility_review(
+    unit_record: dict[str, object],
+    extraction_category: SourceUnitEligibilityCategory,
+    verification: SourceUnitVerificationOutput,
+) -> tuple[bool, bool]:
+    verification_category = verification.eligibility_category
+    categories_agree = eligibility_categories_agree(
+        extraction_category,
+        verification_category,
+    )
+    unit_record["verification_eligibility_category"] = verification_category.value
+    unit_record["eligibility_categories_agree"] = categories_agree
+    unit_record["coverage_decision"] = verification.coverage_decision.value
+    unit_record["coverage_reasoning"] = verification.coverage_reasoning
+    coverage_confirmed = verification.coverage_decision in {
+        SourceUnitCoverageDecision.CANDIDATES_COMPLETE,
+        SourceUnitCoverageDecision.NO_EVENT_CONFIRMED,
+    }
+    return categories_agree, coverage_confirmed
+
+
+def _partition_verified_candidates(
+    candidates: tuple[VerifiedEventCandidate, ...],
+) -> tuple[
+    list[dict[str, object]],
+    tuple[BoundClaimInventoryItem, ...],
+    list[dict[str, object]],
+]:
+    decisions: list[dict[str, object]] = []
+    accepted: list[BoundClaimInventoryItem] = []
+    rejected: list[dict[str, object]] = []
+    for candidate in candidates:
+        serialized = {
+            "candidate_id": candidate.claim.inventory_id,
+            **candidate.verification.model_dump(mode="json"),
+        }
+        decisions.append(serialized)
+        if candidate.verification.decision is EntailmentDecision.ENTAILED:
+            accepted.append(candidate.claim)
+        else:
+            rejected.append(serialized)
+    return decisions, tuple(accepted), rejected
+
+
+def eligibility_categories_agree(
+    extraction: SourceUnitEligibilityCategory,
+    verification: SourceUnitEligibilityCategory,
+) -> bool:
+    """Require independent agents to return the same eligibility category."""
+
+    return extraction is verification
+
+
 def restart_gate_requirements(inputs: RestartGateInputs) -> dict[str, bool]:
     """Derive every pre-registered stop/go requirement deterministically."""
 
@@ -468,6 +527,8 @@ def _sha256_json(value: object) -> str:
 
 __all__ = [
     "RestartGateInputs",
+    "eligibility_categories_agree",
+    "receipt_expectations_for_finite_source_records",
     "restart_gate_requirements",
     "run_finite_source_unit_pilot",
     "source_supported_unmatched_count",

--- a/scripts/validation/claim_events/finite_source_unit/service.py
+++ b/scripts/validation/claim_events/finite_source_unit/service.py
@@ -40,8 +40,25 @@ if TYPE_CHECKING:
         FrozenSourceUnit,
     )
 
-_EXTRACTION_PROMPT_VERSION = "tg04.finite_source_unit.extraction.v1"
-_VERIFICATION_PROMPT_VERSION = "tg04.finite_source_unit.verification.v1"
+_EXTRACTION_PROMPT_VERSION = "tg04.finite_source_unit.extraction.v2"
+_VERIFICATION_PROMPT_VERSION = "tg04.finite_source_unit.verification.v2"
+_SCIENTIFIC_EVENT_ELIGIBILITY_POLICY = """SCIENTIFIC EVENT ELIGIBILITY POLICY
+Classify source meaning, never section labels, keywords, or perceived importance.
+Return exactly one eligibility_category:
+- FINDING: an asserted biological relationship or result;
+- HYPOTHESIS: an explicitly proposed biological explanation or mechanism;
+- NULL_RESULT: an explicit no-effect, no-association, or threshold-failing result;
+- PROCEDURE: sample handling, preparation, intervention application, assay setup,
+  instrument use, or another action without a reported biological result;
+- MEASUREMENT_ONLY: an outcome is measured but no value, direction, comparison,
+  or conclusion is reported;
+- NO_EVENT: none of the categories above is explicit;
+- ABSTAIN: the source cannot safely resolve the category.
+
+Only FINDING, HYPOTHESIS, and NULL_RESULT are scientific events. PROCEDURE and
+MEASUREMENT_ONLY remain visible categorical findings but are excluded from the
+scientific-event inventory. A methods sentence is scientific only when it
+reports a biological result or explicitly proposes a mechanism."""
 
 
 class FiniteSourceUnitModelClient(Protocol):
@@ -267,13 +284,14 @@ async def verify_source_unit_candidates(  # noqa: PLR0913
 def _extraction_prompt(unit: FrozenSourceUnit) -> str:
     return f"""You are the event-extraction agent in a sealed biomedical diagnostic.
 
-Use only the frozen source unit below. Do not use outside knowledge. Decide one
-closed category: EXPLICIT_EVENT, NO_EVENT, or ABSTAIN. EXPLICIT_EVENT means the
-unit literally states at least one biomedical event with a trigger and at least
-two material typed arguments. Return every distinct explicit event in this unit.
-NO_EVENT means it contains no explicit biomedical event, including procedural
-instructions that merely describe an assay. ABSTAIN means the source cannot
-safely resolve the category.
+Use only the frozen source unit below. Do not use outside knowledge.
+
+{_SCIENTIFIC_EVENT_ELIGIBILITY_POLICY}
+
+Map FINDING, HYPOTHESIS, and NULL_RESULT to EXPLICIT_EVENT and return every
+distinct explicit event with a trigger and at least two material typed
+arguments. Map PROCEDURE, MEASUREMENT_ONLY, and NO_EVENT to NO_EVENT with no
+events. Map ABSTAIN to ABSTAIN with no events.
 
 For each event, copy exact_span, relation_cue_span, and every argument span
 verbatim. Use normalized_extraction_text as source_locator. Keep claim_kind,
@@ -305,13 +323,18 @@ def _verification_prompt(
     ]
     return f"""You are an independent source-only biomedical verifier.
 
-Use only the frozen source unit. First decide whether the candidate inventory is
-CANDIDATES_COMPLETE, NO_EVENT_CONFIRMED, MISSING_EVENT, or ABSTAIN. Review the
-unit even when no candidates were supplied. NO_EVENT_CONFIRMED is valid only
-when the unit contains no explicit biomedical event. CANDIDATES_COMPLETE is
-valid only when supplied candidates cover every explicit event in the unit.
-Return covered_candidate_ids as exactly the candidate IDs judged ENTAILED. A
-false extracted candidate may be rejected while the unit is NO_EVENT_CONFIRMED.
+Use only the frozen source unit.
+
+{_SCIENTIFIC_EVENT_ELIGIBILITY_POLICY}
+
+First return your own eligibility_category, without using extractor reasoning.
+For FINDING, HYPOTHESIS, or NULL_RESULT, return CANDIDATES_COMPLETE when supplied
+candidates cover every scientific event or MISSING_EVENT otherwise. For
+PROCEDURE, MEASUREMENT_ONLY, or NO_EVENT, return NO_EVENT_CONFIRMED because those
+categories are not scientific events. Map ABSTAIN to ABSTAIN. Review the unit
+even when no candidates were supplied. Return covered_candidate_ids as exactly
+the candidate IDs judged ENTAILED. A false extracted candidate may be rejected
+while the unit is NO_EVENT_CONFIRMED.
 
 For every supplied candidate, return exactly one categorical decision:
 ENTAILED, CONTRADICTED, INSUFFICIENT, or ABSTAIN.

--- a/tests/unit/test_finite_source_unit_audit.py
+++ b/tests/unit/test_finite_source_unit_audit.py
@@ -4,6 +4,7 @@ import hashlib
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from artana_evidence_api.document_extraction_support.claim_frames import (
@@ -18,18 +19,34 @@ from artana_evidence_api.document_extraction_support.llm_fulltext_extraction imp
 )
 from pydantic import ValidationError
 
+from scripts.run_procedure_source_unit_audit import procedure_report_exit_code
 from scripts.validation.claim_events.finite_source_unit.contracts import (
+    SourceUnitCoverageDecision,
+    SourceUnitDecision,
+    SourceUnitEligibilityCategory,
     SourceUnitExtractionOutput,
     SourceUnitVerificationOutput,
+)
+from scripts.validation.claim_events.finite_source_unit.procedure_gate import (
+    ProcedureUnitGateInputs,
+    procedure_unit_gate_requirements,
+)
+from scripts.validation.claim_events.finite_source_unit.procedure_runner import (
+    _execute_agents,
+    select_procedure_unit,
 )
 from scripts.validation.claim_events.finite_source_unit.runner import (
     RestartGateInputs,
     _execute_case,
     _select_panel,
+    eligibility_categories_agree,
     restart_gate_requirements,
     source_supported_unmatched_count,
 )
 from scripts.validation.claim_events.finite_source_unit.service import (
+    FiniteSourceUnitModelClient,
+    _extraction_prompt,
+    _verification_prompt,
     bind_source_unit_extraction,
     bind_source_unit_verification,
     extract_source_unit,
@@ -56,6 +73,46 @@ class _SuccessfulClient:
             seq=1,
             replayed=False,
             response_id=None,
+            response_output_items=(),
+        )
+
+
+class _ProcedureSequenceClient:
+    def __init__(self, unit_id: str) -> None:
+        self._unit_id = unit_id
+        self.calls: list[type[object]] = []
+
+    async def step(self, **kwargs: object) -> object:
+        output_schema = kwargs["output_schema"]
+        assert isinstance(output_schema, type)
+        self.calls.append(output_schema)
+        output: SourceUnitExtractionOutput | SourceUnitVerificationOutput
+        if output_schema is SourceUnitExtractionOutput:
+            output = SourceUnitExtractionOutput(
+                unit_id=self._unit_id,
+                eligibility_category=SourceUnitEligibilityCategory.PROCEDURE,
+                decision=SourceUnitDecision.NO_EVENT,
+                events=(),
+                reasoning="The sentence describes electroporation without a result.",
+            )
+            response_id = "resp_procedure_extraction"
+        else:
+            assert output_schema is SourceUnitVerificationOutput
+            output = SourceUnitVerificationOutput(
+                unit_id=self._unit_id,
+                eligibility_category=SourceUnitEligibilityCategory.PROCEDURE,
+                coverage_decision=SourceUnitCoverageDecision.NO_EVENT_CONFIRMED,
+                coverage_reasoning="Electroporation is procedural setup.",
+                covered_candidate_ids=(),
+                decisions=(),
+            )
+            response_id = "resp_procedure_verification"
+        return SimpleNamespace(
+            output=output,
+            run_id=kwargs["run_id"],
+            seq=len(self.calls),
+            replayed=False,
+            response_id=response_id,
             response_output_items=(),
         )
 
@@ -117,14 +174,15 @@ async def test_extraction_uses_artana_invocation_bound_run_id() -> None:
     unit = enumerate_source_units(case_id="case-1", source_text="Methods only.")[0]
     output = SourceUnitExtractionOutput(
         unit_id=unit.unit_id,
-        decision="NO_EVENT",
+        eligibility_category=SourceUnitEligibilityCategory.PROCEDURE,
+        decision=SourceUnitDecision.NO_EVENT,
         events=(),
         reasoning="No explicit event is stated.",
     )
     audit = start_model_attempt_audit(evidence_unit_id="case-1")
     try:
         result = await extract_source_unit(
-            client=_SuccessfulClient(output),
+            client=cast("FiniteSourceUnitModelClient", _SuccessfulClient(output)),
             tenant=object(),
             model_id="openai/gpt-5.6-luna",
             execution_namespace="topology-regression",
@@ -144,6 +202,7 @@ def test_extraction_contract_rejects_category_payload_conflicts() -> None:
         SourceUnitExtractionOutput.model_validate(
             {
                 "unit_id": "unit-1",
+                "eligibility_category": "FINDING",
                 "decision": "EXPLICIT_EVENT",
                 "events": [],
                 "reasoning": "No event supplied.",
@@ -154,9 +213,38 @@ def test_extraction_contract_rejects_category_payload_conflicts() -> None:
         SourceUnitExtractionOutput.model_validate(
             {
                 "unit_id": "unit-1",
+                "eligibility_category": "PROCEDURE",
                 "decision": "NO_EVENT",
                 "events": [_event_item().model_dump(mode="json")],
                 "reasoning": "Conflicting payload.",
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("eligibility_category", "decision"),
+    [
+        ("PROCEDURE", "EXPLICIT_EVENT"),
+        ("FINDING", "NO_EVENT"),
+        ("ABSTAIN", "NO_EVENT"),
+    ],
+)
+def test_extraction_decision_must_match_eligibility_category(
+    eligibility_category: str,
+    decision: str,
+) -> None:
+    with pytest.raises(ValidationError, match="must match the eligibility"):
+        SourceUnitExtractionOutput.model_validate(
+            {
+                "unit_id": "unit-1",
+                "eligibility_category": eligibility_category,
+                "decision": decision,
+                "events": (
+                    [_event_item().model_dump(mode="json")]
+                    if decision == "EXPLICIT_EVENT"
+                    else []
+                ),
+                "reasoning": "Adversarial category mismatch.",
             },
         )
 
@@ -166,7 +254,8 @@ def test_item_binding_preserves_valid_candidate_and_rejected_sibling() -> None:
     unit = enumerate_source_units(case_id="case-1", source_text=source)[1]
     output = SourceUnitExtractionOutput(
         unit_id=unit.unit_id,
-        decision="EXPLICIT_EVENT",
+        eligibility_category=SourceUnitEligibilityCategory.FINDING,
+        decision=SourceUnitDecision.EXPLICIT_EVENT,
         events=(
             _event_item(),
             _event_item(exact_span="IL-4 activated missing protein."),
@@ -188,7 +277,8 @@ def test_verification_requires_exact_candidate_coverage_and_local_evidence() -> 
     extraction = bind_source_unit_extraction(
         SourceUnitExtractionOutput(
             unit_id=unit.unit_id,
-            decision="EXPLICIT_EVENT",
+            eligibility_category=SourceUnitEligibilityCategory.FINDING,
+            decision=SourceUnitDecision.EXPLICIT_EVENT,
             events=(_event_item(),),
             reasoning="One explicit event.",
         ),
@@ -198,6 +288,7 @@ def test_verification_requires_exact_candidate_coverage_and_local_evidence() -> 
     valid = SourceUnitVerificationOutput.model_validate(
         {
             "unit_id": unit.unit_id,
+            "eligibility_category": "FINDING",
             "coverage_decision": "CANDIDATES_COMPLETE",
             "coverage_reasoning": "The supplied event covers the unit.",
             "covered_candidate_ids": [candidate_id],
@@ -223,7 +314,8 @@ def test_verification_requires_exact_candidate_coverage_and_local_evidence() -> 
 
     missing = SourceUnitVerificationOutput(
         unit_id=unit.unit_id,
-        coverage_decision="MISSING_EVENT",
+        eligibility_category=SourceUnitEligibilityCategory.FINDING,
+        coverage_decision=SourceUnitCoverageDecision.MISSING_EVENT,
         coverage_reasoning="The candidate inventory is unresolved.",
         covered_candidate_ids=(),
         decisions=(),
@@ -238,6 +330,7 @@ def test_verification_requires_exact_candidate_coverage_and_local_evidence() -> 
     fabricated = SourceUnitVerificationOutput.model_validate(
         {
             "unit_id": unit.unit_id,
+            "eligibility_category": "FINDING",
             "coverage_decision": "CANDIDATES_COMPLETE",
             "coverage_reasoning": "The supplied event covers the unit.",
             "covered_candidate_ids": [candidate_id],
@@ -262,6 +355,7 @@ def test_verification_requires_exact_candidate_coverage_and_local_evidence() -> 
     partial = SourceUnitVerificationOutput.model_validate(
         {
             "unit_id": unit.unit_id,
+            "eligibility_category": "FINDING",
             "coverage_decision": "CANDIDATES_COMPLETE",
             "coverage_reasoning": "The supplied event covers the unit.",
             "covered_candidate_ids": [candidate_id],
@@ -291,7 +385,8 @@ def test_no_event_unit_receives_independent_coverage_review() -> None:
     )[0]
     output = SourceUnitVerificationOutput(
         unit_id=unit.unit_id,
-        coverage_decision="NO_EVENT_CONFIRMED",
+        eligibility_category=SourceUnitEligibilityCategory.MEASUREMENT_ONLY,
+        coverage_decision=SourceUnitCoverageDecision.NO_EVENT_CONFIRMED,
         coverage_reasoning="The source describes a procedure without a result.",
         covered_candidate_ids=(),
         decisions=(),
@@ -308,7 +403,8 @@ def test_false_candidate_can_be_rejected_while_unit_confirms_no_event() -> None:
     extraction = bind_source_unit_extraction(
         SourceUnitExtractionOutput(
             unit_id=unit.unit_id,
-            decision="EXPLICIT_EVENT",
+            eligibility_category=SourceUnitEligibilityCategory.FINDING,
+            decision=SourceUnitDecision.EXPLICIT_EVENT,
             events=(item,),
             reasoning="The extractor proposed a relationship.",
         ),
@@ -318,6 +414,7 @@ def test_false_candidate_can_be_rejected_while_unit_confirms_no_event() -> None:
     verification = SourceUnitVerificationOutput.model_validate(
         {
             "unit_id": unit.unit_id,
+            "eligibility_category": "MEASUREMENT_ONLY",
             "coverage_decision": "NO_EVENT_CONFIRMED",
             "coverage_reasoning": "Measurement alone does not state a relationship.",
             "covered_candidate_ids": [],
@@ -342,21 +439,30 @@ def test_false_candidate_can_be_rejected_while_unit_confirms_no_event() -> None:
 
 
 @pytest.mark.parametrize(
-    ("coverage_decision", "candidate_decision", "covered_ids", "error"),
+    (
+        "eligibility_category",
+        "coverage_decision",
+        "candidate_decision",
+        "covered_ids",
+        "error",
+    ),
     [
         (
+            "FINDING",
             "CANDIDATES_COMPLETE",
             "INSUFFICIENT",
             [],
             "requires an ENTAILED candidate",
         ),
         (
+            "FINDING",
             "MISSING_EVENT",
             "ENTAILED",
             [],
             "must equal ENTAILED candidates",
         ),
         (
+            "PROCEDURE",
             "NO_EVENT_CONFIRMED",
             "ENTAILED",
             ["candidate-1"],
@@ -365,6 +471,7 @@ def test_false_candidate_can_be_rejected_while_unit_confirms_no_event() -> None:
     ],
 )
 def test_verification_rejects_contradictory_coverage_truth_table(
+    eligibility_category: str,
     coverage_decision: str,
     candidate_decision: str,
     covered_ids: list[str],
@@ -374,6 +481,7 @@ def test_verification_rejects_contradictory_coverage_truth_table(
         SourceUnitVerificationOutput.model_validate(
             {
                 "unit_id": "opaque-unit",
+                "eligibility_category": eligibility_category,
                 "coverage_decision": coverage_decision,
                 "coverage_reasoning": "Adversarial truth-table probe.",
                 "covered_candidate_ids": covered_ids,
@@ -394,18 +502,231 @@ def test_verification_rejects_contradictory_coverage_truth_table(
         )
 
 
+@pytest.mark.parametrize(
+    ("eligibility_category", "coverage_decision"),
+    [
+        ("PROCEDURE", "MISSING_EVENT"),
+        ("FINDING", "NO_EVENT_CONFIRMED"),
+        ("ABSTAIN", "NO_EVENT_CONFIRMED"),
+    ],
+)
+def test_verification_coverage_must_match_eligibility_category(
+    eligibility_category: str,
+    coverage_decision: str,
+) -> None:
+    with pytest.raises(ValidationError, match="must match the eligibility"):
+        SourceUnitVerificationOutput.model_validate(
+            {
+                "unit_id": "opaque-unit",
+                "eligibility_category": eligibility_category,
+                "coverage_decision": coverage_decision,
+                "coverage_reasoning": "Adversarial category mismatch.",
+                "covered_candidate_ids": [],
+                "decisions": [],
+            },
+        )
+
+
+def test_abstaining_verifier_cannot_return_an_entailed_candidate() -> None:
+    with pytest.raises(ValidationError, match="ABSTAIN cannot contain ENTAILED"):
+        SourceUnitVerificationOutput.model_validate(
+            {
+                "unit_id": "opaque-unit",
+                "eligibility_category": "ABSTAIN",
+                "coverage_decision": "ABSTAIN",
+                "coverage_reasoning": "The category cannot be resolved safely.",
+                "covered_candidate_ids": ["candidate-1"],
+                "decisions": [
+                    {
+                        "candidate_id": "candidate-1",
+                        "decision": "ENTAILED",
+                        "evidence_spans": ["complete event"],
+                        "reasoning": "Contradictory entailed output.",
+                        "falsification_condition": "The event is absent.",
+                    }
+                ],
+            },
+        )
+
+
 def test_agent_contracts_contain_no_numeric_score_fields() -> None:
     extraction_fields = set(SourceUnitExtractionOutput.model_fields)
     verification_fields = set(SourceUnitVerificationOutput.model_fields)
 
-    assert extraction_fields == {"unit_id", "decision", "events", "reasoning"}
+    assert extraction_fields == {
+        "unit_id",
+        "eligibility_category",
+        "decision",
+        "events",
+        "reasoning",
+    }
     assert verification_fields == {
         "unit_id",
+        "eligibility_category",
         "coverage_decision",
         "coverage_reasoning",
         "covered_candidate_ids",
         "decisions",
     }
+
+
+def test_both_agents_receive_the_same_scientific_eligibility_policy() -> None:
+    unit = enumerate_source_units(
+        case_id="frozen-procedure-control",
+        source_text=(
+            "Reporter vectors were added to CD4+ T cells and electroporated."
+        ),
+    )[0]
+
+    prompts = (
+        _extraction_prompt(unit),
+        _verification_prompt(unit=unit, candidates=()),
+    )
+
+    for prompt in prompts:
+        assert "Return exactly one eligibility_category" in prompt
+        assert "PROCEDURE: sample handling" in prompt
+        assert "MEASUREMENT_ONLY: an outcome is measured" in prompt
+        assert "Only FINDING, HYPOTHESIS, and NULL_RESULT" in prompt
+        assert "A methods sentence is scientific only when it" in prompt
+
+
+def test_independent_eligibility_categories_must_agree() -> None:
+    assert eligibility_categories_agree(
+        SourceUnitEligibilityCategory.PROCEDURE,
+        SourceUnitEligibilityCategory.PROCEDURE,
+    )
+    assert not eligibility_categories_agree(
+        SourceUnitEligibilityCategory.NO_EVENT,
+        SourceUnitEligibilityCategory.PROCEDURE,
+    )
+
+
+def test_procedure_unit_gate_requires_both_agents_to_recognize_procedure() -> None:
+    baseline = ProcedureUnitGateInputs(
+        agent_execution_complete=True,
+        extraction_category=SourceUnitEligibilityCategory.PROCEDURE,
+        verification_category=SourceUnitEligibilityCategory.PROCEDURE,
+        extraction_decision=SourceUnitDecision.NO_EVENT,
+        verification_coverage=SourceUnitCoverageDecision.NO_EVENT_CONFIRMED,
+        extracted_candidate_count=0,
+        verification_decision_count=0,
+        binding_rejection_count=0,
+        invalid_agent_output_count=0,
+        unidentified_provider_attempt_count=0,
+        extraction_provider_response_id_count=1,
+        verification_provider_response_id_count=1,
+        distinct_provider_response_id_count=2,
+        verified_provider_receipt_count=2,
+        provider_receipt_gate_passed=True,
+        fallback_count=0,
+    )
+
+    assert all(procedure_unit_gate_requirements(baseline).values())
+
+    generic_no_event = replace(
+        baseline,
+        extraction_category=SourceUnitEligibilityCategory.NO_EVENT,
+        verification_category=SourceUnitEligibilityCategory.NO_EVENT,
+    )
+    requirements = procedure_unit_gate_requirements(generic_no_event)
+    assert requirements["independent_categories_agree"] is True
+    assert requirements["extractor_recognized_procedure"] is False
+    assert requirements["verifier_recognized_procedure"] is False
+
+
+def test_procedure_unit_gate_fails_closed_on_every_safety_boundary() -> None:
+    baseline = ProcedureUnitGateInputs(
+        agent_execution_complete=True,
+        extraction_category=SourceUnitEligibilityCategory.PROCEDURE,
+        verification_category=SourceUnitEligibilityCategory.PROCEDURE,
+        extraction_decision=SourceUnitDecision.NO_EVENT,
+        verification_coverage=SourceUnitCoverageDecision.NO_EVENT_CONFIRMED,
+        extracted_candidate_count=0,
+        verification_decision_count=0,
+        binding_rejection_count=0,
+        invalid_agent_output_count=0,
+        unidentified_provider_attempt_count=0,
+        extraction_provider_response_id_count=1,
+        verification_provider_response_id_count=1,
+        distinct_provider_response_id_count=2,
+        verified_provider_receipt_count=2,
+        provider_receipt_gate_passed=True,
+        fallback_count=0,
+    )
+    mutations = (
+        {"agent_execution_complete": False},
+        {"verification_category": SourceUnitEligibilityCategory.NO_EVENT},
+        {"extracted_candidate_count": 1},
+        {"verification_decision_count": 1},
+        {"binding_rejection_count": 1},
+        {"invalid_agent_output_count": 1},
+        {"unidentified_provider_attempt_count": 1},
+        {"extraction_provider_response_id_count": 0},
+        {"verification_provider_response_id_count": 0},
+        {"distinct_provider_response_id_count": 1},
+        {"verified_provider_receipt_count": 1},
+        {"provider_receipt_gate_passed": False},
+        {"fallback_count": 1},
+    )
+
+    for mutation in mutations:
+        assert not all(
+            procedure_unit_gate_requirements(replace(baseline, **mutation)).values(),
+        )
+
+
+def test_procedure_runner_freezes_the_previously_disputed_unit() -> None:
+    fixture = load_fixture(
+        Path("scripts/validation/claim_events/fixtures/tg04_bionlp_ge_development_v1.json"),
+    )
+
+    unit = select_procedure_unit(fixture)
+
+    assert unit.unit_id == (
+        "source-unit-063ab2e2ce044fe71c9f700805f4ed61be4a66879bd9aa3d50e7a683c2ee3af1"
+    )
+    assert unit.input_sha256 == (
+        "19f72827611fa17d2b45c457ed6b632a1f549a9e44c3bb58387dc8d86dbdf47d"
+    )
+    assert "electroporated using the U-15 program" in unit.text
+
+
+@pytest.mark.asyncio
+async def test_procedure_runner_executes_exactly_one_call_per_agent_role() -> None:
+    fixture = load_fixture(
+        Path("scripts/validation/claim_events/fixtures/tg04_bionlp_ge_development_v1.json"),
+    )
+    unit = select_procedure_unit(fixture)
+    client = _ProcedureSequenceClient(unit.unit_id)
+
+    result = await _execute_agents(
+        client=cast("FiniteSourceUnitModelClient", client),
+        tenant=object(),
+        model_id="openai/gpt-5.6-luna",
+        execution_namespace="procedure-sequence-regression",
+        unit=unit,
+    )
+
+    assert client.calls == [
+        SourceUnitExtractionOutput,
+        SourceUnitVerificationOutput,
+    ]
+    assert [record.pass_role for record in result.records] == [
+        "primary",
+        "weak_review",
+    ]
+    assert {record.provider_response_id for record in result.records} == {
+        "resp_procedure_extraction",
+        "resp_procedure_verification",
+    }
+    assert result.error_type is None
+
+
+def test_procedure_cli_exit_status_follows_the_deterministic_gate() -> None:
+    assert procedure_report_exit_code({"gate": {"passed": True}}) == 0
+    assert procedure_report_exit_code({"gate": {"passed": False}}) == 1
+    assert procedure_report_exit_code({}) == 1
 
 
 def test_restart_gate_blocks_binding_rejections_and_unconfirmed_coverage() -> None:


### PR DESCRIPTION
## Scope

This PR contains only the post-#171 procedure-recognition experiment. It does not run an expert event or discovery case and does not authorize graph persistence.

## Root cause

The prior finite-unit extractor excluded procedures, while its verifier could treat assay setup as a missing biomedical event. The two roles did not share a measurable eligibility category.

## Change

- Add one shared categorical eligibility contract for extraction and blinded verification.
- Require category/decision consistency and reject cross-agent disagreement.
- Add a dedicated procedure gate that requires both agents to return `PROCEDURE`, not merely agree on `NO_EVENT`.
- Freeze the previously disputed electroporation sentence by case, index, unit ID, and input hash.
- Require exactly one extraction response, one verification response, two distinct IDs, and two verified live receipts.
- Make the CLI return nonzero whenever the deterministic gate fails.

## Live result

The single authorized run passed:

- extractor: `PROCEDURE / NO_EVENT`, zero candidates
- blinded verifier: `PROCEDURE / NO_EVENT_CONFIRMED`, zero decisions
- binding rejection: 0
- invalid output: 0
- fallback: 0
- provider receipts: 2/2 verified live
- artifact SHA-256: `1edea7a836ad766724ac402d9375ad616d94d5a1051c1030f1a8b8b418168116`

This proves improved procedure eligibility and false-positive control only. It does not prove scientific reconstruction accuracy.

## Validation

- 45 focused tests passed.
- Ruff and mypy passed.
- `make service-checks` passed with 87.47% coverage.
- Commit and push hooks passed.
- Adversarial review found and drove closure of seven false-pass paths before the live run.

## Next stop

After merge, run exactly one known expert event. Do not run the unannotated discovery unit unless the expert event passes exact reconstruction and custody gates.