### PR TITLE
TG-04: isolate known expert-event reconstruction

### DIFF
--- a/docs/validation/reports/2026-07-18-tg04-known-expert-source-unit.md
+++ b/docs/validation/reports/2026-07-18-tg04-known-expert-source-unit.md
@@ -1,0 +1,118 @@
+# TG-04 Known Expert-Event Source-Unit Experiment
+
+Date: 2026-07-18
+
+## Decision
+
+**STOP AND RECALIBRATE.** The first authorized run reconstructed one
+source-grounded scientific finding and passed every execution, provenance, and
+receipt check. It did not exactly reconstruct the sealed expert-corpus event,
+so the deterministic gate correctly blocked the unannotated discovery unit and
+any persistence work.
+
+This is not a provider, fallback, or evidence-grounding failure. It is a
+representation-alignment failure between Artana's source-faithful claim frame
+and the BioNLP corpus event projection.
+
+## Frozen Experiment
+
+- Harness commit: `d9108953`
+- Model: `openai:gpt-5.6-luna`
+- Run ID: `tg04-known-expert-unit-luna-01`
+- Agent calls: exactly `2`
+- Extraction calls: `1`
+- Blinded verification calls: `1`
+- Biomedical fallback: `0`
+- Artifact:
+  `/tmp/artana-tg04/known-expert-unit-2026-07-18/luna-r1.json`
+- Artifact SHA-256:
+  `865a4eadab94021d57e7446b7f8ce96125aa29b7b3d6df6ed92f267f6a36f775`
+- Embedded report SHA-256:
+  `adc7d5fa2aac69464f72c8e7f62327d8696838373f67b7682a9200af037031dc`
+
+The artifact was written create-once. Its embedded digest was recomputed after
+removing `report_sha256` and matched exactly. No replacement run was made.
+
+## Source Unit And Sealed Gold
+
+The source unit is the asserted result sentence:
+
+> Interestingly, we observed a specific four-fold upregulation of Id1 mRNA in
+> BMP-6-treated B cells (Figure 7).
+
+- Case: `bionlp-ge-2011:PMC-1134658-06-Results-05`
+- Expert event: `PMC-1134658-06-Results-05:E9`
+- Unit ID:
+  `source-unit-e14e44064324af2f721a3d02d2caf44c00218a0ab6c4afc58e9bace413c9d46c`
+- Input SHA-256:
+  `14aec6614afd9d47d4cbafe7298b0e6b77b7a3d324048635d3fb98f463b9a0fd`
+
+The model saw only the source unit. The expert event was loaded only after both
+agent calls for deterministic comparison.
+
+## What The Agents Did Correctly
+
+Both the extraction agent and independent verifier returned `FINDING`. The
+extractor produced exactly one candidate; the verifier marked it `ENTAILED`
+with local evidence spans and `CANDIDATES_COMPLETE` coverage. Both provider
+receipts verified live, with one distinct response per role.
+
+The candidate preserved the source's direction, observed status, target
+(`Id1 mRNA`), magnitude, and treated-cell context. Binding rejection, invalid
+agent output, fallback, unidentified provider attempts, and epistemic
+escalation were all zero.
+
+## Why The Strict Gate Failed
+
+The sealed corpus event is a `POSITIVE_REGULATION` event with:
+
+- trigger: `upregulation`;
+- `CAUSE`: `BMP-6`;
+- `THEME`: `Id1`.
+
+Luna instead produced an `INCREASE` event with:
+
+- trigger: `four-fold upregulation`;
+- `THEME`: `Id1 mRNA`;
+- `CONTEXT`: `BMP-6-treated B cells`.
+
+The output is source-anchored and plausibly useful, but its event type, trigger
+boundary, argument roles, and participant surface differ from the sealed
+projection. Whole-event precision and recall are therefore both `0/1`. The
+gate requires `1/1`, so `exactly_one_complete_expert_event` is false.
+
+This demonstrates the distinction we need to preserve: a source-valid claim is
+not automatically an exact match to a particular corpus ontology projection.
+Changing the gold, weakening exact matching, or prompting the model toward the
+known event would turn the experiment into a self-fulfilling pass.
+
+## Next Step: Recalibration Before Discovery
+
+Do not run the unannotated discovery unit. First create a small, independent
+adjudication protocol for representation equivalence:
+
+1. Keep the raw expert event immutable.
+2. Record a separate, categorical adjudication for whether a source-faithful
+   Artana claim is an acceptable alternate representation, a partial claim, or
+   a contradiction.
+3. Require an independent agent reviewer to provide cited reasons for that
+   category; deterministic code records the category and computes all rates.
+4. Run the same one-unit result only after the protocol and its negative tests
+   are frozen. It must not treat an alternate representation as an exact
+   expert-event match.
+
+Only a pre-registered accepted-equivalence result can justify moving to one
+unannotated discovery unit. Even then, graph persistence remains prohibited.
+
+## Validation
+
+- `49` focused finite-unit and provider-receipt tests passed before the live
+  run.
+- Ruff and Python compilation passed on every changed file.
+- Shared-environment mypy passed for `612` evidence API source files.
+- Commit hooks ran and passed graph/evidence lint and type checks.
+- The worktree-local `make service-checks` target could not start because its
+  local virtualenv is missing Ruff; this was an environment limitation, not a
+  passing full-gate result.
+- An adversarial second-opinion pass found no actionable false-pass or
+  gold-leakage issue in the harness.

--- a/scripts/run_known_expert_source_unit_audit.py
+++ b/scripts/run_known_expert_source_unit_audit.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Run the one-shot TG-04 known-expert source-unit experiment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+for _path in (_REPO_ROOT, _REPO_ROOT / "services"):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from scripts.validation.claim_events.finite_source_unit.known_expert_runner import (  # noqa: E402
+    run_known_expert_source_unit_pilot,
+)
+from scripts.validation.claim_events.fixture import (  # noqa: E402
+    DEFAULT_DEVELOPMENT_FIXTURE_PATH,
+    load_fixture,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--fixture", type=Path, default=_REPO_ROOT / DEFAULT_DEVELOPMENT_FIXTURE_PATH
+    )
+    args = parser.parse_args()
+    report = run_known_expert_source_unit_pilot(
+        fixture=load_fixture(args.fixture), run_id=args.run_id
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("x", encoding="utf-8") as output_file:
+        output_file.write(
+            json.dumps(report, indent=2, sort_keys=True, ensure_ascii=True) + "\n"
+        )
+    print(args.output)
+    return known_expert_report_exit_code(report)
+
+
+def known_expert_report_exit_code(report: dict[str, object]) -> int:
+    gate = report.get("gate")
+    return 0 if isinstance(gate, dict) and gate.get("passed") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/claim_events/finite_source_unit/known_expert_gate.py
+++ b/scripts/validation/claim_events/finite_source_unit/known_expert_gate.py
@@ -1,0 +1,89 @@
+"""Deterministic stop/go gate for one sealed expert-event source unit."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from scripts.validation.claim_events.finite_source_unit.contracts import (
+    SourceUnitCoverageDecision,
+    SourceUnitDecision,
+    SourceUnitEligibilityCategory,
+)
+
+_EXPECTED_PROVIDER_CALL_COUNT: Final = 2
+
+
+@dataclass(frozen=True, slots=True)
+class KnownExpertUnitGateInputs:
+    """Machine evidence required before attempting an unannotated unit."""
+
+    agent_execution_complete: bool
+    extraction_category: SourceUnitEligibilityCategory | None
+    verification_category: SourceUnitEligibilityCategory | None
+    extraction_decision: SourceUnitDecision | None
+    verification_coverage: SourceUnitCoverageDecision | None
+    extracted_candidate_count: int
+    entailed_candidate_count: int
+    exact_whole_event_match_count: int
+    predicted_event_count: int
+    binding_rejection_count: int
+    invalid_agent_output_count: int
+    unidentified_provider_attempt_count: int
+    extraction_provider_response_id_count: int
+    verification_provider_response_id_count: int
+    distinct_provider_response_id_count: int
+    verified_provider_receipt_count: int
+    provider_receipt_gate_passed: bool
+    fallback_count: int
+    epistemic_escalation_count: int
+
+
+def known_expert_unit_gate_requirements(
+    inputs: KnownExpertUnitGateInputs,
+) -> dict[str, bool]:
+    """Derive strict reconstruction eligibility without model-produced scores."""
+
+    return {
+        "agent_execution_complete": inputs.agent_execution_complete,
+        "extractor_recognized_finding": (
+            inputs.extraction_category is SourceUnitEligibilityCategory.FINDING
+        ),
+        "verifier_recognized_finding": (
+            inputs.verification_category is SourceUnitEligibilityCategory.FINDING
+        ),
+        "independent_categories_agree": (
+            inputs.extraction_category is inputs.verification_category
+        ),
+        "extractor_returned_one_candidate": (
+            inputs.extraction_decision is SourceUnitDecision.EXPLICIT_EVENT
+            and inputs.extracted_candidate_count == 1
+        ),
+        "verifier_confirmed_complete_candidate": (
+            inputs.verification_coverage
+            is SourceUnitCoverageDecision.CANDIDATES_COMPLETE
+            and inputs.entailed_candidate_count == 1
+        ),
+        "exactly_one_complete_expert_event": (
+            inputs.exact_whole_event_match_count == 1
+            and inputs.predicted_event_count == 1
+        ),
+        "epistemic_escalation_zero": inputs.epistemic_escalation_count == 0,
+        "binding_rejection_zero": inputs.binding_rejection_count == 0,
+        "invalid_agent_output_zero": inputs.invalid_agent_output_count == 0,
+        "provider_lineage_complete": (
+            inputs.unidentified_provider_attempt_count == 0
+            and inputs.extraction_provider_response_id_count == 1
+            and inputs.verification_provider_response_id_count == 1
+            and inputs.distinct_provider_response_id_count
+            == _EXPECTED_PROVIDER_CALL_COUNT
+        ),
+        "provider_receipts_verified": (
+            inputs.provider_receipt_gate_passed
+            and inputs.verified_provider_receipt_count == _EXPECTED_PROVIDER_CALL_COUNT
+        ),
+        "fallback_zero": inputs.fallback_count == 0,
+    }
+
+
+__all__ = ["KnownExpertUnitGateInputs", "known_expert_unit_gate_requirements"]

--- a/scripts/validation/claim_events/finite_source_unit/known_expert_runner.py
+++ b/scripts/validation/claim_events/finite_source_unit/known_expert_runner.py
@@ -1,0 +1,348 @@
+"""One-unit TG-04 reconstruction experiment against sealed expert gold."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from contextlib import suppress
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+from uuid import uuid4
+
+from artana_evidence_api.document_extraction import normalize_text_document
+from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+    start_model_attempt_audit,
+    stop_model_attempt_audit,
+)
+
+from scripts.validation.claim_events.finite_source_unit.contracts import (
+    EntailmentDecision,
+    SourceUnitExtractionOutput,
+    SourceUnitVerificationOutput,
+)
+from scripts.validation.claim_events.finite_source_unit.known_expert_gate import (
+    KnownExpertUnitGateInputs,
+    known_expert_unit_gate_requirements,
+)
+from scripts.validation.claim_events.finite_source_unit.runner import (
+    receipt_expectations_for_finite_source_records,
+)
+from scripts.validation.claim_events.finite_source_unit.service import (
+    FiniteSourceUnitModelClient,
+    as_model_client,
+    extract_source_unit,
+    verify_source_unit_candidates,
+)
+from scripts.validation.claim_events.finite_source_unit.source_units import (
+    FrozenSourceUnit,
+    enumerate_source_units,
+)
+from scripts.validation.claim_events.fixture import require_frozen_development_fixture
+from scripts.validation.claim_events.runner import (
+    build_tg04_runtime,
+    nary_events_from_bound_inventory,
+)
+from scripts.validation.claim_events.scoring import score_fixture
+from scripts.validation.claim_frames.evidence import collect_repository_evidence
+from scripts.validation.claim_frames.provider_receipts import (
+    OpenAIProviderReceiptVerifier,
+    verify_provider_receipts,
+)
+
+if TYPE_CHECKING:
+    from artana_evidence_api.document_extraction_support.claim_frames import (
+        BoundClaimInventoryItem,
+    )
+    from artana_evidence_api.document_extraction_support.llm_fulltext_extraction import (
+        ModelAttemptAuditRecord,
+    )
+
+    from scripts.validation.claim_events.contracts import (
+        NaryClaimEvent,
+        NaryClaimFixture,
+    )
+
+_REPO_ROOT: Final = Path(__file__).resolve().parents[4]
+_MODEL_ID: Final = "openai:gpt-5.6-luna"
+_CASE_ID: Final = "bionlp-ge-2011:PMC-1134658-06-Results-05"
+_EVENT_ID: Final = "PMC-1134658-06-Results-05:E9"
+_UNIT_INDEX: Final = 4
+_EXPECTED_UNIT_ID: Final = (
+    "source-unit-e14e44064324af2f721a3d02d2caf44c00218a0ab6c4afc58e9bace413c9d46c"
+)
+_EXPECTED_INPUT_SHA256: Final = (
+    "14aec6614afd9d47d4cbafe7298b0e6b77b7a3d324048635d3fb98f463b9a0fd"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _SingleEventCase:
+    case_id: str
+    events: tuple[NaryClaimEvent, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _SingleEventFixture:
+    cases: tuple[_SingleEventCase, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _AgentRunEvidence:
+    extraction: SourceUnitExtractionOutput | None
+    verification: SourceUnitVerificationOutput | None
+    accepted: tuple[BoundClaimInventoryItem, ...]
+    extracted_candidate_count: int
+    binding_rejection_count: int
+    records: tuple[ModelAttemptAuditRecord, ...]
+    error_type: str | None
+
+
+def run_known_expert_source_unit_pilot(
+    *, fixture: NaryClaimFixture, run_id: str
+) -> dict[str, object]:
+    """Run exactly two agent calls against one source unit, blind to its gold."""
+
+    require_frozen_development_fixture(fixture)
+    repository_evidence = collect_repository_evidence(_REPO_ROOT)
+    if repository_evidence["clean"] is not True:
+        raise RuntimeError(
+            "known expert source-unit runs require a clean tracked worktree"
+        )
+    unit, event = select_known_expert_unit(fixture)
+    return asyncio.run(
+        _run_known_expert_source_unit(
+            unit=unit,
+            event=event,
+            run_id=run_id,
+            repository_evidence=repository_evidence,
+        )
+    )
+
+
+def select_known_expert_unit(
+    fixture: NaryClaimFixture,
+) -> tuple[FrozenSourceUnit, NaryClaimEvent]:
+    """Select the sealed expert event by immutable corpus identities."""
+
+    case = next((case for case in fixture.cases if case.case_id == _CASE_ID), None)
+    if case is None:
+        raise RuntimeError("frozen known-expert case is missing")
+    event = next((event for event in case.events if event.event_id == _EVENT_ID), None)
+    if event is None:
+        raise RuntimeError("frozen known-expert event is missing")
+    units = enumerate_source_units(
+        case_id=case.case_id,
+        source_text=normalize_text_document(case.source_text),
+    )
+    if len(units) <= _UNIT_INDEX:
+        raise RuntimeError("frozen known-expert source unit is missing")
+    unit = units[_UNIT_INDEX]
+    if unit.unit_id != _EXPECTED_UNIT_ID or unit.input_sha256 != _EXPECTED_INPUT_SHA256:
+        raise RuntimeError("frozen known-expert source-unit identity changed")
+    if not unit.source_start <= event.trigger_source_start < unit.source_end:
+        raise RuntimeError("sealed expert trigger no longer belongs to source unit")
+    return unit, event
+
+
+async def _run_known_expert_source_unit(
+    *,
+    unit: FrozenSourceUnit,
+    event: NaryClaimEvent,
+    run_id: str,
+    repository_evidence: dict[str, object],
+) -> dict[str, object]:
+    client, tenant, execution_model_id, kernel, store = build_tg04_runtime(_MODEL_ID)
+    try:
+        agent_run = await _execute_agents(
+            client=as_model_client(client),
+            tenant=tenant,
+            model_id=execution_model_id,
+            execution_namespace=f"{run_id}:{unit.unit_id}:{uuid4().hex}",
+            unit=unit,
+        )
+    finally:
+        with suppress(Exception):
+            await kernel.close()
+        with suppress(Exception):
+            await store.close()
+    if collect_repository_evidence(_REPO_ROOT) != repository_evidence:
+        raise RuntimeError(
+            "repository state changed during known expert source-unit run"
+        )
+
+    events = nary_events_from_bound_inventory(agent_run.accepted)
+    score = score_fixture(
+        _SingleEventFixture(
+            cases=(_SingleEventCase(case_id=_CASE_ID, events=(event,)),)
+        ),
+        [{"case_id": _CASE_ID, "events": events, "abstained": not events}],
+    )
+    expectations, invalid_count, unidentified_count = (
+        receipt_expectations_for_finite_source_records(list(agent_run.records))
+    )
+    receipts = verify_provider_receipts(
+        expectations, OpenAIProviderReceiptVerifier.from_environment()
+    )
+    extraction_ids = _provider_response_ids(agent_run.records, "primary")
+    verification_ids = _provider_response_ids(agent_run.records, "weak_review")
+    inputs = KnownExpertUnitGateInputs(
+        agent_execution_complete=(
+            agent_run.extraction is not None
+            and agent_run.verification is not None
+            and agent_run.error_type is None
+        ),
+        extraction_category=None
+        if agent_run.extraction is None
+        else agent_run.extraction.eligibility_category,
+        verification_category=None
+        if agent_run.verification is None
+        else agent_run.verification.eligibility_category,
+        extraction_decision=None
+        if agent_run.extraction is None
+        else agent_run.extraction.decision,
+        verification_coverage=None
+        if agent_run.verification is None
+        else agent_run.verification.coverage_decision,
+        extracted_candidate_count=agent_run.extracted_candidate_count,
+        entailed_candidate_count=len(agent_run.accepted),
+        exact_whole_event_match_count=score.metrics.whole_event_recall.count,
+        predicted_event_count=score.metrics.whole_event_precision.denominator,
+        binding_rejection_count=agent_run.binding_rejection_count,
+        invalid_agent_output_count=invalid_count,
+        unidentified_provider_attempt_count=unidentified_count,
+        extraction_provider_response_id_count=len(extraction_ids),
+        verification_provider_response_id_count=len(verification_ids),
+        distinct_provider_response_id_count=len(extraction_ids | verification_ids),
+        verified_provider_receipt_count=receipts.verified_count,
+        provider_receipt_gate_passed=receipts.gate_passed,
+        fallback_count=0,
+        epistemic_escalation_count=score.metrics.epistemic_escalation.count,
+    )
+    requirements = known_expert_unit_gate_requirements(inputs)
+    report: dict[str, object] = {
+        "schema_version": "tg04_known_expert_source_unit.v1",
+        "run_id": run_id,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "model_id": _MODEL_ID,
+        "task_id": "known_expert_event_reconstruction",
+        "repository_evidence": repository_evidence,
+        "unit": {
+            "case_id": _CASE_ID,
+            "event_id": _EVENT_ID,
+            "unit_id": unit.unit_id,
+            "unit_index": unit.index,
+            "source_start": unit.source_start,
+            "source_end": unit.source_end,
+            "source_sha256": unit.source_sha256,
+            "input_sha256": unit.input_sha256,
+            "text": unit.text,
+        },
+        "agent_outputs": {
+            "extraction": _model_json(agent_run.extraction),
+            "verification": _model_json(agent_run.verification),
+            "error_type": agent_run.error_type,
+        },
+        "predicted_events": events,
+        "metrics": asdict(score.metrics),
+        "attempts": [record.as_json() for record in agent_run.records],
+        "provider_receipts": receipts.as_json(),
+        "gate_inputs": asdict(inputs),
+        "gate": {
+            "passed": all(requirements.values()),
+            "decision": "PROCEED_TO_UNANNOTATED_DISCOVERY_UNIT"
+            if all(requirements.values())
+            else "STOP_AND_RECALIBRATE",
+            "requirements": requirements,
+        },
+        "conclusion_scope": {
+            "known_expert_reconstruction_only": True,
+            "new_discovery_measured": False,
+            "persistence_authorized": False,
+        },
+    }
+    report["report_sha256"] = _sha256_json(report)
+    return report
+
+
+async def _execute_agents(
+    *,
+    client: FiniteSourceUnitModelClient,
+    tenant: object,
+    model_id: str,
+    execution_namespace: str,
+    unit: FrozenSourceUnit,
+) -> _AgentRunEvidence:
+    audit = start_model_attempt_audit(evidence_unit_id=unit.unit_id)
+    extraction_output: SourceUnitExtractionOutput | None = None
+    verification_output: SourceUnitVerificationOutput | None = None
+    accepted: tuple[BoundClaimInventoryItem, ...] = ()
+    extracted_candidate_count = binding_rejection_count = 0
+    error_type: str | None = None
+    try:
+        extraction = await extract_source_unit(
+            client=client,
+            tenant=tenant,
+            model_id=model_id,
+            execution_namespace=execution_namespace,
+            unit=unit,
+        )
+        extraction_output = extraction.value.output
+        extracted_candidate_count = len(extraction.value.accepted)
+        binding_rejection_count = len(extraction.value.rejected)
+        verification = await verify_source_unit_candidates(
+            client=client,
+            tenant=tenant,
+            model_id=model_id,
+            execution_namespace=execution_namespace,
+            unit=unit,
+            candidates=extraction.value.accepted,
+        )
+        verification_output = verification.parsed
+        accepted = tuple(
+            candidate.claim
+            for candidate in verification.value
+            if candidate.verification.decision is EntailmentDecision.ENTAILED
+        )
+    except Exception as exc:  # noqa: BLE001 - retain categorical failure evidence
+        error_type = type(exc).__name__
+    finally:
+        stop_model_attempt_audit(audit)
+    return _AgentRunEvidence(
+        extraction=extraction_output,
+        verification=verification_output,
+        accepted=accepted,
+        extracted_candidate_count=extracted_candidate_count,
+        binding_rejection_count=binding_rejection_count,
+        records=tuple(audit.records),
+        error_type=error_type,
+    )
+
+
+def _provider_response_ids(
+    records: tuple[ModelAttemptAuditRecord, ...], pass_role: str
+) -> set[str]:
+    return {
+        record.provider_response_id
+        for record in records
+        if record.pass_role == pass_role and record.provider_response_id is not None
+    }
+
+
+def _model_json(
+    model: SourceUnitExtractionOutput | SourceUnitVerificationOutput | None,
+) -> dict[str, object] | None:
+    return None if model is None else model.model_dump(mode="json")
+
+
+def _sha256_json(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+__all__ = ["run_known_expert_source_unit_pilot", "select_known_expert_unit"]

--- a/tests/unit/test_known_expert_source_unit_audit.py
+++ b/tests/unit/test_known_expert_source_unit_audit.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from scripts.run_known_expert_source_unit_audit import known_expert_report_exit_code
+from scripts.validation.claim_events.finite_source_unit.contracts import (
+    SourceUnitCoverageDecision,
+    SourceUnitDecision,
+    SourceUnitEligibilityCategory,
+)
+from scripts.validation.claim_events.finite_source_unit.known_expert_gate import (
+    KnownExpertUnitGateInputs,
+    known_expert_unit_gate_requirements,
+)
+from scripts.validation.claim_events.finite_source_unit.known_expert_runner import (
+    select_known_expert_unit,
+)
+from scripts.validation.claim_events.fixture import load_fixture
+
+
+def _baseline() -> KnownExpertUnitGateInputs:
+    return KnownExpertUnitGateInputs(
+        agent_execution_complete=True,
+        extraction_category=SourceUnitEligibilityCategory.FINDING,
+        verification_category=SourceUnitEligibilityCategory.FINDING,
+        extraction_decision=SourceUnitDecision.EXPLICIT_EVENT,
+        verification_coverage=SourceUnitCoverageDecision.CANDIDATES_COMPLETE,
+        extracted_candidate_count=1,
+        entailed_candidate_count=1,
+        exact_whole_event_match_count=1,
+        predicted_event_count=1,
+        binding_rejection_count=0,
+        invalid_agent_output_count=0,
+        unidentified_provider_attempt_count=0,
+        extraction_provider_response_id_count=1,
+        verification_provider_response_id_count=1,
+        distinct_provider_response_id_count=2,
+        verified_provider_receipt_count=2,
+        provider_receipt_gate_passed=True,
+        fallback_count=0,
+        epistemic_escalation_count=0,
+    )
+
+
+def test_known_expert_gate_requires_one_complete_expert_event() -> None:
+    baseline = _baseline()
+
+    assert all(known_expert_unit_gate_requirements(baseline).values())
+
+    partial = replace(baseline, exact_whole_event_match_count=0)
+    extra = replace(baseline, predicted_event_count=2)
+    requirements = known_expert_unit_gate_requirements(partial)
+    assert requirements["exactly_one_complete_expert_event"] is False
+    assert not all(requirements.values())
+    assert not all(known_expert_unit_gate_requirements(extra).values())
+
+
+def test_known_expert_gate_fails_closed_on_all_safety_boundaries() -> None:
+    baseline = _baseline()
+    mutations = (
+        {"agent_execution_complete": False},
+        {"extraction_category": SourceUnitEligibilityCategory.HYPOTHESIS},
+        {"verification_category": SourceUnitEligibilityCategory.HYPOTHESIS},
+        {"extraction_decision": SourceUnitDecision.NO_EVENT},
+        {"verification_coverage": SourceUnitCoverageDecision.MISSING_EVENT},
+        {"extracted_candidate_count": 2},
+        {"entailed_candidate_count": 0},
+        {"binding_rejection_count": 1},
+        {"invalid_agent_output_count": 1},
+        {"unidentified_provider_attempt_count": 1},
+        {"extraction_provider_response_id_count": 0},
+        {"verification_provider_response_id_count": 0},
+        {"distinct_provider_response_id_count": 1},
+        {"verified_provider_receipt_count": 1},
+        {"provider_receipt_gate_passed": False},
+        {"fallback_count": 1},
+        {"epistemic_escalation_count": 1},
+    )
+
+    for mutation in mutations:
+        assert not all(
+            known_expert_unit_gate_requirements(replace(baseline, **mutation)).values(),
+        )
+
+
+def test_known_expert_runner_freezes_event_and_source_unit_identity() -> None:
+    fixture = load_fixture(
+        Path(
+            "scripts/validation/claim_events/fixtures/tg04_bionlp_ge_development_v1.json"
+        ),
+    )
+
+    unit, event = select_known_expert_unit(fixture)
+
+    assert event.event_id == "PMC-1134658-06-Results-05:E9"
+    assert event.trigger_span == "upregulation"
+    assert unit.unit_id == (
+        "source-unit-e14e44064324af2f721a3d02d2caf44c00218a0ab6c4afc58e9bace413c9d46c"
+    )
+    assert unit.input_sha256 == (
+        "14aec6614afd9d47d4cbafe7298b0e6b77b7a3d324048635d3fb98f463b9a0fd"
+    )
+    assert "four-fold upregulation of Id1 mRNA" in unit.text
+
+
+def test_known_expert_cli_exit_status_follows_deterministic_gate() -> None:
+    assert known_expert_report_exit_code({"gate": {"passed": True}}) == 0
+    assert known_expert_report_exit_code({"gate": {"passed": False}}) == 1
+    assert known_expert_report_exit_code({}) == 1


### PR DESCRIPTION
## Summary
- add a one-unit, two-agent known-expert-event reconstruction harness with immutable source identity and no gold in prompts
- require exact whole-event reconstruction plus source binding, categorical agent agreement, verified provider receipts, and zero fallback before discovery
- record the first Luna run honestly: source-grounded finding and receipts passed, but exact expert-event reconstruction failed

## Result
The strict gate is **STOP_AND_RECALIBRATE**. Luna returned `INCREASE(Id1 mRNA, BMP-6-treated B cells)` while the sealed BioNLP event is `POSITIVE_REGULATION(CAUSE=BMP-6, THEME=Id1)`. This is a representation-alignment mismatch, not permission to weaken the gate or run discovery.

## Validation
- 49 focused finite-unit/provider-receipt tests passed
- Ruff and compilation passed
- mypy passed for 612 evidence API source files in the shared environment
- commit hooks passed graph/evidence lint and type checks
- live artifact: `/tmp/artana-tg04/known-expert-unit-2026-07-18/luna-r1.json`

## Limitation
`make service-checks` could not start in this worktree because its local `.venv` lacks Ruff; this is reported as an environment limitation, not a passing full gate.